### PR TITLE
gitignore: cover Claude Code local settings + /security-audit scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ client-sdk/python/tests/_evidence/
 .vscode/
 *.swp
 *.swo
+
+# Claude Code (local, per-user)
+.claude/settings.local.json
+.security-audit/

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ client-sdk/python/tests/_evidence/
 
 # Claude Code (local, per-user)
 .claude/settings.local.json
+
+# /security-audit scratch dir (transient)
 .security-audit/


### PR DESCRIPTION
## Summary

- Add `.claude/settings.local.json` to `.gitignore` — per-user Claude Code state that should not be committed.
- Add `.security-audit/` to `.gitignore` — the scratch dir the `/security-audit` slash command uses; intermediate findings are transient.

## Why now

This is also a deliberate smoke test for the new Claude Code review workflow we added in commit `6f1ead0`. Opening this PR should trigger `.github/workflows/claude.yml` and produce an automated review comment from the Claude GitHub App.

## Test plan

- [ ] Verify the `Claude Code` check appears on this PR within ~1 min.
- [ ] Confirm Claude posts a review comment.
- [ ] Confirm the review references the tailored `review_focus` (protocol compliance, cross-SDK interop, attachment safety, etc.) where relevant — though this PR is trivial, so mostly we're just validating the plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)