### PR TITLE
release: @synadia-ai/agents 0.1.1 (loadContextOptions)

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -11,6 +11,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 > not actual npm releases. `[0.1.0]` is the first real release under
 > `@synadia-ai/agents`.
 
+## [0.1.1] - 2026-04-25
+
+### Added
+
+- **`loadContextOptions(selector)`** — resolves a `nats` CLI context by
+  name (or `"current"`) into `NodeConnectionOptions` ready to pass to
+  `connect()`. Re-introduces the lookup logic that was dropped in `[0.1.0]`,
+  this time as a thin standalone helper rather than a `connect({ context })`
+  factory: callers still own the `NatsConnection`. Supports `url`, `creds`,
+  `user_jwt`, `user`/`password`/`token`, and `inbox_prefix`; `nkey` and TLS
+  cert/key/ca remain deferred. Strict name validation rejects path
+  separators, null bytes, and bare `..`.
+- **`NatsContextError`** exported as the single error class for context
+  resolution failures.
+
 ## [0.1.0] - 2026-04-24
 
 **First release under the `@synadia-ai/agents` npm scope.** The API

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/agents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for the NATS Agent Protocol — discover, prompt, and stream from AI agents over NATS.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -26,15 +26,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { credsAuthenticator, jwtAuthenticator } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
-import { NatsAgentError } from "./errors.js";
-
-/** Base error for context resolution failures. */
-export class NatsContextError extends NatsAgentError {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "NatsContextError";
-  }
-}
+import { NatsContextError } from "./errors.js";
 
 /**
  * Resolve a NATS CLI context by name into `NodeConnectionOptions` ready to

--- a/client-sdk/typescript/src/errors.ts
+++ b/client-sdk/typescript/src/errors.ts
@@ -97,3 +97,15 @@ export class ProtocolError extends NatsAgentError {
     this.name = "ProtocolError";
   }
 }
+
+// ---------------------------------------------------------------------------
+// Configuration / context resolution.
+// ---------------------------------------------------------------------------
+
+/** Failure resolving a `nats` CLI context (see {@link loadContextOptions}). */
+export class NatsContextError extends NatsAgentError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "NatsContextError";
+  }
+}

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -61,6 +61,7 @@ export {
   ServiceError,
   StreamStalledError,
   ProtocolError,
+  NatsContextError,
   type ServiceErrorBody,
 } from "./errors.js";
 
@@ -68,7 +69,7 @@ export {
 export { type Logger, SILENT_LOGGER } from "./internal/logger.js";
 
 // NATS CLI context loader
-export { loadContextOptions, NatsContextError } from "./context.js";
+export { loadContextOptions } from "./context.js";
 
 // Version metadata
 export {

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -2,7 +2,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadContextOptions, NatsContextError } from "../../src/context.js";
+import { loadContextOptions } from "../../src/context.js";
+import { NatsContextError } from "../../src/errors.js";
 
 describe("loadContextOptions", () => {
   let baseDir: string;


### PR DESCRIPTION
## Summary

Cuts the 0.1.1 release of \`@synadia-ai/agents\` so the new \`loadContextOptions\` helper (merged in #17) is consumable from a released npm version.

- Bump \`client-sdk/typescript/package.json\` 0.1.0 → 0.1.1.
- Add \`[0.1.1] - 2026-04-25\` CHANGELOG entry covering \`loadContextOptions\` and the \`NatsContextError\` export.

## Why a separate release PR

Examples (\`pi-headless\`, \`agent-web-ui\`) depend on \`@synadia-ai/agents@^0.1.0\` from npm rather than via \`file:\` links. Without a published 0.1.1 they can't migrate to the new helper. PR #16 (the example migration) is blocked on this landing + the npm publish.

## Verification

- \`cd client-sdk/typescript && bun run typecheck\` clean
- \`cd client-sdk/typescript && bun test test/unit/\` — 153 pass

## Post-merge steps

1. \`cd client-sdk/typescript && npm publish\` (with the @synadia-ai publish identity)
2. Update PR #16 to depend on \`^0.1.1\` and drop its now-redundant \`[Unreleased]\` CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)