### PR TITLE
client-sdk/typescript: add loadContextOptions helper

### DIFF
--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -108,7 +108,6 @@ function str(v: unknown): string | undefined {
 
 function resolveBaseDir(): string {
   const explicit = process.env["NATS_CONFIG_HOME"];
-  const explicit = process.env["NATS_CONFIG_HOME"];
   if (explicit) {
     return explicit.startsWith("~/") ? join(homedir(), explicit.slice(2)) : explicit;
   }

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -45,6 +45,9 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   const baseDir = resolveBaseDir();
   const name = selector === "current" ? await resolveCurrentName(baseDir) : selector;
 
+  if (name.includes("/") || name.includes("\\") || name === ".." || name.includes("../") || name.includes("..\\")) {
+    throw new NatsContextError(`invalid context name: "${name}"`);
+  }
   const path = join(baseDir, "context", `${name}.json`);
   let raw: string;
   try {

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -1,0 +1,130 @@
+// `nats` CLI context loader.
+//
+// Reads context files written by `nats context add` / `nats context select`
+// under `~/.config/nats` (or $NATS_CONFIG_HOME / $XDG_CONFIG_HOME/nats) and
+// translates them into `@nats-io/transport-node` connection options ready to
+// pass straight to `connect()`:
+//
+//     import { connect } from "@nats-io/transport-node";
+//     import { Agents, loadContextOptions } from "@synadia/agents";
+//
+//     const opts = await loadContextOptions("prod");
+//     const nc = await connect(opts);
+//     const agents = new Agents({ nc });
+//
+// Supports: `url`, `creds` (path), `user_jwt`, `user`+`password`, `token`,
+// `inbox_prefix`.
+// Skips: `nkey`, TLS cert/key/ca, `nsc` integration.
+//
+// Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
+//
+// `user_jwt` without an accompanying nkey seed leaves the CONNECT signature
+// empty, so it only works against servers that do not require nonce signing.
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { credsAuthenticator, jwtAuthenticator } from "@nats-io/nats-core";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import { NatsAgentError } from "./errors.js";
+
+/** Base error for context resolution failures. */
+export class NatsContextError extends NatsAgentError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "NatsContextError";
+  }
+}
+
+/**
+ * Resolve a NATS CLI context by name into `NodeConnectionOptions` ready to
+ * pass to `connect()`. Pass `"current"` to resolve via `$NATS_CONTEXT` or
+ * the `context.txt` selection file.
+ */
+export async function loadContextOptions(selector: string): Promise<NodeConnectionOptions> {
+  const baseDir = resolveBaseDir();
+  const name = selector === "current" ? await resolveCurrentName(baseDir) : selector;
+
+  const path = join(baseDir, "context", `${name}.json`);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new NatsContextError(`NATS context "${name}" not found at ${path}`);
+    }
+    throw err;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    throw new NatsContextError(
+      `NATS context "${name}" is not valid JSON: ${(err as Error).message}`,
+    );
+  }
+
+  const url = str(parsed["url"]);
+  if (!url) throw new NatsContextError(`NATS context "${name}" is missing \`url\``);
+  const servers = url
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const opts: NodeConnectionOptions = { servers };
+
+  const creds = str(parsed["creds"]);
+  const userJwt = str(parsed["user_jwt"]);
+  if (creds) {
+    const credsPath = creds.startsWith("~/") ? join(homedir(), creds.slice(2)) : creds;
+    const bytes = await readFile(credsPath);
+    opts.authenticator = credsAuthenticator(
+      new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+    );
+  } else if (userJwt) {
+    opts.authenticator = jwtAuthenticator(userJwt);
+  } else {
+    const token = str(parsed["token"]);
+    const user = str(parsed["user"]);
+    const password = str(parsed["password"]);
+    if (token) opts.token = token;
+    if (user) opts.user = user;
+    if (password) opts.pass = password;
+  }
+
+  const inboxPrefix = str(parsed["inbox_prefix"]);
+  if (inboxPrefix) opts.inboxPrefix = inboxPrefix;
+
+  return opts;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function resolveBaseDir(): string {
+  const explicit = process.env["NATS_CONFIG_HOME"];
+  if (explicit) return explicit;
+  const xdg = process.env["XDG_CONFIG_HOME"];
+  if (xdg) return join(xdg, "nats");
+  return join(homedir(), ".config", "nats");
+}
+
+async function resolveCurrentName(baseDir: string): Promise<string> {
+  const envName = process.env["NATS_CONTEXT"];
+  if (envName && envName.length > 0) return envName;
+  const path = join(baseDir, "context.txt");
+  try {
+    const selected = (await readFile(path, "utf8")).trim();
+    if (selected.length === 0) {
+      throw new NatsContextError(`no NATS context is selected (empty ${path})`);
+    }
+    return selected;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new NatsContextError(`no NATS context is selected ($NATS_CONTEXT unset, no ${path})`);
+    }
+    throw err;
+  }
+}

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -45,7 +45,13 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   const baseDir = resolveBaseDir();
   const name = selector === "current" ? await resolveCurrentName(baseDir) : selector;
 
-  if (name.includes("/") || name.includes("\\") || name === ".." || name.includes("../") || name.includes("..\\")) {
+  if (
+    name.includes("/") ||
+    name.includes("\\") ||
+    name === ".." ||
+    name.includes("../") ||
+    name.includes("..\\")
+  ) {
     throw new NatsContextError(`invalid context name: "${name}"`);
   }
   const path = join(baseDir, "context", `${name}.json`);

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -108,7 +108,10 @@ function str(v: unknown): string | undefined {
 
 function resolveBaseDir(): string {
   const explicit = process.env["NATS_CONFIG_HOME"];
-  if (explicit) return explicit;
+  const explicit = process.env["NATS_CONFIG_HOME"];
+  if (explicit) {
+    return explicit.startsWith("~/") ? join(homedir(), explicit.slice(2)) : explicit;
+  }
   const xdg = process.env["XDG_CONFIG_HOME"];
   if (xdg) return join(xdg, "nats");
   return join(homedir(), ".config", "nats");

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -67,6 +67,9 @@ export {
 // Logging
 export { type Logger, SILENT_LOGGER } from "./internal/logger.js";
 
+// NATS CLI context loader
+export { loadContextOptions, NatsContextError } from "./context.js";
+
 // Version metadata
 export {
   SDK_PROTOCOL_VERSION,

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadContextOptions, NatsContextError } from "../../src/context.js";
+
+describe("loadContextOptions", () => {
+  let baseDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), "nats-ctx-"));
+    await mkdir(join(baseDir, "context"), { recursive: true });
+    savedEnv["NATS_CONFIG_HOME"] = process.env["NATS_CONFIG_HOME"];
+    savedEnv["NATS_CONTEXT"] = process.env["NATS_CONTEXT"];
+    savedEnv["XDG_CONFIG_HOME"] = process.env["XDG_CONFIG_HOME"];
+    process.env["NATS_CONFIG_HOME"] = baseDir;
+    delete process.env["NATS_CONTEXT"];
+    delete process.env["XDG_CONFIG_HOME"];
+  });
+
+  afterEach(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  async function writeContext(name: string, body: Record<string, unknown>): Promise<void> {
+    await writeFile(join(baseDir, "context", `${name}.json`), JSON.stringify(body));
+  }
+
+  it("returns servers split from a comma-separated url", async () => {
+    await writeContext("multi", { url: "nats://a:4222, nats://b:4222 ,nats://c:4222" });
+    const opts = await loadContextOptions("multi");
+    expect(opts.servers).toEqual(["nats://a:4222", "nats://b:4222", "nats://c:4222"]);
+  });
+
+  it("maps user/password/token/inbox_prefix", async () => {
+    await writeContext("creds-basic", {
+      url: "nats://localhost:4222",
+      user: "alice",
+      password: "s3cret",
+      token: "tok",
+      inbox_prefix: "_INBOX.alice",
+    });
+    const opts = await loadContextOptions("creds-basic");
+    expect(opts.user).toBe("alice");
+    expect(opts.pass).toBe("s3cret");
+    expect(opts.token).toBe("tok");
+    expect(opts.inboxPrefix).toBe("_INBOX.alice");
+  });
+
+  it("prefers user_jwt over user/password/token", async () => {
+    await writeContext("jwt", {
+      url: "nats://localhost:4222",
+      user_jwt: "eyJ0eXAiOiJKV1QifQ.payload.sig",
+      user: "ignored",
+      password: "ignored",
+      token: "ignored",
+    });
+    const opts = await loadContextOptions("jwt");
+    expect(opts.authenticator).toBeDefined();
+    expect(opts.user).toBeUndefined();
+    expect(opts.pass).toBeUndefined();
+    expect(opts.token).toBeUndefined();
+  });
+
+  it("resolves selector 'current' from $NATS_CONTEXT", async () => {
+    await writeContext("prod", { url: "nats://prod:4222" });
+    process.env["NATS_CONTEXT"] = "prod";
+    const opts = await loadContextOptions("current");
+    expect(opts.servers).toEqual(["nats://prod:4222"]);
+  });
+
+  it("resolves selector 'current' from context.txt when env unset", async () => {
+    await writeContext("staging", { url: "nats://staging:4222" });
+    await writeFile(join(baseDir, "context.txt"), "staging\n");
+    const opts = await loadContextOptions("current");
+    expect(opts.servers).toEqual(["nats://staging:4222"]);
+  });
+
+  it("throws NatsContextError when context file is missing", async () => {
+    await expect(loadContextOptions("nope")).rejects.toBeInstanceOf(NatsContextError);
+  });
+
+  it("throws NatsContextError when JSON is malformed", async () => {
+    await writeFile(join(baseDir, "context", "bad.json"), "{not json");
+    await expect(loadContextOptions("bad")).rejects.toBeInstanceOf(NatsContextError);
+  });
+
+  it("throws NatsContextError when url is missing", async () => {
+    await writeContext("no-url", { user: "alice" });
+    await expect(loadContextOptions("no-url")).rejects.toBeInstanceOf(NatsContextError);
+  });
+
+  it("throws NatsContextError when 'current' has no selection", async () => {
+    await expect(loadContextOptions("current")).rejects.toBeInstanceOf(NatsContextError);
+  });
+});


### PR DESCRIPTION
Add a thin SDK helper that resolves a `nats` CLI context by name into `NodeConnectionOptions` ready to pass straight to `connect()`:

 ```
  import { connect } from "@nats-io/transport-node";
  import { Agents, loadContextOptions } from "@synadia/agents";

  const nc = await connect(await loadContextOptions("prod"));
  const agents = new Agents({ nc });
```

Pass `"current"` to resolve via `$NATS_CONTEXT` or the `context.txt` selection file under `~/.config/nats` (honors `$NATS_CONFIG_HOME` /