### PR TITLE
claude-code: rename subject token from ccc to cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Type tokens currently in this repo:
 | ----------| -------------------- | --------------------- |
 | `pi`      | PI Agent             | `agents/pi/`          |
 | `oc`      | OpenClaw             | `agents/openclaw/`    |
-| `ccc`     | Claude Code          | `agents/claude-code/` |
+| `cc`      | Claude Code          | `agents/claude-code/` |
 | `hermes`  | Hermes Agent         | `agents/hermes/`      |
 | `dspy`    | ax-llm ReAct (DSPy)  | `examples/dspy/`      |
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -10,7 +10,7 @@ For an example of *building* a fresh agent from scratch using the TypeScript SDK
 | ------------------- | ---------- | ------------------------------------------- | ------------------------------------------------------ | ------------- | ---------------- |
 | `pi/`               | `pi`       | [PI Agent](https://github.com/badlogic/pi-mono) | `agents.pi.<owner>.<session>`                      | 1 MB          | true             |
 | `openclaw/`         | `oc`       | [OpenClaw](https://openclaw.ai)             | `agents.oc.<owner>.<agentName>`                        | 1 MB          | true             |
-| `claude-code/`      | `ccc`      | [Claude Code](https://claude.com/claude-code) | `agents.ccc.<owner>.<session>`                      | 1 MB          | true             |
+| `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.cc.<owner>.<name>`                          | 1 MB          | true             |
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.hermes.<owner>.<name>`          | 1 MB (configurable) | true        |
 
 Every agent also publishes `<subject>.heartbeat` every 30 s.

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -4,8 +4,8 @@ Connect Claude Code to NATS messaging as a spec-compliant
 [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2 agent.
 
 The MCP server registers an `agents` micro service, exposes a
-`prompt` endpoint at `agents.ccc.<owner>.<session>`, publishes heartbeats
-at `agents.ccc.<owner>.<session>.heartbeat`, and bridges prompt requests
+`prompt` endpoint at `agents.cc.<owner>.<name>`, publishes heartbeats
+at `agents.cc.<owner>.<name>.heartbeat`, and bridges prompt requests
 into the Claude Code session. Replies stream back as typed JSON chunks
 (`{"type":"response","data":"..."}`) terminated by an empty headerless
 message - the protocol's uniform end-of-stream signal.
@@ -39,8 +39,8 @@ claude --dangerously-load-development-channels plugin:nats-channel@synadia-plugi
 ```
 
 By default, the server connects to `demo.nats.io` (no credentials required)
-and registers a micro service on `agents.ccc.<user>.<session>`, where
-`<session>` defaults to the working directory name.
+and registers a micro service on `agents.cc.<user>.<name>`, where
+`<name>` defaults to the working directory name.
 
 **4. (Optional) Configure the channel.**
 
@@ -52,7 +52,7 @@ and permissions. All state lives in `~/.claude/channels/nats/config.json`.
 | `/nats-channel:configure` | Show current config, list available contexts, and offer to switch |
 | `/nats-channel:configure list` | List available NATS CLI contexts |
 | `/nats-channel:configure <context-name>` | Select a NATS CLI context to connect to |
-| `/nats-channel:configure session <name>` | Override the session name (fourth token in `agents.ccc.<user>.<name>`) |
+| `/nats-channel:configure session <name>` | Override the session name (fourth token in `agents.cc.<user>.<name>`) |
 | `/nats-channel:configure session clear` | Remove session name override, revert to CWD basename |
 | `/nats-channel:configure permissions terminal` | Prompt for permissions in the terminal (default) |
 | `/nats-channel:configure permissions query` | Relay permission prompts as protocol query chunks |
@@ -89,7 +89,7 @@ await client.close();
 Or directly via the NATS CLI (plain-text shorthand per spec §5.1):
 
 ```sh
-nats req agents.ccc.<user>.<session-name> "Hello Claude" --replies=0 --timeout=90s
+nats req agents.cc.<user>.<name> "Hello Claude" --replies=0 --timeout=90s
 ```
 
 Claude's response streams back as typed JSON chunks on the reply subject;
@@ -129,7 +129,7 @@ canonical counterpart.
 
 ## Session names
 
-The micro service subject is `agents.ccc.<user>.<session-name>`.
+The micro service subject is `agents.cc.<user>.<name>`.
 
 - **Default:** sanitized basename of the working directory (e.g., `my-project`)
 - **Override:** set `NATS_SESSION_NAME` env var, or use `/nats-channel:configure session <name>`
@@ -222,7 +222,7 @@ If no reply is received within 2 minutes, the permission defaults to
 ## Access control
 
 NATS server authentication and authorization handle access control. If a
-user can connect and publish to `agents.ccc.<user>.<session>`, they can
+user can connect and publish to `agents.cc.<user>.<name>`, they can
 interact with Claude. No additional pairing or allowlist is needed.
 
 ## Configuration
@@ -258,5 +258,5 @@ NATS CLI contexts live in `~/.config/nats/context/<name>.json`.
 
 | Variable | Purpose |
 | --- | --- |
-| `NATS_SESSION_NAME` | Override the session name (fourth token in `agents.ccc.<user>.<name>`) |
+| `NATS_SESSION_NAME` | Override the session name (fourth token in `agents.cc.<user>.<name>`) |
 | `NATS_STATE_DIR` | Override the state directory (default: `~/.claude/channels/nats`) |

--- a/agents/claude-code/scripts/roundtrip-test.ts
+++ b/agents/claude-code/scripts/roundtrip-test.ts
@@ -14,7 +14,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { connect } from '@nats-io/transport-node'
 import { readFileSync, rmSync, existsSync } from 'fs'
 
-const SUBJECT = 'agents.ccc.m64.rt-test'
+const SUBJECT = 'agents.cc.m64.rt-test'
 const STATE_DIR = '/tmp/rt-test-state'
 const MAX_PAYLOAD = 1024 * 1024
 

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -4,7 +4,7 @@
  * NATS Agent Protocol v0.1 (see https://github.com/synadia-ai/nats-agent-sdk-docs).
  *
  * Self-contained MCP server that registers as an `agents` micro service,
- * exposes a `prompt` endpoint on agents.ccc.<owner>.<session>, publishes
+ * exposes a `prompt` endpoint on agents.cc.<owner>.<name>, publishes
  * heartbeats on <subject>.heartbeat, and bridges prompt requests into the
  * Claude Code session via MCP <channel> notifications. Claude responds via
  * the `reply` tool; each response is emitted as typed JSON chunks
@@ -41,7 +41,7 @@ import { fileURLToPath } from 'url'
 // ── Constants ──────────────────────────────────────────────────────────
 const PROTOCOL_VERSION = '0.2'
 const AGENT_ID = 'claude-code'          // metadata.agent (canonical per Appendix C)
-const AGENT_SUBJECT_TOKEN = 'ccc'       // 2nd subject token (abbreviation per Appendix C)
+const AGENT_SUBJECT_TOKEN = 'cc'        // 2nd subject token (abbreviation per Appendix C)
 const SERVICE_NAME = 'agents'           // §3.1 — the bare token, subject-safe as-is
 const PROMPT_QUEUE_GROUP = 'agents'     // §3.3 — queue group on the prompt endpoint
 const MAX_PAYLOAD_STRING = '1MB'        // advertised in endpoint metadata

--- a/agents/claude-code/skills/configure/SKILL.md
+++ b/agents/claude-code/skills/configure/SKILL.md
@@ -71,7 +71,7 @@ Two separate steps - do NOT combine into one Bash call:
 ### `session <name>` - set session name override
 
 1. The session name is the fourth token in the subject
-   `agents.ccc.<user>.<name>`. It defaults to the working directory
+   `agents.cc.<user>.<name>`. It defaults to the working directory
    basename. This command overrides it.
 2. Read existing `config.json` (or start fresh). Set `sessionName` field.
    Write back.

--- a/client-sdk/typescript/src/testing/reference-agent.ts
+++ b/client-sdk/typescript/src/testing/reference-agent.ts
@@ -45,7 +45,7 @@ export interface ReferenceAgentOptions {
   readonly promptHandler?: ReferenceAgentPromptHandler;
   /**
    * Override the 2nd subject token — useful when a deployment uses the
-   * abbreviation convention (e.g. `"ccc"` for `"claude-code"`). Defaults to
+   * abbreviation convention (e.g. `"cc"` for `"claude-code"`). Defaults to
    * `agent` verbatim.
    */
   readonly subjectAgentToken?: string;

--- a/client-sdk/typescript/test/unit/discovered-agent.test.ts
+++ b/client-sdk/typescript/test/unit/discovered-agent.test.ts
@@ -16,7 +16,7 @@ function validInfo(overrides: Partial<RawServiceInfo> = {}): RawServiceInfo {
     endpoints: [
       {
         name: "prompt",
-        subject: "agents.ccc.alice.sess-1",
+        subject: "agents.cc.alice.sess-1",
         queue_group: "agents",
         metadata: { max_payload: "1MB", attachments_ok: "true" },
       },
@@ -69,7 +69,7 @@ describe("buildDiscoveredAgent", () => {
     expect(
       buildDiscoveredAgent(
         validInfo({
-          endpoints: [{ name: "other", subject: "agents.ccc.alice.sess-1.other" }],
+          endpoints: [{ name: "other", subject: "agents.cc.alice.sess-1.other" }],
         }),
       ),
     ).toBeNull();

--- a/client-sdk/typescript/test/unit/heartbeat-payload.test.ts
+++ b/client-sdk/typescript/test/unit/heartbeat-payload.test.ts
@@ -36,7 +36,7 @@ describe("decodeHeartbeatPayload", () => {
 
   it("preserves unknown fields on the `extras` map (§12 forward-compat)", () => {
     const raw = {
-      agent: "ccc",
+      agent: "claude-code",
       owner: "alice",
       instance_id: "abc",
       ts: "2026-04-21T14:23:01Z",


### PR DESCRIPTION
Shorten the 2nd subject token for the claude-code harness (agents.ccc.<owner>.<session> → agents.cc.<owner>.<name>) and standardize the 4th-token placeholder as <name> to match the other harnesses (hermes, oc, pi).

- server.ts: AGENT_SUBJECT_TOKEN = 'cc'
- README.md, skills/configure/SKILL.md: docs updated
- scripts/roundtrip-test.ts: test subject updated