### PR TITLE
rebrand: move all packages to @synadia-ai scope, reset to 0.1.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
         - NATS Agent Protocol compliance (spec: https://github.com/synadia-ai/nats-agent-sdk-docs).
         - Cross-SDK wire compatibility between client-sdk/typescript and client-sdk/python — anything that changes the wire shape must keep both SDKs interoperable.
         - Attachment handling: base64 validation (strict RFC 4648), filename safety (no absolute paths, no ".." traversal, no NUL bytes), and path safety in per-agent staging directories.
-        - Public API stability in @synadia/agents (TypeScript) and natsagent (Python). Call out breaking changes explicitly.
+        - Public API stability in @synadia-ai/agents (TypeScript) and natsagent (Python). Call out breaking changes explicitly.
         - Sandbox soundness in examples/dspy — the bash tool is a soft boundary; flag anything that weakens it further.
         - Error envelopes and Nats-Service-Error-Code handling (400 for client errors, 500 for server; terminator is an empty body with no headers).
     secrets:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ synadia-agents/
 ├── README.md              ← you are here
 ├── client-sdk/            ← language SDKs (callers)
 │   ├── README.md
-│   ├── typescript/        ← @synadia/agents (TypeScript/Node/Bun)
+│   ├── typescript/        ← @synadia-ai/agents (TypeScript/Node/Bun)
 │   └── python/            ← natsagent (Python ≥ 3.11)
 ├── agents/                ← plugins that put existing AI harnesses on NATS
 │   ├── README.md
@@ -79,7 +79,7 @@ You bring a `NatsConnection`; the SDK uses it. Use `@nats-io/transport-node` for
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ See `client-sdk/typescript/README.md` for install, error handling, and full exam
 
 ## License
 
-Apache-2.0 for the SDK, MIT for the agent channels and examples - see each subtree's `LICENSE` file.
+Apache-2.0 across this monorepo - see each package's `LICENSE` file.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ One home for everything built on the **NATS Agent Protocol** - the SDKs that spe
 
 Every AI agent in this repo (Claude Code, OpenClaw, PI, DSPy-ReAct, …) registers as a NATS micro service named `agents`. Callers discover, prompt, and stream from it using any language's SDK - same wire format everywhere.
 
+The TypeScript SDK, the OpenClaw and PI channel plugins, and two runnable examples ship to npm under the **`@synadia-ai/*`** scope — see each package's `package.json` for its published identity.
+
 ## Repository layout
 
 ```

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -72,12 +72,12 @@ The server reads connection details (URL, credentials) from
 
 **5. Send a prompt.**
 
-With the [`@synadia/agents`](../../client-sdk/typescript)
+With the [`@synadia-ai/agents`](../../client-sdk/typescript)
 TypeScript SDK:
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -9,7 +9,7 @@
 
 NATS gateway for [Hermes Agent](https://github.com/NousResearch/hermes-agent), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
-Hermes is a self-improving coding agent with a CLI, a TUI, and a messaging gateway sharing one agent core. With the NATS gateway enabled, each running Hermes instance becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`natsagent`](../../client-sdk/python) (Python) or [`@synadia/agents`](../../client-sdk/typescript) (TypeScript) - can enumerate running Hermes instances, prompt them (with attachments), and stream responses back.
+Hermes is a self-improving coding agent with a CLI, a TUI, and a messaging gateway sharing one agent core. With the NATS gateway enabled, each running Hermes instance becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`natsagent`](../../client-sdk/python) (Python) or [`@synadia-ai/agents`](../../client-sdk/typescript) (TypeScript) - can enumerate running Hermes instances, prompt them (with attachments), and stream responses back.
 
 Sibling implementations sharing the same wire protocol: [`pi`](../pi) (PI), [`openclaw`](../openclaw) (OpenClaw), [`claude-code`](../claude-code) (Claude Code).
 

--- a/agents/openclaw/LICENSE
+++ b/agents/openclaw/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Synadia Communications
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -230,4 +230,4 @@ The smoke test drives a minimal spec-compliant service assembled from the repo's
 
 ## License
 
-MIT
+Apache-2.0

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -1,10 +1,8 @@
-# @synadia/nats-channel
-
-> Currently published on npm as `@m64/nats-channel`; moving to `@synadia/nats-channel` once Synadia publishing access lands. Install commands below use the current name.
+# @synadia-ai/nats-channel
 
 NATS channel plugin for [OpenClaw](https://openclaw.ai), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
-Every configured OpenClaw agent becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia/agents`](../../client-sdk/typescript) - can enumerate running OpenClaw agents, prompt them, and stream responses back.
+Every configured OpenClaw agent becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) - can enumerate running OpenClaw agents, prompt them, and stream responses back.
 
 Sibling implementations sharing the same wire protocol: [`pi`](../pi) (PI), [`claude-code`](../claude-code) (Claude Code).
 
@@ -24,13 +22,7 @@ Malformed envelopes, oversized payloads, invalid base64, and unsafe filenames ar
 ## Install
 
 ```bash
-openclaw plugins install @m64/nats-channel
-```
-
-Or use the one-line installer with a guided config wizard:
-
-```bash
-curl -fsSL https://m64.io/nats-channels/openclaw.sh | bash
+openclaw plugins install @synadia-ai/nats-channel
 ```
 
 ## Configure
@@ -147,7 +139,7 @@ With the TypeScript SDK:
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -2,7 +2,6 @@
   "name": "@synadia-ai/nats-channel",
   "version": "0.1.0",
   "description": "NATS Agent Protocol channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
-  "license": "MIT",
   "keywords": [
     "openclaw",
     "nats",
@@ -11,7 +10,29 @@
     "nats-agent-protocol",
     "synadia-agents"
   ],
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "agents/openclaw"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/agents/openclaw",
+  "bugs": {
+    "url": "https://github.com/synadia-ai/synadia-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
+  "files": [
+    "src",
+    "index.ts",
+    "setup-entry.ts",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@m64/nats-channel",
-  "version": "0.4.1",
+  "name": "@synadia-ai/nats-channel",
+  "version": "0.1.0",
   "description": "NATS Agent Protocol channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
   "license": "MIT",
   "keywords": [

--- a/agents/openclaw/src/nats/protocol.ts
+++ b/agents/openclaw/src/nats/protocol.ts
@@ -11,7 +11,7 @@ import type { MsgHdrs } from "@nats-io/nats-core";
 import type { DecodedAttachment, HeartbeatPayload, ParsedEnvelope } from "./types.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Spec constants (mirror `@synadia/agents` 0.2.0-draft)
+// Spec constants (mirror `@synadia-ai/agents` 0.2.0-draft)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Spec §3.1: the service name is the bare token `agents`. Subject-safe as-is. */

--- a/agents/openclaw/test/smoke.mjs
+++ b/agents/openclaw/test/smoke.mjs
@@ -1,5 +1,5 @@
 // Wire-level smoke test for the NATS Agent Protocol 0.2.0-draft layer of
-// @m64/nats-channel (OpenClaw).
+// @synadia-ai/nats-channel (OpenClaw).
 //
 // This test does NOT boot a full OpenClaw pipeline. Instead it assembles a
 // minimal spec-compliant service from the same primitives gateway.ts uses

--- a/agents/pi/LICENSE
+++ b/agents/pi/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Synadia Communications
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -189,4 +189,4 @@ Deliberate deferrals:
 
 ## License
 
-MIT
+Apache-2.0

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -1,10 +1,8 @@
-# @synadia/nats-pi-channel
-
-> Currently published on npm as `@m64/nats-pi-channel`; moving to `@synadia/nats-pi-channel` once Synadia publishing access lands. Install commands below use the current name.
+# @synadia-ai/nats-pi-channel
 
 NATS channel for [PI Agent](https://github.com/badlogic/pi-mono), implementing the **[NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.2.0**.
 
-Every PI session becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia/agents`](../../client-sdk/typescript) - can enumerate running PI sessions, prompt them, and stream responses back.
+Every PI session becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol - e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) - can enumerate running PI sessions, prompt them, and stream responses back.
 
 Sibling implementations (same wire protocol): [`claude-code`](../claude-code), [`openclaw`](../openclaw).
 
@@ -24,8 +22,8 @@ Multiple PI sessions on the same host register as distinct instances of the same
 ## Install
 
 ```bash
-# From npm (once published)
-pi install npm:@m64/nats-pi-channel
+# From npm
+pi install npm:@synadia-ai/nats-pi-channel
 
 # From a local clone during development
 pi install /absolute/path/to/nats-pi-channel
@@ -103,7 +101,7 @@ With the TypeScript SDK:
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -49,7 +49,7 @@ import type { Service, ServiceMsg } from "@nats-io/services";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Protocol constants (mirror @synadia/agents spec 0.1.0-draft)
+// Protocol constants (mirror @synadia-ai/agents spec 0.1.0-draft)
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Spec §3.1: the service name is the bare token `agents`. Subject-safe as-is,

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -2,8 +2,6 @@
   "name": "@synadia-ai/nats-pi-channel",
   "version": "0.1.0",
   "description": "NATS Agent Protocol channel for PI Agent. Makes every PI session a discoverable, spec-compliant agent on NATS.",
-  "license": "MIT",
-  "type": "module",
   "keywords": [
     "pi-package",
     "pi-agent",
@@ -13,8 +11,25 @@
     "nats-agent-protocol",
     "synadia-agents"
   ],
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "agents/pi"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/agents/pi",
+  "bugs": {
+    "url": "https://github.com/synadia-ai/synadia-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
   "files": [
-    "extensions"
+    "extensions",
+    "README.md",
+    "LICENSE"
   ],
   "pi": {
     "extensions": [

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@m64/nats-pi-channel",
-  "version": "0.4.1",
+  "name": "@synadia-ai/nats-pi-channel",
+  "version": "0.1.0",
   "description": "NATS Agent Protocol channel for PI Agent. Makes every PI session a discoverable, spec-compliant agent on NATS.",
   "license": "MIT",
   "type": "module",

--- a/client-sdk/README.md
+++ b/client-sdk/README.md
@@ -6,7 +6,7 @@ Caller-side libraries that speak the **NATS Agent Protocol**. They discover agen
 
 | Language   | Path          | Package           | Runtime              |
 | ---------- | ------------- | ----------------- | -------------------- |
-| TypeScript | `typescript/` | `@synadia/agents` | Node ≥ 20, Bun ≥ 1.2 |
+| TypeScript | `typescript/` | `@synadia-ai/agents` | Node ≥ 20, Bun ≥ 1.2 |
 | Python     | `python/`     | `natsagent`       | Python ≥ 3.11        |
 
 Go and other languages are planned.
@@ -17,7 +17,7 @@ Go and other languages are planned.
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -4,9 +4,24 @@ All notable changes to `@synadia-ai/agents` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+> **Note:** this SDK was developed under the placeholder name
+> `@synadia/agents` but never actually published to npm under that name.
+> The `[0.2.0-dev]` and `[0.1.0-dev]` sections below document the API as
+> it evolved prior to the rebrand; they are retained as design history,
+> not actual npm releases. `[0.1.0]` is the first real release under
+> `@synadia-ai/agents`.
 
-### Changed (breaking)
+## [0.1.0] - 2026-04-24
+
+**First release under the `@synadia-ai/agents` npm scope.** The API
+shipped at 0.1.0 matches what was previously staged under `[Unreleased]`
+during pre-rebrand development — the `new Agents({ nc })` entry point,
+directly-callable `Agent[]` from `discover()`, and the `stall` default.
+Breakage and removals below are expressed relative to `[0.2.0-dev]`
+(the last pre-rebrand design state); as a first real release under the
+new scope, this *is* the shipping API.
+
+### Changed (breaking) vs `[0.2.0-dev]`
 
 - **Single entry point: `new Agents({ nc })`.** The SDK no longer opens
   NATS connections — callers build a `NatsConnection` via
@@ -88,7 +103,7 @@ const bound = configured
   .filter((a): a is Agent => a !== undefined);
 ```
 
-## [0.2.0] - protocol `0.2.0-draft`
+## [0.2.0-dev] - protocol `0.2.0-draft` (pre-rebrand design history)
 
 Tracks the rename of the protocol's service filter (spec §3.1) and the new
 queue-group requirement on the `prompt` endpoint (§3.3). **Not wire-compatible
@@ -139,7 +154,7 @@ with 0.1**: agents and callers must be upgraded together.
   Common cases (`url`, `creds`, `token`, `user`/`password`, `user_jwt`,
   `inbox_prefix`) ship in `0.2`.
 
-## [0.1.0] - initial pre-release
+## [0.1.0-dev] - initial pre-release (pre-rebrand design history)
 
 Implements the client surface of the NATS Agent Protocol `0.1.0-draft`.
 

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -19,7 +19,7 @@ during pre-rebrand development — the `new Agents({ nc })` entry point,
 directly-callable `Agent[]` from `discover()`, and the `stall` default.
 Breakage and removals below are expressed relative to `[0.2.0-dev]`
 (the last pre-rebrand design state); as a first real release under the
-new scope, this *is* the shipping API.
+new scope, this _is_ the shipping API.
 
 ### Changed (breaking) vs `[0.2.0-dev]`
 

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `@synadia/agents` will be documented in this file.
+All notable changes to `@synadia-ai/agents` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -55,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ```ts
 // Before
-import { connect } from "@synadia/agents";
+import { connect } from "@synadia-ai/agents";
 const client = await connect({ name: "my-app", servers: "nats://localhost:4222" });
 const found = await client.discover();
 const remote = client.bind(found[0]!);
@@ -63,7 +63,7 @@ await remote.prompt("hi");
 
 // After
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await natsConnect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });
@@ -159,7 +159,7 @@ Implements the client surface of the NATS Agent Protocol `0.1.0-draft`.
 - **Heartbeat tracking (§8)** keyed on `instance_id` (not subject) - multi-instance safe. Narrow wildcard via `heartbeatScope: {agent, owner}`.
 - **`Client.ping(instanceId)`** for on-demand reachability (§8.4).
 - **`Client.close()`** aborts all in-flight streams via shared AbortController; closes connection iff owned.
-- **Subpath exports:** `@synadia/agents/errors`, `@synadia/agents/testing` (spec-compliant `ReferenceAgent` + harness).
+- **Subpath exports:** `@synadia-ai/agents/errors`, `@synadia-ai/agents/testing` (spec-compliant `ReferenceAgent` + harness).
 - **Runtime-agnostic pure core** - envelope, validation, chunk-decoder, terminator, bytes, version, subjects, endpoint-info, heartbeat-payload - enforced by ESLint.
 - **5 runnable examples** under `examples/`; spec-compliance docs under `docs/protocol-mapping.md`.
 

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -1,4 +1,4 @@
-# @synadia/agents
+# @synadia-ai/agents
 
 **TypeScript SDK for the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs).** Discover, prompt, and stream from AI agents over NATS.
 
@@ -9,9 +9,9 @@
 ## Install
 
 ```sh
-bun add @synadia/agents
-# or: npm install @synadia/agents
-# or: pnpm add @synadia/agents
+bun add @synadia-ai/agents
+# or: npm install @synadia-ai/agents
+# or: pnpm add @synadia-ai/agents
 ```
 
 ## 30-second quickstart
@@ -23,7 +23,7 @@ services, and anything else in the `@nats-io/*` ecosystem.
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });
@@ -45,7 +45,7 @@ await nc.close(); // caller owns the NATS connection
 If the target agent doesn't accept attachments, or if the envelope exceeds its `max_payload`, the SDK fails your call _before_ publishing:
 
 ```ts
-import { AttachmentsNotSupportedError, PayloadTooLargeError } from "@synadia/agents";
+import { AttachmentsNotSupportedError, PayloadTooLargeError } from "@synadia-ai/agents";
 
 try {
   const stream = await remote.prompt("describe this photo", {
@@ -78,8 +78,8 @@ Both error types extend `ValidationError` → `NatsAgentError`. See [Error handl
 
 Subpath exports:
 
-- **`@synadia/agents/errors`** - the error class hierarchy, for targeted `instanceof` branches.
-- **`@synadia/agents/testing`** - a `ReferenceAgent` helper for your own test suite.
+- **`@synadia-ai/agents/errors`** - the error class hierarchy, for targeted `instanceof` branches.
+- **`@synadia-ai/agents/testing`** - a `ReferenceAgent` helper for your own test suite.
 
 ## Documentation
 

--- a/client-sdk/typescript/TODO.md
+++ b/client-sdk/typescript/TODO.md
@@ -32,7 +32,7 @@ Flag once this SDK is tested & published:
 
 ## Agent-hosting surface (planned for 0.2)
 
-`@synadia/agents` today is client-only. A future release adds an
+`@synadia-ai/agents` today is client-only. A future release adds an
 agent-hosting side so TS authors can build protocol-compliant agents
 without re-implementing service registration + chunk framing by hand.
 

--- a/client-sdk/typescript/docs/getting-started.md
+++ b/client-sdk/typescript/docs/getting-started.md
@@ -1,16 +1,16 @@
 # Getting started
 
-`@synadia/agents` is the TypeScript client SDK for the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs). This guide walks through the complete flow: connecting, discovering agents, prompting one with attachments, and handling the three protocol-defined failure modes locally.
+`@synadia-ai/agents` is the TypeScript client SDK for the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs). This guide walks through the complete flow: connecting, discovering agents, prompting one with attachments, and handling the three protocol-defined failure modes locally.
 
 ## Prerequisites
 
 - Node.js ≥ 20 **or** Bun ≥ 1.2
 - A running `nats-server` reachable from the client.
-- At least one protocol-compliant agent registered on the NATS system. The `@synadia/agents/testing` subpath ships a spec-compliant reference agent you can run locally:
+- At least one protocol-compliant agent registered on the NATS system. The `@synadia-ai/agents/testing` subpath ships a spec-compliant reference agent you can run locally:
 
   ```ts
   import { connect as natsConnect } from "@nats-io/transport-node";
-  import { ReferenceAgent } from "@synadia/agents/testing";
+  import { ReferenceAgent } from "@synadia-ai/agents/testing";
 
   const nc = await natsConnect({ servers: "nats://localhost:4222" });
   const agent = new ReferenceAgent({
@@ -26,7 +26,7 @@
 ## Install
 
 ```sh
-bun add @synadia/agents     # or: npm install @synadia/agents
+bun add @synadia-ai/agents     # or: npm install @synadia-ai/agents
 ```
 
 ## Connect + discover + prompt
@@ -38,7 +38,7 @@ KV, services, or any other `@nats-io/*` library.
 
 ```ts
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await natsConnect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });
@@ -61,7 +61,7 @@ That's the quickstart. Everything else below is depth on specific features.
 The boss's scenario - send a photo and ask about it:
 
 ```ts
-import { AttachmentsNotSupportedError, PayloadTooLargeError } from "@synadia/agents";
+import { AttachmentsNotSupportedError, PayloadTooLargeError } from "@synadia-ai/agents";
 
 try {
   const stream = await remote.prompt("describe this photo", {
@@ -181,10 +181,10 @@ The SDK enforces spec §8.5 automatically: the first call to `discover()` implic
 
 ## Bun usage
 
-`@synadia/agents` runs unchanged on Bun 1.2+:
+`@synadia-ai/agents` runs unchanged on Bun 1.2+:
 
 ```sh
-bun add @synadia/agents
+bun add @synadia-ai/agents
 bun run examples/01-discover.ts
 ```
 

--- a/client-sdk/typescript/examples/01-discover.ts
+++ b/client-sdk/typescript/examples/01-discover.ts
@@ -2,7 +2,7 @@
 // Useful as a quick sanity check when bringing up a new environment.
 
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 async function main(): Promise<void> {
   const nc = await natsConnect({

--- a/client-sdk/typescript/examples/02-prompt-text.ts
+++ b/client-sdk/typescript/examples/02-prompt-text.ts
@@ -3,7 +3,7 @@
 
 import { stdout } from "node:process";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 async function main(): Promise<void> {
   const text = process.argv[2] ?? "hello";

--- a/client-sdk/typescript/examples/03-prompt-attachment.ts
+++ b/client-sdk/typescript/examples/03-prompt-attachment.ts
@@ -24,7 +24,7 @@ import {
   NatsAgentError,
   PayloadTooLargeError,
   type ResponseAttachment,
-} from "@synadia/agents";
+} from "@synadia-ai/agents";
 
 async function main(): Promise<void> {
   const attachmentPath = argv[2];

--- a/client-sdk/typescript/examples/04-query-reply.ts
+++ b/client-sdk/typescript/examples/04-query-reply.ts
@@ -6,7 +6,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents, type QueryEvent } from "@synadia/agents";
+import { Agents, type QueryEvent } from "@synadia-ai/agents";
 
 async function ask(prompt: string): Promise<string> {
   const rl = createInterface({ input: stdin, output: stdout });

--- a/client-sdk/typescript/examples/05-liveness.ts
+++ b/client-sdk/typescript/examples/05-liveness.ts
@@ -3,7 +3,7 @@
 // expected cadence.
 
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents, type HeartbeatPayload } from "@synadia/agents";
+import { Agents, type HeartbeatPayload } from "@synadia-ai/agents";
 
 async function main(): Promise<void> {
   const nc = await natsConnect({

--- a/client-sdk/typescript/examples/_run-reference-agent.ts
+++ b/client-sdk/typescript/examples/_run-reference-agent.ts
@@ -4,7 +4,7 @@
 
 import type { ServiceMsg } from "@nats-io/services";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { ReferenceAgent } from "@synadia/agents/testing";
+import { ReferenceAgent } from "@synadia-ai/agents/testing";
 
 async function main(): Promise<void> {
   const nc = await natsConnect({ servers: process.env["NATS_URL"] ?? "nats://127.0.0.1:4222" });
@@ -14,7 +14,7 @@ async function main(): Promise<void> {
     agent: "demo-agent",
     owner: process.env["USER"] ?? "anon",
     name: "example",
-    description: "reference agent for @synadia/agents examples",
+    description: "reference agent for @synadia-ai/agents examples",
     maxPayload: "1MB",
     attachmentsOk: true,
     heartbeatIntervalS: 5,

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@synadia/agents",
-  "version": "0.2.0",
+  "name": "@synadia-ai/agents",
+  "version": "0.1.0",
   "description": "TypeScript SDK for the NATS Agent Protocol — discover, prompt, and stream from AI agents over NATS.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -49,7 +49,8 @@
     "test:integration": "vitest run test/integration",
     "test:watch": "vitest",
     "docs": "typedoc",
-    "check": "npm run typecheck && npm run lint && npm run format:check && npm run test"
+    "check": "npm run typecheck && npm run lint && npm run format:check && npm run test",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "nats",

--- a/client-sdk/typescript/src/agents.ts
+++ b/client-sdk/typescript/src/agents.ts
@@ -5,7 +5,7 @@
 // Construct with a pre-opened `NatsConnection`:
 //
 //   import { connect } from "@nats-io/transport-node";
-//   import { Agents } from "@synadia/agents";
+//   import { Agents } from "@synadia-ai/agents";
 //
 //   const nc = await connect({ servers: "nats://localhost:4222" });
 //   const agents = new Agents({ nc });
@@ -148,7 +148,7 @@ export class Agents {
   async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
-    this.#closeController.abort(new Error("@synadia/agents: Agents is closed"));
+    this.#closeController.abort(new Error("@synadia-ai/agents: Agents is closed"));
     await this.#tracker.stop();
   }
 
@@ -159,7 +159,7 @@ export class Agents {
 
   #ensureOpen(): void {
     if (this.#closed) {
-      throw new Error("@synadia/agents: Agents is closed");
+      throw new Error("@synadia-ai/agents: Agents is closed");
     }
   }
 }

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -1,4 +1,4 @@
-// @synadia/agents — TypeScript SDK for the NATS Agent Protocol.
+// @synadia-ai/agents — TypeScript SDK for the NATS Agent Protocol.
 //
 // Public API:
 //   - {@link Agents}              — construct with a `NatsConnection`.
@@ -6,8 +6,8 @@
 //   - {@link Agent.prompt}        — stream a prompt to an agent.
 //
 // Subpath entry points:
-//   - `@synadia/agents/errors`  — error class hierarchy for `instanceof`.
-//   - `@synadia/agents/testing` — spec-compliant reference agent and harness.
+//   - `@synadia-ai/agents/errors`  — error class hierarchy for `instanceof`.
+//   - `@synadia-ai/agents/testing` — spec-compliant reference agent and harness.
 
 export { Agents, DEFAULT_STREAM_INACTIVITY_TIMEOUT_MS, type AgentsOptions } from "./agents.js";
 

--- a/client-sdk/typescript/src/testing/index.ts
+++ b/client-sdk/typescript/src/testing/index.ts
@@ -1,4 +1,4 @@
-// Public exports for the `@synadia/agents/testing` subpath.
+// Public exports for the `@synadia-ai/agents/testing` subpath.
 //
 // These helpers let third-party implementations test against a
 // spec-compliant counterparty without rolling their own.

--- a/client-sdk/typescript/src/testing/reference-agent.ts
+++ b/client-sdk/typescript/src/testing/reference-agent.ts
@@ -11,7 +11,7 @@
 //   - Emits an empty-body no-headers terminator after each prompt (default handler).
 //
 // Third parties can use this as a canonical counterparty for their own test
-// suites. Exported via the `@synadia/agents/testing` subpath.
+// suites. Exported via the `@synadia-ai/agents/testing` subpath.
 
 import type { NatsConnection } from "@nats-io/nats-core";
 import { Svcm, type Service, type ServiceMsg } from "@nats-io/services";

--- a/client-sdk/typescript/tsconfig.json
+++ b/client-sdk/typescript/tsconfig.json
@@ -37,9 +37,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "@synadia/agents": ["./src/index.ts"],
-      "@synadia/agents/errors": ["./src/errors.ts"],
-      "@synadia/agents/testing": ["./src/testing/index.ts"]
+      "@synadia-ai/agents": ["./src/index.ts"],
+      "@synadia-ai/agents/errors": ["./src/errors.ts"],
+      "@synadia-ai/agents/testing": ["./src/testing/index.ts"]
     }
   },
   "include": [

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,9 @@ End-to-end apps built with the SDK in `../client-sdk/`. Some are **callers** tha
 
 | Path             | Kind   | Stack                                    | What it shows                                                                 |
 | ---------------- | ------ | ---------------------------------------- | ----------------------------------------------------------------------------- |
-| `agent-web-ui/`  | caller | Vue 3 + Bun (server) + `@synadia/agents` | Browser client for discovery, prompting with attachments, and streaming responses. Renders mid-stream `query` chunks inline with allow/deny controls. When a pi-headless controller is discovered, a second "PI Exec" workspace unlocks: spawn form, session list with lifetime/queue metadata, and a fan-out composer that streams one prompt across N working directories in parallel. |
-| `dspy/`          | agent  | Bun + `@synadia/agents` + [ax-llm](https://github.com/ax-llm/ax) | A standalone NATS Agent Protocol service built from scratch with the SDK's `ReferenceAgent` helper. Runs a DSPy-style ReAct loop with four sandboxed tools (`list_files`, `read_file`, `write_file`, `bash`). Registers as type token `dspy` and can be driven by any caller - including `agent-web-ui/`. |
-| `pi-headless/`   | agent  | Bun/Node + `@synadia/agents` + `@mariozechner/pi-coding-agent` | One process that spawns and manages any number of headless PI coding-agent sessions. Each session registers as its OWN first-class NATS agent at `agents.pi.<owner>.<session_id>` - discoverable and promptable with any protocol client. A small controller at `agents.pi.<owner>.exec` adds request/reply endpoints for session lifecycle (`spawn`, `stop`, `list`) alongside the protocol-required `prompt`. Pairs naturally with `agent-web-ui/` for an interactive spawn/prompt/fan-out UI. |
+| `agent-web-ui/`  | caller | Vue 3 + Bun (server) + `@synadia-ai/agents` | Browser client for discovery, prompting with attachments, and streaming responses. Renders mid-stream `query` chunks inline with allow/deny controls. When a pi-headless controller is discovered, a second "PI Exec" workspace unlocks: spawn form, session list with lifetime/queue metadata, and a fan-out composer that streams one prompt across N working directories in parallel. |
+| `dspy/`          | agent  | Bun + `@synadia-ai/agents` + [ax-llm](https://github.com/ax-llm/ax) | A standalone NATS Agent Protocol service built from scratch with the SDK's `ReferenceAgent` helper. Runs a DSPy-style ReAct loop with four sandboxed tools (`list_files`, `read_file`, `write_file`, `bash`). Registers as type token `dspy` and can be driven by any caller - including `agent-web-ui/`. |
+| `pi-headless/`   | agent  | Bun/Node + `@synadia-ai/agents` + `@mariozechner/pi-coding-agent` | One process that spawns and manages any number of headless PI coding-agent sessions. Each session registers as its OWN first-class NATS agent at `agents.pi.<owner>.<session_id>` - discoverable and promptable with any protocol client. A small controller at `agents.pi.<owner>.exec` adds request/reply endpoints for session lifecycle (`spawn`, `stop`, `list`) alongside the protocol-required `prompt`. Pairs naturally with `agent-web-ui/` for an interactive spawn/prompt/fan-out UI. |
 
 ## Architecture pattern (browser examples)
 
@@ -33,7 +33,7 @@ Browser (Vue / React / …)  ⇄  server process (SDK + NATS)  ⇄  NATS  ⇄  a
 
 **In agent examples (like `dspy/`):**
 
-1. **Building on `ReferenceAgent`** - the SDK's `@synadia/agents/testing` helper handles registration, heartbeats, and stream termination for you.
+1. **Building on `ReferenceAgent`** - the SDK's `@synadia-ai/agents/testing` helper handles registration, heartbeats, and stream termination for you.
 2. **Envelope handling** - accept both plain text and JSON envelopes.
 3. **Chunk streaming** - emit `status` for progress/keep-alive and `response` for content deltas.
 4. **Metadata** - advertise `max_payload` and `attachments_ok` correctly.

--- a/examples/agent-web-ui/LICENSE
+++ b/examples/agent-web-ui/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Synadia Communications
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -1,6 +1,6 @@
 # agent-web-ui
 
-A Bun + Vue 3 test client for the [`@synadia/agents`](../../client-sdk/typescript) SDK.
+A Bun + Vue 3 test client for the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK.
 Discover agents over NATS, prompt them (with optional attachments),
 stream responses back, and — when a [`pi-headless`](../pi-headless) controller
 is online — spawn, prompt, and fan out PI sessions from the browser.

--- a/examples/agent-web-ui/bun.lock
+++ b/examples/agent-web-ui/bun.lock
@@ -6,7 +6,7 @@
       "name": "@m64/nats-ai-tttclient",
       "dependencies": {
         "@nats-io/transport-node": "^3.3.1",
-        "@synadia/agents": "file:../../client-sdk/typescript",
+        "@synadia-ai/agents": "file:../../client-sdk/typescript",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -205,7 +205,7 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@synadia/agents": ["@synadia/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
+    "@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
@@ -745,7 +745,7 @@
 
     "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
-    "@synadia/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+    "@synadia-ai/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/examples/agent-web-ui/bun.lock
+++ b/examples/agent-web-ui/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@m64/nats-ai-tttclient",
+      "name": "@synadia-ai/nats-ai-testui",
       "dependencies": {
         "@nats-io/transport-node": "^3.3.1",
         "@synadia-ai/agents": "file:../../client-sdk/typescript",
@@ -207,7 +207,7 @@
 
     "@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -273,27 +273,27 @@
 
     "@volar/typescript": ["@volar/typescript@2.4.15", "", { "dependencies": { "@volar/language-core": "2.4.15", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.32", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.32", "", { "dependencies": { "@vue/compiler-core": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.33", "", { "dependencies": { "@vue/compiler-core": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA=="],
 
-    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.33", "@vue/compiler-dom": "3.5.33", "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.10", "source-map-js": "^1.2.1" } }, "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA=="],
 
-    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw=="],
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A=="],
 
     "@vue/compiler-vue2": ["@vue/compiler-vue2@2.7.16", "", { "dependencies": { "de-indent": "^1.0.2", "he": "^1.2.0" } }, "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A=="],
 
     "@vue/language-core": ["@vue/language-core@2.2.12", "", { "dependencies": { "@volar/language-core": "2.4.15", "@vue/compiler-dom": "^3.5.0", "@vue/compiler-vue2": "^2.7.16", "@vue/shared": "^3.5.0", "alien-signals": "^1.0.3", "minimatch": "^9.0.3", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA=="],
 
-    "@vue/reactivity": ["@vue/reactivity@3.5.32", "", { "dependencies": { "@vue/shared": "3.5.32" } }, "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ=="],
+    "@vue/reactivity": ["@vue/reactivity@3.5.33", "", { "dependencies": { "@vue/shared": "3.5.33" } }, "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A=="],
 
-    "@vue/runtime-core": ["@vue/runtime-core@3.5.32", "", { "dependencies": { "@vue/reactivity": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ=="],
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ=="],
 
-    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.32", "", { "dependencies": { "@vue/reactivity": "3.5.32", "@vue/runtime-core": "3.5.32", "@vue/shared": "3.5.32", "csstype": "^3.2.3" } }, "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ=="],
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/runtime-core": "3.5.33", "@vue/shared": "3.5.33", "csstype": "^3.2.3" } }, "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw=="],
 
-    "@vue/server-renderer": ["@vue/server-renderer@3.5.32", "", { "dependencies": { "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "vue": "3.5.32" } }, "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ=="],
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.33", "", { "dependencies": { "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "vue": "3.5.33" } }, "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw=="],
 
-    "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
+    "@vue/shared": ["@vue/shared@3.5.33", "", {}, "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="],
 
     "@vue/tsconfig": ["@vue/tsconfig@0.7.0", "", { "peerDependencies": { "typescript": "5.x", "vue": "^3.4.0" }, "optionalPeers": ["typescript", "vue"] }, "sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg=="],
 
@@ -301,7 +301,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "alien-signals": ["alien-signals@1.0.13", "", {}, "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg=="],
 
@@ -321,7 +321,7 @@
 
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -373,7 +373,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "dompurify": ["dompurify@3.4.0", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg=="],
+    "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
@@ -719,7 +719,7 @@
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
-    "vue": ["vue@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/compiler-sfc": "3.5.32", "@vue/runtime-dom": "3.5.32", "@vue/server-renderer": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw=="],
+    "vue": ["vue@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/compiler-sfc": "3.5.33", "@vue/runtime-dom": "3.5.33", "@vue/server-renderer": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ=="],
 
     "vue-tsc": ["vue-tsc@2.2.12", "", { "dependencies": { "@volar/typescript": "2.4.15", "@vue/language-core": "2.2.12" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "./bin/vue-tsc.js" } }, "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw=="],
 

--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -1,9 +1,36 @@
 {
   "name": "@synadia-ai/nats-ai-testui",
   "version": "0.1.0",
-  "type": "module",
-  "private": true,
   "description": "Bun + Vue 3 web test client for the @synadia-ai/agents SDK — prompt NATS agents with optional attachments and stream responses.",
+  "keywords": [
+    "nats",
+    "agents",
+    "agent-protocol",
+    "vue",
+    "bun",
+    "synadia-agents"
+  ],
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "examples/agent-web-ui"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/examples/agent-web-ui",
+  "bugs": {
+    "url": "https://github.com/synadia-ai/synadia-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "files": [
+    "dist",
+    "server",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "dev": "bun run server/index.ts --dev",
     "vite": "vite",

--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -36,7 +36,8 @@
     "vite": "vite",
     "build": "vite build",
     "start": "bun run server/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
   },
   "dependencies": {
     "@nats-io/transport-node": "^3.3.1",

--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@m64/nats-ai-testui",
+  "name": "@synadia-ai/nats-ai-testui",
   "version": "0.1.0",
   "type": "module",
   "private": true,
-  "description": "Bun + Vue 3 web test client for the @synadia/agents SDK — prompt NATS agents with optional attachments and stream responses.",
+  "description": "Bun + Vue 3 web test client for the @synadia-ai/agents SDK — prompt NATS agents with optional attachments and stream responses.",
   "scripts": {
     "dev": "bun run server/index.ts --dev",
     "vite": "vite",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia/agents": "file:../../client-sdk/typescript"
+    "@synadia-ai/agents": "file:../../client-sdk/typescript"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -19,7 +19,7 @@ import {
   type QueryEvent,
   type RawServiceInfo,
   type RequestAttachment,
-} from "@synadia/agents";
+} from "@synadia-ai/agents";
 import type { Subscription } from "@nats-io/nats-core";
 import type {
   ClientMessage,

--- a/examples/agent-web-ui/server/index.ts
+++ b/examples/agent-web-ui/server/index.ts
@@ -1,6 +1,6 @@
 // nats-ai-testui — Bun server entry point.
 //
-// Owns the single @synadia/agents Client (one NATS connection for the whole
+// Owns the single @synadia-ai/agents Client (one NATS connection for the whole
 // process) and serves:
 //   - GET /ws     → WebSocket; each connection gets a fresh Bridge.
 //   - everything else → static files from ./dist/ (SPA fallback to index.html).
@@ -14,7 +14,7 @@ import {
   Agents,
   SDK_PROTOCOL_VERSION,
   type NatsConnection,
-} from "@synadia/agents";
+} from "@synadia-ai/agents";
 import {
   connect as natsConnect,
   type NodeConnectionOptions,

--- a/examples/agent-web-ui/server/wire.ts
+++ b/examples/agent-web-ui/server/wire.ts
@@ -1,5 +1,5 @@
 // Shared WebSocket message types — the contract between the Bun server (which
-// owns the @synadia/agents SDK client) and the browser UI.
+// owns the @synadia-ai/agents SDK client) and the browser UI.
 //
 // All messages are JSON text. Binary attachments are carried as base64 strings
 // so the wire stays a single JSON stream in both directions.

--- a/examples/dspy/README.md
+++ b/examples/dspy/README.md
@@ -1,6 +1,6 @@
 # examples/dspy - building an agent with the SDK
 
-An example of **building a new agent from scratch** using the `@synadia/agents` TypeScript SDK. It runs a [ax-llm](https://github.com/ax-llm/ax) (DSPy-style signatures + ReAct) loop with four sandboxed tools: `list_files`, `read_file`, `write_file`, `bash`. Once started it appears as a normal NATS Agent Protocol service and can be driven by any caller - the CLI examples in `../../client-sdk/typescript/examples/`, the web UI in `../agent-web-ui/`, or your own code.
+An example of **building a new agent from scratch** using the `@synadia-ai/agents` TypeScript SDK. It runs a [ax-llm](https://github.com/ax-llm/ax) (DSPy-style signatures + ReAct) loop with four sandboxed tools: `list_files`, `read_file`, `write_file`, `bash`. Once started it appears as a normal NATS Agent Protocol service and can be driven by any caller - the CLI examples in `../../client-sdk/typescript/examples/`, the web UI in `../agent-web-ui/`, or your own code.
 
 - `list_files` / `read_file` / `write_file` refuse any path that escapes the sandbox root.
 - `bash` runs commands with `cwd` set to the sandbox root, a 30 s timeout, and 8000-char output truncation. **Note:** a shell is a soft boundary - the model can `cd ..`, `curl`, etc. Don't point this at anything you care about.

--- a/examples/dspy/bun.lock
+++ b/examples/dspy/bun.lock
@@ -8,7 +8,7 @@
         "@ax-llm/ax": "^19.0.45",
         "@nats-io/services": "^3.3.1",
         "@nats-io/transport-node": "^3.3.1",
-        "@synadia/agents": "file:../../client-sdk/typescript",
+        "@synadia-ai/agents": "file:../../client-sdk/typescript",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -202,7 +202,7 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@synadia/agents": ["@synadia/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
+    "@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -682,9 +682,9 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@synadia/agents/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+    "@synadia-ai/agents/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
-    "@synadia/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+    "@synadia-ai/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/examples/dspy/package.json
+++ b/examples/dspy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@synadia/nats-dspy-agent",
+  "name": "@synadia-ai/nats-dspy-agent",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -12,7 +12,7 @@
     "@ax-llm/ax": "^19.0.45",
     "@nats-io/services": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia/agents": "file:../../client-sdk/typescript"
+    "@synadia-ai/agents": "file:../../client-sdk/typescript"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/dspy/scripts/ask.ts
+++ b/examples/dspy/scripts/ask.ts
@@ -2,7 +2,7 @@
 import process from "node:process";
 import { stdout } from "node:process";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const question = process.argv.slice(2).join(" ") || "list the sandbox contents and summarize what you find";
 

--- a/examples/dspy/src/index.ts
+++ b/examples/dspy/src/index.ts
@@ -8,7 +8,7 @@ import process from "node:process";
 import { ai, ax } from "@ax-llm/ax";
 import type { ServiceMsg } from "@nats-io/services";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { ReferenceAgent } from "@synadia/agents/testing";
+import { ReferenceAgent } from "@synadia-ai/agents/testing";
 import { makeFsTools } from "./tools.js";
 
 const NATS_URL = process.env["NATS_URL"] ?? "nats://127.0.0.1:4222";

--- a/examples/pi-headless/LICENSE
+++ b/examples/pi-headless/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Synadia Communications
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/examples/pi-headless/README.md
+++ b/examples/pi-headless/README.md
@@ -1,8 +1,8 @@
 # pi-headless
 
-A headless NATS agent host for the [PI coding agent](https://github.com/badlogic/pi-mono), built on `@synadia/agents` and conforming to the NATS Agent Protocol v0.2.0.
+A headless NATS agent host for the [PI coding agent](https://github.com/badlogic/pi-mono), built on `@synadia-ai/agents` and conforming to the NATS Agent Protocol v0.2.0.
 
-Each spawned PI session registers as its own NATS agent instance under `agents.pi.<owner>.<session_id>` - discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia/agents` SDK. A small **controller** service at `agents.pi.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle - `spawn`, `stop`, `list` - alongside the protocol-required `prompt` endpoint (which returns help text).
+Each spawned PI session registers as its own NATS agent instance under `agents.pi.<owner>.<session_id>` - discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.pi.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle - `spawn`, `stop`, `list` - alongside the protocol-required `prompt` endpoint (which returns help text).
 
 In short: one process, many PI sessions, all first-class NATS agents.
 
@@ -93,7 +93,7 @@ Programmatically with the SDK:
 
 ```ts
 import { connect } from "@nats-io/transport-node";
-import { Agents } from "@synadia/agents";
+import { Agents } from "@synadia-ai/agents";
 
 const nc = await connect({ servers: "nats://localhost:4222" });
 const agents = new Agents({ nc });

--- a/examples/pi-headless/bun.lock
+++ b/examples/pi-headless/bun.lock
@@ -8,7 +8,7 @@
         "@mariozechner/pi-coding-agent": "latest",
         "@nats-io/services": "^3.3.1",
         "@nats-io/transport-node": "^3.3.1",
-        "@synadia/agents": "file:../../client-sdk/typescript",
+        "@synadia-ai/agents": "file:../../client-sdk/typescript",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -422,7 +422,7 @@
 
     "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
 
-    "@synadia/agents": ["@synadia/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
+    "@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" }, "devDependencies": { "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -1112,9 +1112,9 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "@synadia/agents/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+    "@synadia-ai/agents/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
-    "@synadia/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+    "@synadia-ai/agents/typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@synadia/nats-pi-headless",
+  "name": "@synadia-ai/nats-pi-headless",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -12,7 +12,7 @@
     "@mariozechner/pi-coding-agent": "latest",
     "@nats-io/services": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia/agents": "file:../../client-sdk/typescript"
+    "@synadia-ai/agents": "file:../../client-sdk/typescript"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -1,9 +1,36 @@
 {
   "name": "@synadia-ai/nats-pi-headless",
   "version": "0.1.0",
-  "private": true,
-  "type": "module",
   "description": "Headless NATS agent host that spawns, prompts, and stops PI coding-agent sessions as first-class NATS Agent Protocol (v0.2.0-draft) instances. Each session registers as agents.pi.<owner>.<session_id>; a small controller service adds spawn/stop/list custom endpoints.",
+  "keywords": [
+    "nats",
+    "agents",
+    "agent-protocol",
+    "pi",
+    "pi-agent",
+    "synadia-agents"
+  ],
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "examples/pi-headless"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/examples/pi-headless",
+  "bugs": {
+    "url": "https://github.com/synadia-ai/synadia-agents/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "files": [
+    "src",
+    "scripts",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "bun run src/index.ts",
     "typecheck": "tsc --noEmit"

--- a/examples/pi-headless/scripts/_common.ts
+++ b/examples/pi-headless/scripts/_common.ts
@@ -3,7 +3,7 @@
 import { connect as natsConnect } from "@nats-io/transport-node";
 import type { NatsConnection } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
-import { Agents, type Agent } from "@synadia/agents";
+import { Agents, type Agent } from "@synadia-ai/agents";
 import { loadNatsContext } from "../src/nats-context.js";
 
 export interface CliArgs {

--- a/examples/pi-headless/src/controller.ts
+++ b/examples/pi-headless/src/controller.ts
@@ -18,7 +18,7 @@ import {
   SDK_PROTOCOL_VERSION,
   SERVICE_NAME,
   PROMPT_QUEUE_GROUP,
-} from "@synadia/agents";
+} from "@synadia-ai/agents";
 
 import { responseText, statusAck } from "./chunk-encoder.js";
 import {

--- a/examples/pi-headless/src/managed-session.ts
+++ b/examples/pi-headless/src/managed-session.ts
@@ -5,7 +5,7 @@
 
 import type { NatsConnection } from "@nats-io/nats-core";
 import type { ServiceMsg } from "@nats-io/services";
-import { ReferenceAgent } from "@synadia/agents/testing";
+import { ReferenceAgent } from "@synadia-ai/agents/testing";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 
 import { cleanupStaged, decorateWithAttachments, stageAttachments } from "./attachments.js";


### PR DESCRIPTION
## Summary

Rebrands every publishable package in the monorepo to the **`@synadia-ai`** npm scope and resets them to **`0.1.0`** as the fresh-start version under Synadia. Adds the LICENSE files and metadata the old `@m64` packages never had, so the next `npm publish` under the new scope is routine.

| Path | Old name | New name | Status |
|---|---|---|---|
| `client-sdk/typescript` | `@synadia/agents` | `@synadia-ai/agents` | first publish |
| `agents/openclaw` | `@m64/nats-channel` | `@synadia-ai/nats-channel` | first publish new scope; old deprecated after merge |
| `agents/pi` | `@m64/nats-pi-channel` | `@synadia-ai/nats-pi-channel` | first publish new scope; old deprecated after merge |
| `examples/pi-headless` | `@synadia/nats-pi-headless` | `@synadia-ai/nats-pi-headless` | first publish (was `private`) |
| `examples/agent-web-ui` | `@m64/nats-ai-testui` | `@synadia-ai/nats-ai-testui` | first publish (was `private`) |
| `examples/dspy` | `@synadia/nats-dspy-agent` | `@synadia-ai/nats-dspy-agent` | stays private; rename only for scope consistency |

## What's in the four commits

1. **`rebrand:` rename @m64/* and @synadia/* to @synadia-ai/*, reset to 0.1.0** — mechanical scope rename across 43 files (6 package.json, tsconfig paths, ~20 source imports/comments, ~15 READMEs, CI workflow). Also drops the "moving to @synadia/... once publishing access lands" transition notes and the `m64.io` one-line installer block.
2. **`metadata:` align package.json + add LICENSE across publishable packages** — openclaw/pi/pi-headless/agent-web-ui now carry the SDK's metadata shape (author, repository, homepage, bugs, publishConfig, keywords, explicit `files` allow-list). LICENSE unified to **Apache-2.0** across the monorepo — openclaw was MIT, relicensed. Apache-2.0 `LICENSE` files added to the four packages that lacked them. `private: true` removed from pi-headless + agent-web-ui. SDK gets a `prepublishOnly: npm run build` hook.
3. **`docs:` CHANGELOG 0.1.0 entry + root README npm note** — SDK CHANGELOG opens a fresh `[0.1.0] - 2026-04-24` entry explaining the rebrand. Prior `[0.2.0]` and `[0.1.0]` sections renamed to `[0.2.0-dev]` and `[0.1.0-dev]` to mark them as pre-rebrand design history (never published under any name) and avoid version collision. Root README gets a one-line note that packages ship under `@synadia-ai/*`.
4. **`chore:` regenerate bun.lock files + prettier fix on CHANGELOG** — bun lockfiles picked up the renamed dep key; prettier formatted the new CHANGELOG note.

## Validation run on this branch

- `bun run typecheck` in SDK, agent-web-ui, pi-headless, dspy — all pass
- `bun run build` (tsup) in SDK — clean dist/
- `bun run lint` + `bun run format:check` in SDK — both pass
- `bun run test:unit` in SDK — **142 passed**
- `bun run build` (vite) in agent-web-ui — dist/ produced
- `npm pack --dry-run` in the 5 publishable packages — tarballs inspected below

### Tarball summaries (from `npm pack --dry-run`)

| Package | Files | Size | Notes |
|---|---|---|---|
| `@synadia-ai/agents` | 22 | 92.9 kB | dist/ + README + LICENSE + CHANGELOG |
| `@synadia-ai/nats-channel` | 18 | 22.0 kB | src/, index.ts, setup-entry.ts, openclaw.plugin.json, README, LICENSE |
| `@synadia-ai/nats-pi-channel` | 4 | 16.9 kB | extensions/ + README + LICENSE (clean) |
| `@synadia-ai/nats-pi-headless` | 17 | 23.2 kB | src/, scripts/, README, LICENSE |
| `@synadia-ai/nats-ai-testui` | 11 | 107.3 kB | dist/ (vite build) + server/, README, LICENSE |

### Not run on this branch

- `bun run test:smoke` in `agents/openclaw` and `agents/pi` — both need a running `nats-server`, and pi additionally needs the `pi` CLI host installed. The SDK's 142 unit tests cover the protocol wire rules those smoke tests also exercise.

## Known follow-ups (intentionally not in this PR)

- **Examples' SDK deps stay on `file:../../client-sdk/typescript` in this PR.** After `@synadia-ai/agents@0.1.0` publishes, a follow-up PR switches those three deps to `"^0.1.0"` so they resolve from the registry. Doing it that way avoids a publish race between PR merge and registry availability.
- **`openclaw` tarball ships `src/accounts.test.ts` + `src/protocol.test.ts`** (~8 kB of test code inside a 22 kB package). npm's `files` field doesn't support `!` exclusion, so cleanly dropping these needs either a test file move (to `test/`) or an `.npmignore` strategy that replaces `files`. Not a blocker for 0.1.0; punt to a follow-up.
- **`peerDependencies.openclaw: ""` on openclaw and `@mariozechner/pi-coding-agent: "*"` on pi** — pre-existing, kept as-is to keep this PR scoped to the rebrand.

## Publishing sequence after merge (manual, user-gated)

1. `npm whoami` → confirm `mschallner` (Synadia-authorized identity). Then `npm publish --access public` **the SDK first** (`@synadia-ai/agents@0.1.0`).
2. Open follow-up PR: switch `examples/{agent-web-ui,pi-headless,dspy}` deps from `file:` → `^0.1.0`. Validate `bun install` resolves from the registry.
3. After follow-up merges, publish the remaining four under `@synadia-ai/*`.
4. `npm logout && npm login` back to `m64`. Then `npm deprecate '@m64/nats-channel@*' 'Moved to @synadia-ai/nats-channel'` and the same for `@m64/nats-pi-channel`.

Each publish is a separate user-approval gate — not batched.

## Test plan

- [ ] CI green on branch
- [ ] `claude-code-reviewer` pass (the check we normally wait for)
- [ ] Spot-check the four new LICENSE files match the SDK's Apache-2.0 text
- [ ] Confirm `npm whoami` is `mschallner` before any actual publish after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)