### PR TITLE
fix: expose Agents.closeSignal + restore user_jwt in context helpers

### DIFF
--- a/client-sdk/typescript/src/agents.ts
+++ b/client-sdk/typescript/src/agents.ts
@@ -61,6 +61,17 @@ export class Agents {
   }
 
   /**
+   * Abort signal that fires when `close()` is called. Callers that construct
+   * `Agent` instances outside of `discover()` (e.g. materialising one from a
+   * heartbeat + `$SRV.INFO.agents.<id>` lookup) SHOULD pass this to the
+   * `Agent` constructor so in-flight streams on those handles are aborted
+   * when the `Agents` client is torn down, matching what `discover()` does.
+   */
+  get closeSignal(): AbortSignal {
+    return this.#closeController.signal;
+  }
+
+  /**
    * Discover protocol-compliant agents reachable on the NATS connection.
    * Returns a live `Agent[]` — each entry is directly callable via `.prompt()`.
    *

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -430,7 +430,12 @@ export class Bridge {
       if (this.agentsByInstanceId.has(instanceId)) return; // raced
       const info = buildAgentInfo(raw);
       if (!info) return;
-      const agent = new Agent(this.nc, info, this.agents.streamInactivityTimeoutMs);
+      const agent = new Agent(
+        this.nc,
+        info,
+        this.agents.streamInactivityTimeoutMs,
+        this.agents.closeSignal,
+      );
       this.registerAgent(agent);
     } catch (e) {
       console.warn(

--- a/examples/agent-web-ui/server/nats-context.ts
+++ b/examples/agent-web-ui/server/nats-context.ts
@@ -4,15 +4,21 @@
 // under `~/.config/nats` (or $NATS_CONFIG_HOME / $XDG_CONFIG_HOME/nats) and
 // translates them into `@nats-io/transport-node` connection options.
 //
-// Supports: `url`, `creds` (path), `user`+`password`, `token`, `inbox_prefix`.
-// Skips: `nkey`, `user_jwt`, TLS cert/key/ca, `nsc` integration — those are
-// uncommon enough that we'd rather keep this helper small. Re-add here if you
-// need them.
+// Supports: `url`, `creds` (path), `user_jwt`, `user`+`password`, `token`,
+// `inbox_prefix`.
+// Skips: `nkey`, TLS cert/key/ca, `nsc` integration — those are uncommon
+// enough that we'd rather keep this helper small. Re-add here if you need
+// them.
+//
+// Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
+//
+// Keep in sync with `examples/agent-web-ui/server/nats-context.ts` —
+// the two copies are byte-identical on purpose.
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { credsAuthenticator } from "@nats-io/nats-core";
+import { credsAuthenticator, jwtAuthenticator } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
 
 export interface LoadedContext {
@@ -55,12 +61,15 @@ export async function loadNatsContext(selector: string): Promise<LoadedContext> 
   const opts: Omit<NodeConnectionOptions, "servers"> = {};
 
   const creds = str(parsed["creds"]);
+  const userJwt = str(parsed["user_jwt"]);
   if (creds) {
     const credsPath = creds.startsWith("~/") ? join(homedir(), creds.slice(2)) : creds;
     const bytes = await readFile(credsPath);
     opts.authenticator = credsAuthenticator(
       new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
     );
+  } else if (userJwt) {
+    opts.authenticator = jwtAuthenticator(userJwt);
   } else {
     const token = str(parsed["token"]);
     const user = str(parsed["user"]);

--- a/examples/agent-web-ui/server/nats-context.ts
+++ b/examples/agent-web-ui/server/nats-context.ts
@@ -12,8 +12,13 @@
 //
 // Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
 //
-// Keep in sync with `examples/agent-web-ui/server/nats-context.ts` —
-// the two copies are byte-identical on purpose.
+// Note: `user_jwt` without an accompanying nkey seed leaves the CONNECT
+// signature empty, so it only works against servers that do not require
+// nonce signing. Standard operator-mode deployments need `nkey` support
+// (see the "Skips" list above).
+//
+// Keep in sync with the other `nats-context.ts` copy in this monorepo —
+// the two example copies are byte-identical on purpose.
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";

--- a/examples/pi-headless/src/nats-context.ts
+++ b/examples/pi-headless/src/nats-context.ts
@@ -4,15 +4,21 @@
 // under `~/.config/nats` (or $NATS_CONFIG_HOME / $XDG_CONFIG_HOME/nats) and
 // translates them into `@nats-io/transport-node` connection options.
 //
-// Supports: `url`, `creds` (path), `user`+`password`, `token`, `inbox_prefix`.
-// Skips: `nkey`, `user_jwt`, TLS cert/key/ca, `nsc` integration — those are
-// uncommon enough that we'd rather keep this helper small. Re-add here if you
-// need them.
+// Supports: `url`, `creds` (path), `user_jwt`, `user`+`password`, `token`,
+// `inbox_prefix`.
+// Skips: `nkey`, TLS cert/key/ca, `nsc` integration — those are uncommon
+// enough that we'd rather keep this helper small. Re-add here if you need
+// them.
+//
+// Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
+//
+// Keep in sync with `examples/agent-web-ui/server/nats-context.ts` —
+// the two copies are byte-identical on purpose.
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { credsAuthenticator } from "@nats-io/nats-core";
+import { credsAuthenticator, jwtAuthenticator } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
 
 export interface LoadedContext {
@@ -55,12 +61,15 @@ export async function loadNatsContext(selector: string): Promise<LoadedContext> 
   const opts: Omit<NodeConnectionOptions, "servers"> = {};
 
   const creds = str(parsed["creds"]);
+  const userJwt = str(parsed["user_jwt"]);
   if (creds) {
     const credsPath = creds.startsWith("~/") ? join(homedir(), creds.slice(2)) : creds;
     const bytes = await readFile(credsPath);
     opts.authenticator = credsAuthenticator(
       new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
     );
+  } else if (userJwt) {
+    opts.authenticator = jwtAuthenticator(userJwt);
   } else {
     const token = str(parsed["token"]);
     const user = str(parsed["user"]);

--- a/examples/pi-headless/src/nats-context.ts
+++ b/examples/pi-headless/src/nats-context.ts
@@ -12,8 +12,13 @@
 //
 // Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
 //
-// Keep in sync with `examples/agent-web-ui/server/nats-context.ts` —
-// the two copies are byte-identical on purpose.
+// Note: `user_jwt` without an accompanying nkey seed leaves the CONNECT
+// signature empty, so it only works against servers that do not require
+// nonce signing. Standard operator-mode deployments need `nkey` support
+// (see the "Skips" list above).
+//
+// Keep in sync with the other `nats-context.ts` copy in this monorepo —
+// the two example copies are byte-identical on purpose.
 
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";


### PR DESCRIPTION
  Two follow-ups from the PR #7 review that we'd deferred until the web-ui
  experiments settled. Both were small and worth landing now.

  1. Agents.closeSignal getter + bridge.ts lazy-agent wiring. Agents constructed inline by discover() already receive the close signal (threaded through discoverAgents) so in-flight streams abort on Agents.close(). Agents constructed lazily in bridge.ts (ensureAgentKnown, triggered by a heartbeat from an instance not in the last discover) didn't — creating a behavioural inconsistency between the two paths. Expose a public closeSignal getter on Agents and pass it when constructing the lazy Agent.

  2. Restore user_jwt support in both nats-context.ts example copies. The inline CLI-context loaders in examples/pi-headless and examples/agent-web-ui silently discarded the user_jwt field. Anyone with a JWT-only context would connect unauthenticated (or fail at the NATS server, with no useful error at this level). Now: if user_jwt is set (and creds isn't — creds wins), use jwtAuthenticator. Docstring updated to list the support matrix and precedence. Both files are byte-identical by design and carry a "keep in sync" comment at the top.

  Verification
  - SDK: typecheck + lint clean, 142/142 unit tests pass.
  - examples/pi-headless: typecheck clean.
  - examples/agent-web-ui: typecheck clean (vue-tsc).
  - Protocol-level interop between TS and Python SDKs still green (test_interop_e2e.py, 2/2 — re-enabled in 17ffb44).