### PR TITLE
client-sdk/python: reject NUL bytes in nats-context names

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -8,6 +8,17 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+### Deferred for follow-up
+
+- The 2026-04-26 TS-parity sweep deliberately deferred a handful of
+  convenience features (session-name auto-resolution, attachment
+  filesystem-staging helper) and surfaced two behavioural divergences
+  (bare-string vs JSON-wrapped response chunks, no global TTL on
+  mid-stream `ask()` queries). All catalogued in
+  [`docs/protocol-mapping.md` › Deferred TS-parity work](docs/protocol-mapping.md#deferred-ts-parity-work)
+  with rationale + a suggested next step for each, so the team can
+  pick them up in a follow-up PR.
+
 ### Added
 
 - **`Agent(keepalive_interval_s=...)` — automatic per-request keep-alive

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -8,6 +8,20 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+### Added
+
+- **`Agent(keepalive_interval_s=...)` — automatic per-request keep-alive
+  ack.** While a prompt handler is running, the agent now emits
+  `{"type":"status","data":"ack"}` (§6.4) every `keepalive_interval_s`
+  seconds, matching the behaviour every TS reference harness
+  (`agents/pi/`, `agents/claude-code/`, `agents/openclaw/`) implements
+  inline. This prevents callers using a stream inactivity timeout (the
+  TS SDK default is 60 s) from giving up on Python agents whose
+  handlers do real work between response chunks. Defaults to **30 s**;
+  pass `keepalive_interval_s=None` to disable (e.g. when the handler
+  emits its own status chunks at a finer cadence). Constructor
+  validates `> 0` or `None`. Covered by `tests/test_keepalive_e2e.py`.
+
 ### Fixed
 
 - **Reject NUL bytes in `nats` CLI context names.** `natsagent.connect(context=...)`

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -178,10 +178,12 @@ caller as a pair.
 
 ### Interop
 
-- The TypeScript SDK (`../typescript/`) is still on v0.1 at the time
-  of this release. `tests/test_interop_e2e.py` is marked `xfail` until
-  the TS SDK bumps to v0.2; a future TS v0.2 release will flip this
-  back to green (`XPASS` surfaces as a test-suite signal).
+- The TypeScript SDK (`../typescript/`) was still on v0.1 at the time
+  of this release. The test `tests/test_interop_e2e.py` `pytest.skip`s
+  cleanly when its prereqs (`bun` on PATH, sibling `../typescript/`
+  with `node_modules/`) are missing. The TS SDK has since caught up to
+  protocol `0.2`; running the suite with the prereqs in place
+  rounds-trips a prompt through the TS reference agent.
 
 ## [0.1.0] - 2026-04-21
 

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -8,6 +8,16 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reject NUL bytes in `nats` CLI context names.** `natsagent.connect(context=...)`
+  now raises `ContextInvalidError` when the resolved name contains
+  `\x00`, instead of letting it propagate into `Path` and surface as a
+  confusing `ValueError: embedded null byte`. Brings the validator into
+  full parity with the TS SDK's `loadContextOptions` path-traversal
+  guard (PR #17 on the TS side). Other separators (`/`, `\`), ``..``
+  components, and leading-dot names were already rejected.
+
 ## [0.2.0] - 2026-04-22
 
 Aligns the SDK with **NATS Agent Protocol v0.2** (draft dated

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -279,9 +279,12 @@ either guides them to success or frustrates them.
   endpoint now registered with queue group `"agents"` (§3.3);
   `metadata.protocol_version` bumps to `"0.2"`. Envelope.session
   re-labelled as §5.6-tolerated SDK convention (v0.2 §5.1 no longer
-  defines the field). TS SDK is still on v0.1 at the time of this bump
-  - `tests/test_interop_e2e.py` is xfail'd until it catches up. See
-  `CHANGELOG.md` for full migration notes.
+  defines the field). The TS SDK has since caught up to protocol
+  `0.2` (`client-sdk/typescript/src/version.ts`); the interop test
+  `tests/test_interop_e2e.py` rounds-trips a prompt through the TS
+  reference agent and `pytest.skip`s only when `bun` or the sibling
+  `../typescript/` checkout is missing. See `CHANGELOG.md` for full
+  migration notes.
 - **2026-04-21 - v0.1.0 alignment PR (`align-core-protocol-0.1`).** Full
   spec compliance: service name `SynadiaAgents`; `{agent, owner,
   protocol_version, session?}` metadata; §2.1 endpoint caps; §5.4

--- a/client-sdk/python/README.md
+++ b/client-sdk/python/README.md
@@ -7,9 +7,11 @@ typed responses.
 
 **Cross-SDK parity with the [TypeScript SDK](https://github.com/synadia-ai/synadia-agents/tree/main/client-sdk/typescript)**
 is tracked in [`tests/test_interop_e2e.py`](tests/test_interop_e2e.py).
-The TS SDK is currently still on protocol v0.1 while this release is on
-v0.2, so the interop tests are marked `xfail` until the TS side bumps
-- see [`CHANGELOG.md`](CHANGELOG.md) under `[0.2.0] › Interop`.
+Both SDKs declare `protocol_version = "0.2"` in service metadata, so the
+test spawns the TS reference agent via `bun` and rounds-trips a prompt
+through it. The test `pytest.skip`s cleanly when `bun` or the sibling
+`../typescript/` checkout is missing — running the suite without TS
+interop is fine for day-to-day work.
 
 **Agent author?** → [Quickstart - host an agent](#quickstart--host-an-agent).
 **Client / UI author?** → [Quickstart - call an agent](#quickstart--call-an-agent).

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -123,3 +123,83 @@ mirror the TypeScript SDK so the two stay in lockstep.
 1. **`max_payload` base (§2.1).** 1024 vs 1000 - spec silent. SDK uses **1024** (NATS server convention).
 2. **Size-unit case sensitivity (§2.1).** Spec silent. SDK parses **case-insensitive**.
 3. **Unparseable `max_payload` value (§2.1).** `EndpointInfo.max_payload_bytes` is `None`; raw string preserved in `metadata`. No local enforcement - the agent decides server-side.
+
+## Deferred TS-parity work
+
+Items surfaced during the 2026-04-26 TS-parity sweep that were
+intentionally **not** addressed in that round, kept here so the team
+can decide which ones land in a follow-up. Each entry says **what**
+the gap is, **why** it matters, and a hint at the **next step**.
+
+### Convenience features the TS reference harnesses ship that the Python SDK doesn't
+
+1. **Session-name auto-resolution at `Agent.start()`.**
+   PI's harness (`agents/pi/extensions/nats-channel.ts` ~lines 356-377)
+   queries `$SRV.INFO.agents` on startup, sees a name collision, and
+   auto-suffixes `-2`, `-3`, … so two PI instances under the same owner
+   don't fight over a single subject. Python `Agent(name=...)` registers
+   the name as-given; collisions are the developer's problem. Convenience,
+   not wire-compat. Next step: optional `Agent(autosuffix=True)` mirroring
+   the PI behaviour.
+
+2. **Filesystem attachment-staging helper.**
+   PI and Claude Code stage base64-decoded attachments to disk under
+   `ATTACHMENT_DIR/{requestId}` so handlers can pass file paths to
+   tools (shell-outs, MCP servers, etc.). Python keeps attachments
+   in-memory on `Envelope.attachments` and leaves staging to the
+   developer. Next step: an `Attachment.stage_to(path)` helper that
+   handles tempdir creation, RFC 4648 base64 decode, and safe filename
+   sanitisation in one call.
+
+### Behavioural divergences (both spec-valid, different shape)
+
+3. **Bare-string vs JSON-wrapped `response` chunks (§6.3).**
+   Python's `encode_chunk(ResponseChunk)` emits the bare-string
+   shorthand `{"type":"response","data":"<text>"}` when there are no
+   attachments; the TS reference harnesses always emit the wrapped
+   `{"text":...,"attachments":[]}` form even for text-only. Both are
+   valid per §6.3. Worth aligning before any cross-SDK assertion test
+   tries to compare exact wire bytes. Next step: pick one as the
+   canonical Python emit shape, document in CHANGELOG.
+
+4. **Pending-request TTL on mid-stream `ask()` queries (§7).**
+   TS harnesses prune pending request state >30 minutes old (defends
+   against memory leaks from caller-dropped queries). Python's
+   `PromptStream.ask()` pending replies are bounded by an explicit
+   `timeout=` and the surrounding handler's lifetime, so the failure
+   mode is "handler hangs forever" rather than "memory leak"; still,
+   a global ceiling parallel to TS's would be a useful belt. Next
+   step: cap `ask()` at a sensible upper bound or document that
+   handlers are responsible for setting `timeout=`.
+
+### Caller-side parity confirmed but not test-covered
+
+5. **`Agents.closeSignal` analogue.**
+   TS exposes `Agents.closeSignal: AbortSignal` for callers that
+   materialize `Agent` instances outside `discover()` (e.g. lazily
+   from a heartbeat). Python's `Client` doesn't have a parallel
+   materialization path today (everything goes through `Client.discover`
+   + `Client.bind`), so there's no observable gap yet. Next step:
+   no action until/unless a lazy-materialisation path appears; revisit
+   if so.
+
+6. **`NatsContextError` analogue.**
+   TS exposes a single `NatsContextError` class. Python already has
+   finer-grained types (`ContextNotFoundError`, `ContextNotSelectedError`,
+   `ContextInvalidError`, `ContextNotSupportedError`) - Python is
+   already more specific. No port needed; documented here for
+   completeness so a reader doesn't see "missing class" and assume a
+   gap.
+
+### Behaviour-change risks introduced by the 2026-04-26 sweep
+
+7. **Default-on 30 s keep-alive ack.**
+   `Agent` now emits a `status="ack"` chunk every 30 s during
+   long-running handlers by default (`keepalive_interval_s=30.0`).
+   This is extra wire traffic vs prior Python releases - quiet
+   handlers that comfortably fit under the TS SDK's 60 s stream
+   inactivity timeout don't need it. No spec violation (§6.4 status
+   chunks are at the agent's discretion). Pass
+   `keepalive_interval_s=None` to disable. Next step: monitor for
+   integrator complaints; consider documenting "when to disable" as
+   the SDK matures.

--- a/client-sdk/python/pyproject.toml
+++ b/client-sdk/python/pyproject.toml
@@ -43,6 +43,12 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.5",
     "mypy>=1.10",
+    # `rich` is an examples-extra runtime dep, but `tests/test_chat_commands.py`
+    # imports the chat parser out of `examples/06-chat.py`, which top-level
+    # imports rich and `sys.exit(3)`s on ImportError. Including rich in the
+    # default dev set means `uv sync` (no extras) gets a clean `pytest` run
+    # instead of 16 ERROR rows.
+    "rich>=13",
 ]
 
 [build-system]

--- a/client-sdk/python/src/natsagent/agent.py
+++ b/client-sdk/python/src/natsagent/agent.py
@@ -190,9 +190,7 @@ class Agent:
         if heartbeat_interval_s <= 0:
             raise ValueError("heartbeat_interval_s must be > 0 (heartbeat is mandatory in v0.2)")
         if keepalive_interval_s is not None and keepalive_interval_s <= 0:
-            raise ValueError(
-                "keepalive_interval_s must be > 0 or None (None disables keep-alive)"
-            )
+            raise ValueError("keepalive_interval_s must be > 0 or None (None disables keep-alive)")
         # Validate max_payload eagerly so misconfiguration fails at construction
         # rather than surfacing later via caller-side validation (§5.4).
         parse_human_bytes(max_payload)

--- a/client-sdk/python/src/natsagent/agent.py
+++ b/client-sdk/python/src/natsagent/agent.py
@@ -301,15 +301,22 @@ class Agent:
                 await handler(envelope, stream)
             except Exception as exc:
                 log.exception("prompt handler raised on %s", request.subject)
+                # Stop keep-alive BEFORE the §9 error frame so the keepalive
+                # task can't race an ack chunk in between error(500) and the
+                # §6.5 terminator emitted in the outer `finally`. Ditto in
+                # the success path right below.
+                await _stop_keepalive(keepalive_task)
+                keepalive_task = None
                 await request.respond_error("500", _sanitize_error_desc(f"handler error: {exc}"))
+            else:
+                await _stop_keepalive(keepalive_task)
+                keepalive_task = None
         finally:
-            # Stop the keep-alive *before* the terminator so we don't race an
-            # ack chunk in after the empty-body terminator the caller is
-            # already treating as end-of-stream.
-            if keepalive_task is not None:
-                keepalive_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await keepalive_task
+            # Belt-and-braces: if anything above failed before we could stop
+            # the keepalive (e.g. respond_error itself raised), don't leak the
+            # task and don't let it slip an ack past the terminator. No-op
+            # when keepalive_task is already None.
+            await _stop_keepalive(keepalive_task)
             # §6.5 + §9.3: every stream — successful or errored — ends with a
             # zero-byte body message that carries NO NATS headers. The error
             # frame emitted by `respond_error` above is NOT the terminator;
@@ -318,6 +325,20 @@ class Agent:
                 await request.respond(b"")
             except Exception:
                 log.exception("failed to emit stream terminator on %s", request.subject)
+
+
+async def _stop_keepalive(task: asyncio.Task[None] | None) -> None:
+    """Cancel and await a keep-alive task, swallowing the resulting CancelledError.
+
+    No-op when ``task`` is ``None``, so the outer ``finally`` can call this
+    unconditionally as a belt-and-braces guard after the success/error paths
+    have already cleared their own task handles.
+    """
+    if task is None:
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
 
 
 async def _keepalive_loop(request: Request, interval_s: float) -> None:

--- a/client-sdk/python/src/natsagent/agent.py
+++ b/client-sdk/python/src/natsagent/agent.py
@@ -56,6 +56,15 @@ _SDK_VERSION = "0.2.0"
 DEFAULT_MAX_PAYLOAD = "1MB"
 DEFAULT_ATTACHMENTS_OK = True
 
+# §6.4: callers may wire a stream-inactivity timeout — the TS SDK defaults to
+# 60 s — so an agent that goes quiet for too long looks dead even if its
+# handler is still working. To avoid that, every TS reference harness
+# (`agents/pi/`, `agents/claude-code/`, `agents/openclaw/`) emits
+# `{type:"status",data:"ack"}` periodically while a request is in flight. We
+# match that behaviour by default; agent authors who don't want it pass
+# `keepalive_interval_s=None`.
+DEFAULT_KEEPALIVE_INTERVAL_S: float = 30.0
+
 
 class PromptStream:
     """Handle given to a prompt handler for emitting response chunks.
@@ -154,6 +163,14 @@ class Agent:
     carried in both service metadata (§3.2) and the heartbeat payload
     (§8.3) when set; session-aware harnesses (``claude-code``, ``pi``,
     ``hermes``) MUST supply it.
+
+    ``keepalive_interval_s`` controls per-request keep-alive: while a
+    handler is running, the agent emits ``{"type":"status","data":"ack"}``
+    every ``keepalive_interval_s`` seconds so callers using a stream
+    inactivity timeout (the TS SDK default is 60 s) don't fire on slow
+    handlers. Defaults to 30 s, matching the TS reference harnesses.
+    Pass ``None`` to disable — for example when the handler emits its
+    own status chunks at a finer cadence.
     """
 
     def __init__(
@@ -168,9 +185,14 @@ class Agent:
         max_payload: str = DEFAULT_MAX_PAYLOAD,
         attachments_ok: bool = DEFAULT_ATTACHMENTS_OK,
         session: str | None = None,
+        keepalive_interval_s: float | None = DEFAULT_KEEPALIVE_INTERVAL_S,
     ) -> None:
         if heartbeat_interval_s <= 0:
             raise ValueError("heartbeat_interval_s must be > 0 (heartbeat is mandatory in v0.2)")
+        if keepalive_interval_s is not None and keepalive_interval_s <= 0:
+            raise ValueError(
+                "keepalive_interval_s must be > 0 or None (None disables keep-alive)"
+            )
         # Validate max_payload eagerly so misconfiguration fails at construction
         # rather than surfacing later via caller-side validation (§5.4).
         parse_human_bytes(max_payload)
@@ -181,6 +203,7 @@ class Agent:
         self._heartbeat_interval_s = heartbeat_interval_s
         self._max_payload = max_payload
         self._attachments_ok = attachments_ok
+        self._keepalive_interval_s = keepalive_interval_s
         self._prompt_handler: PromptHandler | None = None
         self._service: Service | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
@@ -257,6 +280,7 @@ class Agent:
         log.info("agent stopped on %s", self.subject.inbox)
 
     async def _on_prompt_request(self, request: Request) -> None:
+        keepalive_task: asyncio.Task[None] | None = None
         try:
             try:
                 envelope = decode(request.data)
@@ -269,12 +293,25 @@ class Agent:
             handler = self._prompt_handler
             assert handler is not None  # enforced in start()
 
+            if self._keepalive_interval_s is not None:
+                keepalive_task = asyncio.create_task(
+                    _keepalive_loop(request, self._keepalive_interval_s),
+                    name=f"keepalive-{request.subject}",
+                )
+
             try:
                 await handler(envelope, stream)
             except Exception as exc:
                 log.exception("prompt handler raised on %s", request.subject)
                 await request.respond_error("500", _sanitize_error_desc(f"handler error: {exc}"))
         finally:
+            # Stop the keep-alive *before* the terminator so we don't race an
+            # ack chunk in after the empty-body terminator the caller is
+            # already treating as end-of-stream.
+            if keepalive_task is not None:
+                keepalive_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await keepalive_task
             # §6.5 + §9.3: every stream — successful or errored — ends with a
             # zero-byte body message that carries NO NATS headers. The error
             # frame emitted by `respond_error` above is NOT the terminator;
@@ -283,6 +320,26 @@ class Agent:
                 await request.respond(b"")
             except Exception:
                 log.exception("failed to emit stream terminator on %s", request.subject)
+
+
+async def _keepalive_loop(request: Request, interval_s: float) -> None:
+    """Emit a `status="ack"` chunk every `interval_s` seconds until cancelled.
+
+    Runs as a sibling task to the user's prompt handler; cancelled by
+    :meth:`Agent._on_prompt_request` once the handler returns or raises, so
+    the ack stream never extends past the §6.5 terminator.
+    """
+    payload = encode_chunk(StatusChunk(status="ack"))
+    while True:
+        await asyncio.sleep(interval_s)
+        try:
+            await request.respond(payload)
+        except Exception:
+            # An emit failure (broker dropped, request reply already torn down,
+            # etc.) is best-effort — log and stop. The terminator path will
+            # fail loudly enough on its own if the request is truly dead.
+            log.exception("keepalive emit failed on %s", request.subject)
+            return
 
 
 # NATS message headers are single-line (CR/LF delimited in the wire format),

--- a/client-sdk/python/src/natsagent/connect.py
+++ b/client-sdk/python/src/natsagent/connect.py
@@ -196,10 +196,14 @@ def _assert_valid_context_name(name: str) -> None:
 
     The `nats` CLI only produces names matching ``^[a-zA-Z0-9._-]+$``; we
     tolerate the same plus a little slack for forward compat, but always
-    reject separators, ``..``, and leading ``.``.
+    reject separators, ``..``, leading ``.``, and embedded NUL bytes (which
+    would otherwise crash deep in ``Path``-land with a confusing
+    ``ValueError``).
     """
     if not isinstance(name, str) or not name:
         raise ContextInvalidError(name or "", "context name must be a non-empty string")
+    if "\x00" in name:
+        raise ContextInvalidError(name, f"context name {name!r} contains a NUL byte")
     if "/" in name or "\\" in name or name == ".." or ".." in name.replace("\\", "/").split("/"):
         raise ContextInvalidError(name, f"context name {name!r} contains illegal characters")
     if name.startswith("."):

--- a/client-sdk/python/tests/test_connect_context.py
+++ b/client-sdk/python/tests/test_connect_context.py
@@ -113,7 +113,17 @@ def test_load_context_malformed_json_raises(
 
 @pytest.mark.parametrize(
     "bad_name",
-    ["", "..", "../escape", "a/b", "a\\b", ".hidden"],
+    [
+        "",
+        "..",
+        "../escape",
+        "a/b",
+        "a\\b",
+        ".hidden",
+        "a\x00b",
+        "\x00",
+        "ok\x00..",
+    ],
 )
 def test_context_name_validation(bad_name: str) -> None:
     with pytest.raises(ContextInvalidError):

--- a/client-sdk/python/tests/test_connect_context.py
+++ b/client-sdk/python/tests/test_connect_context.py
@@ -331,6 +331,45 @@ async def test_connect_nats_kwargs_merge_over_context(
     assert captured["kwargs"]["token"] == "override-token"
 
 
+async def test_connect_user_jwt_only_context_produces_authenticated_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `user_jwt`-only context wires `user_jwt_cb` into nats-py kwargs.
+
+    Regression guard against the TS SDK's PR #10 bug, where the example
+    context loaders silently dropped ``user_jwt`` and produced an
+    unauthenticated connection that failed deep in the broker handshake
+    with no useful error. This exercises the full public path:
+    ``connect(context=...)`` → ``_load_context`` → ``_build_connection_kwargs``
+    → ``nats.connect(**kwargs)``, asserting the JWT callback survives the
+    trip and that no fallback auth-fields sneak in.
+    """
+    base = _point_env_at(tmp_path, monkeypatch)
+    _write_context(
+        base,
+        "jwt-only",
+        {"url": "nats://127.0.0.1:4222", "user_jwt": "ey.header.payload"},
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def fake_connect(servers: Any, **kwargs: Any) -> Any:
+        captured["servers"] = servers
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(connect_module.nats, "connect", fake_connect)
+    await natsagent.connect(context="jwt-only")
+
+    kw = captured["kwargs"]
+    assert "user_jwt_cb" in kw, "JWT-only context must wire user_jwt_cb into nats kwargs"
+    assert callable(kw["user_jwt_cb"])
+    assert kw["user_jwt_cb"]() == b"ey.header.payload"
+    # Belt-and-braces: nothing else slid in to silently change the auth shape.
+    for k in ("user_credentials", "token", "user", "password"):
+        assert k not in kw, f"unexpected fallback auth field {k!r} in {kw!r}"
+
+
 async def test_connect_current_honours_env_over_selection_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/client-sdk/python/tests/test_keepalive_e2e.py
+++ b/client-sdk/python/tests/test_keepalive_e2e.py
@@ -1,0 +1,205 @@
+"""End-to-end tests for per-request keep-alive ack emission.
+
+Regression-guards the §6.4 keep-alive behaviour the TS reference harnesses
+implement (`agents/pi/`, `agents/claude-code/`, `agents/openclaw/`):
+while a handler is running, the agent emits ``{"type":"status","data":"ack"}``
+every ``keepalive_interval_s`` so callers using a stream inactivity timeout
+don't fire on slow handlers.
+
+Three integration scenarios:
+
+* **default-on, slow handler** — at least one ack appears in the streamed
+  chunks.
+* **disabled, slow handler** — no ack, even when the handler runs longer
+  than the (non-)interval.
+* **default-on, fast handler** — no ack (the loop's first emit is ``after``
+  the first ``asyncio.sleep``, so a sub-interval handler never trips it).
+
+Plus a unit test guarding the constructor's input validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from natsagent import (
+    Agent,
+    Client,
+    Envelope,
+    PromptStream,
+    ResponseChunk,
+    StatusChunk,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+
+    from tests.harness.evidence import EvidenceRecorder
+
+
+AGENT = "test"
+OWNER = "pytest"
+
+
+def _make_slow_handler(duration_s: float) -> object:
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        del envelope
+        await asyncio.sleep(duration_s)
+        await stream.send("done")
+
+    return handler
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -0.1])
+def test_constructor_rejects_non_positive_keepalive(bad_value: float) -> None:
+    """`keepalive_interval_s` must be > 0 or ``None``; zero/negative is a config bug."""
+    # Pass a sentinel for ``nc`` — construction-time validation runs before
+    # any I/O, so the live client fixture isn't needed here.
+    with pytest.raises(ValueError, match="keepalive_interval_s"):
+        Agent(
+            agent=AGENT,
+            owner=OWNER,
+            name="cfg",
+            nc=object(),  # type: ignore[arg-type]
+            keepalive_interval_s=bad_value,
+        )
+
+
+@pytest.mark.asyncio
+async def test_keepalive_emits_ack_during_slow_handler(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """A handler that runs longer than the interval triggers ≥1 ack chunk."""
+    interval = 0.1
+    handler_duration = 0.45  # ~4 intervals — comfortably more than one tick
+
+    agent = Agent(
+        agent=AGENT,
+        owner=OWNER,
+        name="slow-default",
+        nc=nc,
+        keepalive_interval_s=interval,
+    )
+    agent.on_prompt(_make_slow_handler(handler_duration))  # type: ignore[arg-type]
+    await agent.start()
+
+    try:
+        client = Client(nc=nc)
+        await client.start()
+        try:
+            found = await client.discover(timeout=1.0)
+            discovered = next(d for d in found if d.inbox == agent.subject.inbox)
+            remote = client.bind(discovered)
+
+            received: list[ResponseChunk | StatusChunk] = []
+            async for msg in remote.prompt("hi", timeout=5.0):
+                assert isinstance(msg, ResponseChunk | StatusChunk), (
+                    f"unexpected chunk type: {type(msg).__name__}"
+                )
+                received.append(msg)
+        finally:
+            await client.stop()
+
+        evidence.write_jsonl(
+            "chunks.jsonl",
+            [json.loads(chunk.model_dump_json()) for chunk in received],
+        )
+
+        acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
+        responses = [c for c in received if isinstance(c, ResponseChunk)]
+        assert len(acks) >= 1, f"expected ≥1 keep-alive ack, saw chunks: {received!r}"
+        assert any(r.text == "done" for r in responses), (
+            f"expected the handler's final 'done' response, saw: {received!r}"
+        )
+    finally:
+        await agent.stop()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_disabled_emits_no_ack(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """`keepalive_interval_s=None` suppresses keep-alive even on slow handlers."""
+    handler_duration = 0.3
+
+    agent = Agent(
+        agent=AGENT,
+        owner=OWNER,
+        name="slow-disabled",
+        nc=nc,
+        keepalive_interval_s=None,
+    )
+    agent.on_prompt(_make_slow_handler(handler_duration))  # type: ignore[arg-type]
+    await agent.start()
+
+    try:
+        client = Client(nc=nc)
+        await client.start()
+        try:
+            found = await client.discover(timeout=1.0)
+            discovered = next(d for d in found if d.inbox == agent.subject.inbox)
+            remote = client.bind(discovered)
+
+            received: list[ResponseChunk | StatusChunk] = []
+            async for msg in remote.prompt("hi", timeout=5.0):
+                assert isinstance(msg, ResponseChunk | StatusChunk), (
+                    f"unexpected chunk type: {type(msg).__name__}"
+                )
+                received.append(msg)
+        finally:
+            await client.stop()
+
+        evidence.write_jsonl(
+            "chunks.jsonl",
+            [json.loads(chunk.model_dump_json()) for chunk in received],
+        )
+        acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
+        assert acks == [], f"expected no keep-alive acks when disabled, got: {acks!r}"
+    finally:
+        await agent.stop()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_skips_ack_for_fast_handler(
+    nc: NATSClient,
+) -> None:
+    """A handler that completes within one interval never trips the keep-alive."""
+    interval = 1.0  # well above the handler's duration
+
+    async def fast_handler(envelope: Envelope, stream: PromptStream) -> None:
+        del envelope
+        await stream.send("instant")
+
+    agent = Agent(
+        agent=AGENT,
+        owner=OWNER,
+        name="fast",
+        nc=nc,
+        keepalive_interval_s=interval,
+    )
+    agent.on_prompt(fast_handler)
+    await agent.start()
+
+    try:
+        client = Client(nc=nc)
+        await client.start()
+        try:
+            found = await client.discover(timeout=1.0)
+            discovered = next(d for d in found if d.inbox == agent.subject.inbox)
+            remote = client.bind(discovered)
+
+            received: list[ResponseChunk | StatusChunk] = []
+            async for msg in remote.prompt("hi", timeout=5.0):
+                assert isinstance(msg, ResponseChunk | StatusChunk)
+                received.append(msg)
+        finally:
+            await client.stop()
+
+        acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
+        assert acks == [], f"fast handler must not emit any keep-alive acks, got: {acks!r}"
+    finally:
+        await agent.stop()

--- a/client-sdk/python/tests/test_keepalive_e2e.py
+++ b/client-sdk/python/tests/test_keepalive_e2e.py
@@ -30,6 +30,7 @@ from natsagent import (
     Agent,
     Client,
     Envelope,
+    PromptHandler,
     PromptStream,
     ResponseChunk,
     StatusChunk,
@@ -45,7 +46,7 @@ AGENT = "test"
 OWNER = "pytest"
 
 
-def _make_slow_handler(duration_s: float) -> object:
+def _make_slow_handler(duration_s: float) -> PromptHandler:
     async def handler(envelope: Envelope, stream: PromptStream) -> None:
         del envelope
         await asyncio.sleep(duration_s)
@@ -84,7 +85,7 @@ async def test_keepalive_emits_ack_during_slow_handler(
         nc=nc,
         keepalive_interval_s=interval,
     )
-    agent.on_prompt(_make_slow_handler(handler_duration))  # type: ignore[arg-type]
+    agent.on_prompt(_make_slow_handler(handler_duration))
     await agent.start()
 
     try:
@@ -131,7 +132,7 @@ async def test_keepalive_disabled_emits_no_ack(nc: NATSClient, evidence: Evidenc
         nc=nc,
         keepalive_interval_s=None,
     )
-    agent.on_prompt(_make_slow_handler(handler_duration))  # type: ignore[arg-type]
+    agent.on_prompt(_make_slow_handler(handler_duration))
     await agent.start()
 
     try:
@@ -159,6 +160,92 @@ async def test_keepalive_disabled_emits_no_ack(nc: NATSClient, evidence: Evidenc
         assert acks == [], f"expected no keep-alive acks when disabled, got: {acks!r}"
     finally:
         await agent.stop()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_no_ack_between_error_frame_and_terminator(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """Regression-guard: ack chunks MUST NOT slip between error(500) and the §6.5 terminator.
+
+    PR #20 reviewer surfaced a race: when the handler raises,
+    ``await request.respond_error(...)`` yields to the event loop. If the
+    keep-alive timer fires during that yield, the caller would observe
+    ``error(500) → ack → terminator`` instead of ``error(500) → terminator``.
+    Spec-compliant (terminator is still last) but undesirable. The fix
+    cancels keep-alive *before* calling ``respond_error``; this test
+    asserts that on the wire by subscribing to the reply inbox directly
+    rather than going through ``Client._stream_prompt`` (which raises on
+    the error frame and so can't observe what comes after).
+    """
+    interval = 0.05  # very short, so multiple ticks fire during the handler
+    handler_duration = 0.25  # ~5 intervals of opportunity to race
+
+    async def raising_handler(envelope: Envelope, stream: PromptStream) -> None:
+        del envelope, stream
+        await asyncio.sleep(handler_duration)
+        raise RuntimeError("intentional")
+
+    agent = Agent(
+        agent=AGENT,
+        owner=OWNER,
+        name="raises",
+        nc=nc,
+        keepalive_interval_s=interval,
+    )
+    agent.on_prompt(raising_handler)
+    await agent.start()
+
+    try:
+        # Subscribe to a fresh inbox before publishing so we don't miss any frames.
+        reply_inbox = nc.new_inbox()
+        sub = await nc.subscribe(reply_inbox)
+        try:
+            # The agent's prompt endpoint expects an envelope; a bare-string
+            # request is promoted to {"prompt": "..."} per §5.3.
+            await nc.publish(agent.subject.inbox, b"hi", reply=reply_inbox)
+
+            # Drain frames until we see the empty-body, headerless §6.5 terminator.
+            frames: list[tuple[bytes, dict[str, str]]] = []
+            deadline = asyncio.get_event_loop().time() + 5.0
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    msg = await sub.next_msg(timeout=1.0)
+                except TimeoutError:
+                    pytest.fail(f"no terminator within deadline; frames: {frames!r}")
+                headers = dict(msg.headers or {})
+                frames.append((msg.data, headers))
+                # §6.5 terminator: empty body, NO headers.
+                if msg.data == b"" and not headers:
+                    break
+            else:
+                pytest.fail(f"loop exited without terminator; frames: {frames!r}")
+        finally:
+            await sub.unsubscribe()
+    finally:
+        await agent.stop()
+
+    evidence.write_jsonl(
+        "frames.jsonl",
+        [
+            {"data": data.decode("utf-8", errors="replace"), "headers": headers}
+            for data, headers in frames
+        ],
+    )
+
+    # Find the index of the error frame and the terminator.
+    error_idx = next(i for i, (_, h) in enumerate(frames) if "Nats-Service-Error-Code" in h)
+    terminator_idx = len(frames) - 1
+    assert frames[terminator_idx] == (b"", {}), (
+        f"last frame must be the §6.5 terminator, got: {frames[terminator_idx]!r}"
+    )
+    # Every frame strictly between error and terminator must be empty (the
+    # spec doesn't define what could legitimately go there; the keep-alive
+    # ack is what we're guarding against).
+    between = frames[error_idx + 1 : terminator_idx]
+    assert between == [], (
+        f"no frames may appear between error(500) and the §6.5 terminator; saw: {between!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/client-sdk/python/tests/test_keepalive_e2e.py
+++ b/client-sdk/python/tests/test_keepalive_e2e.py
@@ -120,9 +120,7 @@ async def test_keepalive_emits_ack_during_slow_handler(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_disabled_emits_no_ack(
-    nc: NATSClient, evidence: EvidenceRecorder
-) -> None:
+async def test_keepalive_disabled_emits_no_ack(nc: NATSClient, evidence: EvidenceRecorder) -> None:
     """`keepalive_interval_s=None` suppresses keep-alive even on slow handlers."""
     handler_duration = 0.3
 

--- a/client-sdk/python/uv.lock
+++ b/client-sdk/python/uv.lock
@@ -210,6 +210,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 
@@ -226,6 +227,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff", specifier = ">=0.5" },
 ]
 


### PR DESCRIPTION
Brings the context-name validator into parity with the TS SDK's
loadContextOptions path-traversal guard (PR #17 on the TS side).
Without this, a name containing \x00 fell through to Path() and
surfaced as a ValueError("embedded null byte") deep in the I/O
stack instead of a friendly ContextInvalidError up front.

The other separators ("/", "\\"), ".." components, and leading-dot
names were already rejected; this closes the last gap.