### PR TITLE
tests + docs: use canonical harness names for metadata.agent

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -252,8 +252,8 @@ of this entry.
 ### Migration from 0.0.1
 
 ```diff
-- agent = Agent(platform="ccc", owner="alice", name="worker-1", nc=nc)
-+ agent = Agent(agent="ccc", owner="alice", name="worker-1", nc=nc)
+- agent = Agent(platform="claude-code", owner="alice", name="worker-1", nc=nc)
++ agent = Agent(agent="claude-code", owner="alice", name="worker-1", nc=nc)
 ```
 
 ```diff

--- a/client-sdk/python/tests/test_heartbeat.py
+++ b/client-sdk/python/tests/test_heartbeat.py
@@ -40,18 +40,18 @@ def test_session_optional() -> None:
 def test_unknown_fields_tolerated() -> None:
     """§8.3: receivers MUST tolerate additional unknown fields."""
     wire = (
-        b'{"agent":"ccc","owner":"alice","instance_id":"X",'
+        b'{"agent":"claude-code","owner":"alice","instance_id":"X",'
         b'"ts":"2026-04-21T00:00:00Z","interval_s":30,'
         b'"future_field":42,"another":"ok"}'
     )
     hb = HeartbeatPayload.model_validate_json(wire)
-    assert hb.agent == "ccc"
+    assert hb.agent == "claude-code"
 
 
 def test_encoded_form_omits_session_when_absent() -> None:
     """Session-less payloads MUST NOT emit an empty `session` key on the wire."""
     hb = HeartbeatPayload(
-        agent="occ",
+        agent="openclaw",
         owner="rene",
         instance_id="X",
         ts="2026-04-21T00:00:00Z",
@@ -60,7 +60,7 @@ def test_encoded_form_omits_session_when_absent() -> None:
     parsed = json.loads(hb.model_dump_json(exclude_none=True))
     assert "session" not in parsed
     assert parsed == {
-        "agent": "occ",
+        "agent": "openclaw",
         "owner": "rene",
         "instance_id": "X",
         "ts": "2026-04-21T00:00:00Z",

--- a/client-sdk/python/tests/test_subjects.py
+++ b/client-sdk/python/tests/test_subjects.py
@@ -16,9 +16,9 @@ from natsagent.subjects import (
 
 class TestConstruction:
     def test_valid_simple_tokens(self) -> None:
-        subj = AgentSubject.new(agent="occ", owner="derek", name="summarizer")
-        assert subj.inbox == "agents.occ.derek.summarizer"
-        assert subj.heartbeat == "agents.occ.derek.summarizer.heartbeat"
+        subj = AgentSubject.new(agent="oc", owner="derek", name="summarizer")
+        assert subj.inbox == "agents.oc.derek.summarizer"
+        assert subj.heartbeat == "agents.oc.derek.summarizer.heartbeat"
 
     def test_hyphens_and_underscores_in_name(self) -> None:
         subj = AgentSubject.new(agent="hermes", owner="rene", name="default_worker-1")

--- a/client-sdk/typescript/test/unit/discovered-agent.test.ts
+++ b/client-sdk/typescript/test/unit/discovered-agent.test.ts
@@ -79,7 +79,7 @@ describe("buildDiscoveredAgent", () => {
     const a = buildDiscoveredAgent(
       validInfo({
         metadata: { agent: "openclaw", owner: "rene", protocol_version: "0.2" },
-        endpoints: [{ name: "prompt", subject: "agents.occ.rene.default", metadata: {} }],
+        endpoints: [{ name: "prompt", subject: "agents.oc.rene.default", metadata: {} }],
       }),
     );
     expect(a).not.toBeNull();


### PR DESCRIPTION
tests + docs: use canonical harness names for metadata.agent

  The `agent` field in `metadata.agent` / heartbeat payloads / the Python
  `Agent(agent=...)` kwarg is the canonical harness identifier
  (`claude-code`, `openclaw`, …), not the 2nd subject-token abbreviation
  (`cc`, `oc`, …). A few tests and one CHANGELOG example had these
  conflated, using subject tokens where canonical names belong. These
  tests were passing because the field is a free-form string — but they
  misled readers about what values agents actually put on the wire.

  Fallout from the `ccc -> cc` rename in PR #8 surfaced them (`rg ccc`
  after merge). Separate typo `occ` also got swept (OpenClaw's token has
  always been `oc`; no triple form ever existed).

  Changes
  - client-sdk/python/CHANGELOG.md — migration example now uses
    `agent="claude-code"` instead of the subject token.
  - client-sdk/python/tests/test_heartbeat.py — "tolerate unknown fields"
    test uses a valid canonical name; session-omission test drops the
    `"occ"` typo in favor of `"openclaw"`.
  - client-sdk/python/tests/test_subjects.py — simple-token construction
    test uses OpenClaw's real subject token `oc`.
  - client-sdk/typescript/test/unit/discovered-agent.test.ts — fixture
    subject corrected to `agents.oc.rene.default`.

  Tests: TS 8/8, Python 22/22 on touched files