### PR TITLE
docs: README polish — PI Exec coverage, protocol version consistency

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -1,7 +1,7 @@
 # NATS Channel for Claude Code
 
 Connect Claude Code to NATS messaging as a spec-compliant
-[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2 agent.
+[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0 agent.
 
 The MCP server registers an `agents` micro service, exposes a
 `prompt` endpoint at `agents.cc.<owner>.<name>`, publishes heartbeats
@@ -100,7 +100,7 @@ an empty headerless message signals completion.
 
 ## Protocol compliance
 
-This plugin implements the **NATS Agent Protocol v0.2** end-to-end:
+This plugin implements the **NATS Agent Protocol v0.2.0** end-to-end:
 
 - Registers as an `agents` NATS micro service (§3.1 - the bare subject-safe
   token).

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -7,7 +7,7 @@
 > is planned but not yet filed (needs a catch-up rebase first), so the
 > install below clones the fork directly.
 
-NATS gateway for [Hermes Agent](https://github.com/NousResearch/hermes-agent), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2**.
+NATS gateway for [Hermes Agent](https://github.com/NousResearch/hermes-agent), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
 Hermes is a self-improving coding agent with a CLI, a TUI, and a messaging gateway sharing one agent core. With the NATS gateway enabled, each running Hermes instance becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`natsagent`](../../client-sdk/python) (Python) or [`@synadia/agents`](../../client-sdk/typescript) (TypeScript) - can enumerate running Hermes instances, prompt them (with attachments), and stream responses back.
 

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -2,7 +2,7 @@
 
 > Currently published on npm as `@m64/nats-channel`; moving to `@synadia/nats-channel` once Synadia publishing access lands. Install commands below use the current name.
 
-NATS channel plugin for [OpenClaw](https://openclaw.ai), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0-draft**.
+NATS channel plugin for [OpenClaw](https://openclaw.ai), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
 Every configured OpenClaw agent becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia/agents`](../../client-sdk/typescript) - can enumerate running OpenClaw agents, prompt them, and stream responses back.
 
@@ -87,7 +87,7 @@ openclaw gateway restart
 | `credentials` | no | - | Path to `.creds` file for NATS authentication |
 | `owner` | no | `default` | 3rd subject token - operator/account namespace. Spec §2 requires a 4-token subject. |
 
-> **Migrating from v0.2:** the old `org` field has been renamed `owner` (§3.2 terminology). The old name is still accepted as an alias with a deprecation warning in logs.
+> **Migrating from v0.1:** the old `org` field has been renamed `owner` (§3.2 terminology). The old name is still accepted as an alias with a deprecation warning in logs.
 
 ### Environment variables (Docker / containers)
 

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -2,7 +2,7 @@
 
 > Currently published on npm as `@m64/nats-pi-channel`; moving to `@synadia/nats-pi-channel` once Synadia publishing access lands. Install commands below use the current name.
 
-NATS channel for [PI Agent](https://github.com/badlogic/pi-mono), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0-draft**.
+NATS channel for [PI Agent](https://github.com/badlogic/pi-mono), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
 Every PI session becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia/agents`](../../client-sdk/typescript) - can enumerate running PI sessions, prompt them, and stream responses back.
 

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -1,17 +1,27 @@
 # agent-web-ui
 
 A Bun + Vue 3 test client for the [`@synadia/agents`](../../client-sdk/typescript) SDK.
-Discover agents over NATS, send prompts (with optional attachments), and
-stream responses back in a slick browser UI.
+Discover agents over NATS, prompt them (with optional attachments),
+stream responses back, and — when a [`pi-headless`](../pi-headless) controller
+is online — spawn, prompt, and fan out PI sessions from the browser.
 
 Primary use: manually poking at the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs)
 implementations - [`pi`](../../agents/pi), [`claude-code`](../../agents/claude-code),
-[`openclaw`](../../agents/openclaw), and the SDK's own reference agent.
+[`openclaw`](../../agents/openclaw), [`hermes`](../../agents/hermes),
+[`pi-headless`](../pi-headless), and the SDK's own reference agent.
+
+## Features
+
+- **Chat mode** — default view. Live agent list + per-agent chat surface with streaming responses, attachments, and mid-stream query replies.
+- **PI Exec mode** — appears in the header as soon as a `pi-headless` controller is discovered. Spawn PI sessions (cwd, model, thinking level, max lifetime), prompt them, and fan out one prompt across N working directories in parallel.
+- **Auto-discovery** — new agents appear in the list as soon as they publish their first heartbeat. `ReferenceAgent` fires that synchronously on `start()`, so a fresh session shows up in ~one NATS round-trip — no need to hit Refresh after spawning.
+- **Mid-stream queries** — agents can pause a response to ask a permission or clarification question; the UI renders these inline with shortcut allow/deny buttons and a free-text reply box.
+- **Local validation** — oversized envelopes and unsupported attachments are caught before any wire traffic, with the SDK's typed errors surfaced in the UI.
 
 ## Shape
 
 ```
-Browser (Vue 3)  ⇄  Bun server  ⇄  NATS  ⇄  Agent (pi, claude, ...)
+Browser (Vue 3)  ⇄  Bun server  ⇄  NATS  ⇄  Agent(s)
                      (SDK lives here)
 ```
 
@@ -65,9 +75,21 @@ bun run server/index.ts [--port 3300] [--context current] [--servers nats://...]
 | `--servers <url>` | `NATS_URL` | - | Raw NATS URL (overrides context if given) |
 | `--dev` | - | off | Skip static serving; requires `bun run vite` alongside |
 
+## PI Exec mode
+
+When the UI discovers at least one [`pi-headless`](../pi-headless) controller, a
+**PI Exec** toggle lights up in the header next to **Chat**. The workspace is a
+three-column layout:
+
+- **Left** — spawn form (`cwd`, model, thinking level, max lifetime, optional `session_id`) + a live list of currently-spawned sessions showing lifetime countdown, queue depth, running/idle status, and model/thinking metadata. Click a session to chat with it; hit ✕ to stop it.
+- **Middle** — the same chat surface Chat mode uses, but pointed at whichever session is selected. Streaming chunks, attachments, and mid-stream queries all work identically.
+- **Right** — **Fan-out composer**. Enter one prompt and a list of working directories; the UI spawns N sessions in parallel, streams each into its own card, and (optionally) disposes them when the prompt completes. Per-card abort plus a global clear.
+
+Spawned sessions are first-class NATS agents: discovery sees them, Chat mode lists them, and anything speaking the protocol can prompt them directly. PI Exec mode is just an ergonomic front door for the spawn / prompt / stop / fan-out flow.
+
 ## Mid-stream queries
 
-Agents can pause a response to ask a question (protocol §7 query chunk) -
+Agents can pause a response to ask a question (protocol's query chunk) -
 a permission prompt, a clarification, anything. The UI renders these inline
 as a separate bubble with:
 
@@ -79,14 +101,29 @@ Whichever you use, the reply value is sent verbatim to the query's
 `yes`/`no` maps to allow/deny. For other agents, type whatever answer the
 prompt calls for.
 
-## Verify against the `pi` agent
+## Verify
+
+**Against the `pi` agent:**
 
 ```bash
-# 1. In one terminal, start a pi session with the channel installed.
+# Terminal 1: pi session with the channel installed
 cd ../../agents/pi && pi
 
-# 2. In another, launch the web UI.
+# Terminal 2: web UI
 cd ../../examples/agent-web-ui && bun run build && bun run start
-
-# 3. Open the UI, select the `pi` agent, prompt, attach a file, watch it stream.
 ```
+
+Open the UI, pick `pi` in the agent list, prompt, attach a file, watch it stream.
+
+**Against `pi-headless` (PI Exec mode):**
+
+```bash
+# Terminal 1: controller
+cd ../pi-headless && bun run start
+
+# Terminal 2: web UI (same command as above)
+cd ../../examples/agent-web-ui && bun run build && bun run start
+```
+
+The PI Exec toggle appears. Spawn a session in `/tmp`, prompt it, then try a
+fan-out across a few sandbox directories in parallel.

--- a/examples/pi-headless/README.md
+++ b/examples/pi-headless/README.md
@@ -1,10 +1,12 @@
 # pi-headless
 
-A headless NATS agent host for the [PI coding agent](https://github.com/badlogic/pi-mono), built on `@synadia/agents` and conforming to the NATS Agent Protocol v0.2.0-draft.
+A headless NATS agent host for the [PI coding agent](https://github.com/badlogic/pi-mono), built on `@synadia/agents` and conforming to the NATS Agent Protocol v0.2.0.
 
 Each spawned PI session registers as its own NATS agent instance under `agents.pi.<owner>.<session_id>` - discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia/agents` SDK. A small **controller** service at `agents.pi.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle - `spawn`, `stop`, `list` - alongside the protocol-required `prompt` endpoint (which returns help text).
 
 In short: one process, many PI sessions, all first-class NATS agents.
+
+Paired with [`examples/agent-web-ui/`](../agent-web-ui) you also get a browser-based **PI Exec** workspace that picks up spawned sessions automatically, surfaces lifetime/queue metadata, and includes a fan-out composer for running one prompt across many working directories in parallel.
 
 ## Quickstart
 


### PR DESCRIPTION
  Four small fixes after a repo-wide README sweep:

  - examples/agent-web-ui/README.md: rewritten to document the PI Exec workspace (spawn form, session list with lifetime/queue metadata, fan-out composer), auto-discovery via heartbeat (sub-second visibility for freshly-spawned sessions), and a second Verify recipe using pi-headless. New 'Features' section at the top for scanability.
  - examples/pi-headless/README.md: added a one-paragraph cross-reference pointing at agent-web-ui's PI Exec workspace so users discover the browser UI from the agent side.
  - agents/openclaw/README.md: fixed phrasing on the 'org' -> 'owner' migration note — it was the v0.1 -> v0.2 rename, not intra-v0.2.
  - Protocol version spelling standardized to 'v0.2.0' across all READMEs (previously a mix of 'v0.2' and 'v0.2.0-draft').

  No functional changes.