### PR TITLE
examples: add claude-code-headless + agent-web-ui CC Exec view

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -228,6 +228,16 @@ NATS server authentication and authorization handle access control. If a
 user can connect and publish to `agents.cc.<user>.<name>`, they can
 interact with Claude. No additional pairing or allowlist is needed.
 
+## Anthropic auth
+
+Set `ANTHROPIC_API_KEY` in your environment before launching `claude`.
+Claude Code uses the env var in preference to any `~/.claude/`
+credentials, so logging out is unnecessary.
+
+Bedrock / Vertex / Azure deployments work too — set the standard
+provider env vars before launching `claude` and Claude Code will use
+those instead.
+
 ## Configuration
 
 State lives in `~/.claude/channels/nats/`:

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -2,8 +2,9 @@
 
 A Bun + Vue 3 test client for the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK.
 Discover agents over NATS, prompt them (with optional attachments),
-stream responses back, and — when a [`pi-headless`](../pi-headless) controller
-is online — spawn, prompt, and fan out PI sessions from the browser.
+stream responses back, and — when a [`pi-headless`](../pi-headless) or
+[`claude-code-headless`](../claude-code-headless) controller is online — spawn,
+prompt, and manage sessions from the browser.
 
 Primary use: manually poking at the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs)
 implementations - [`pi`](../../agents/pi), [`claude-code`](../../agents/claude-code),
@@ -12,10 +13,12 @@ implementations - [`pi`](../../agents/pi), [`claude-code`](../../agents/claude-c
 
 ## Features
 
-- **Chat mode** — default view. Live agent list + per-agent chat surface with streaming responses, attachments, and mid-stream query replies.
+- **Chat mode** — default view. Live agent list + per-agent chat surface with streaming responses, attachments, mid-stream query replies, tool-call cards, and per-turn cost annotations.
 - **PI Exec mode** — appears in the header as soon as a `pi-headless` controller is discovered. Spawn PI sessions (cwd, model, thinking level, max lifetime), prompt them, and fan out one prompt across N working directories in parallel.
+- **CC Exec mode** — appears in the header as soon as a `claude-code-headless` controller is discovered. Spawn Claude Code sessions (cwd, model, allowed tools, permission mode, max turns, max lifetime), watch tool calls + results render inline as collapsible cards, approve/deny permission requests with a single click, see per-turn and cumulative cost on every bubble.
 - **Auto-discovery** — new agents appear in the list as soon as they publish their first heartbeat. `ReferenceAgent` fires that synchronously on `start()`, so a fresh session shows up in ~one NATS round-trip — no need to hit Refresh after spawning.
-- **Mid-stream queries** — agents can pause a response to ask a permission or clarification question; the UI renders these inline with shortcut allow/deny buttons and a free-text reply box.
+- **Mid-stream queries** — agents can pause a response to ask a permission or clarification question; the UI renders these inline with shortcut allow/deny buttons and a free-text reply box. Both PI tooling prompts and Claude Code permission requests use this same primitive.
+- **Tool call rendering** — `tool_use` / `tool_result` chunks (emitted by claude-code-headless as prefix-tagged status payloads) are translated by the bridge into typed events and rendered as collapsible cards showing tool name, input JSON, and result output (with success/error glyph).
 - **Local validation** — oversized envelopes and unsupported attachments are caught before any wire traffic, with the SDK's typed errors surfaced in the UI.
 
 ## Shape

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -22,6 +22,8 @@ import {
 } from "@synadia-ai/agents";
 import type { Subscription } from "@nats-io/nats-core";
 import type {
+  CcExecSessionSummary,
+  CcExecSpawnDescriptor,
   ClientMessage,
   DiscoveredAgentDTO,
   PiExecSessionSummary,
@@ -89,6 +91,15 @@ export class Bridge {
         break;
       case "piexec-list":
         void this.handlePiExecList(msg.id, msg.controllerInstanceId);
+        break;
+      case "ccexec-spawn":
+        void this.handleCcExecSpawn(msg.id, msg.controllerInstanceId, msg.spec);
+        break;
+      case "ccexec-stop":
+        void this.handleCcExecStop(msg.id, msg.controllerInstanceId, msg.sessionId);
+        break;
+      case "ccexec-list":
+        void this.handleCcExecList(msg.id, msg.controllerInstanceId);
         break;
       default: {
         const anyMsg = msg as { kind?: string };
@@ -360,25 +371,141 @@ export class Bridge {
     id: string,
     controllerInstanceId: string,
     endpoint: "spawn" | "stop" | "list",
+    role: string = "pi-headless-controller",
+    label: string = "pi-headless",
   ): string | null {
     const agent = this.agentsByInstanceId.get(controllerInstanceId);
     if (!agent) {
       this.sendError(
         id,
         "agent_not_found",
-        `no pi-headless controller with instance id ${controllerInstanceId} in last discovery result — click Refresh`,
+        `no ${label} controller with instance id ${controllerInstanceId} in last discovery result — click Refresh`,
       );
       return null;
     }
-    if (agent.metadata["role"] !== "pi-headless-controller") {
+    if (agent.metadata["role"] !== role) {
       this.sendError(
         id,
         "not_a_controller",
-        `instance ${controllerInstanceId} is not a pi-headless controller`,
+        `instance ${controllerInstanceId} is not a ${label} controller`,
       );
       return null;
     }
     return `${agent.promptEndpoint.subject}.${endpoint}`;
+  }
+
+  // ─── claude-code-headless control plane ───────────────────────────────────
+
+  private async handleCcExecSpawn(
+    id: string,
+    controllerInstanceId: string,
+    spec: unknown,
+  ): Promise<void> {
+    const subject = this.resolveControllerSubject(
+      id,
+      controllerInstanceId,
+      "spawn",
+      "claude-code-headless-controller",
+      "claude-code-headless",
+    );
+    if (!subject) return;
+    try {
+      const rep = await this.nc.request(subject, JSON.stringify(spec ?? {}), { timeout: 15_000 });
+      const errHeader = rep.headers?.get("Nats-Service-Error-Code");
+      if (errHeader) {
+        this.sendError(
+          id,
+          errHeader,
+          rep.headers?.get("Nats-Service-Error") ?? "spawn error",
+        );
+        return;
+      }
+      const descriptor = JSON.parse(rep.string()) as CcExecSpawnDescriptor;
+      await this.ensureAgentKnown(descriptor.instance_id);
+      this.send({ kind: "ccexec-spawned", id, descriptor });
+    } catch (err) {
+      this.sendError(id, "ccexec_spawn_failed", (err as Error).message);
+    }
+  }
+
+  private async handleCcExecStop(
+    id: string,
+    controllerInstanceId: string,
+    sessionId: string,
+  ): Promise<void> {
+    const subject = this.resolveControllerSubject(
+      id,
+      controllerInstanceId,
+      "stop",
+      "claude-code-headless-controller",
+      "claude-code-headless",
+    );
+    if (!subject) return;
+    try {
+      const rep = await this.nc.request(
+        subject,
+        JSON.stringify({ session_id: sessionId }),
+        { timeout: 10_000 },
+      );
+      const errHeader = rep.headers?.get("Nats-Service-Error-Code");
+      if (errHeader) {
+        this.sendError(
+          id,
+          errHeader,
+          rep.headers?.get("Nats-Service-Error") ?? "stop error",
+        );
+        return;
+      }
+      // Drop the stopped session from this bridge's agent map + UI eagerly.
+      // The session_id equals the 4th-token `name` of a claude-code-headless session.
+      for (const [instanceId, agent] of this.agentsByInstanceId) {
+        if (
+          agent.metadata["spawner"] === "claude-code-headless" &&
+          agent.name === sessionId
+        ) {
+          this.forgetAgent(instanceId);
+          break;
+        }
+      }
+      this.send({ kind: "ccexec-stopped", id, sessionId });
+    } catch (err) {
+      this.sendError(id, "ccexec_stop_failed", (err as Error).message);
+    }
+  }
+
+  private async handleCcExecList(
+    id: string,
+    controllerInstanceId: string,
+  ): Promise<void> {
+    const subject = this.resolveControllerSubject(
+      id,
+      controllerInstanceId,
+      "list",
+      "claude-code-headless-controller",
+      "claude-code-headless",
+    );
+    if (!subject) return;
+    try {
+      const rep = await this.nc.request(subject, "", { timeout: 10_000 });
+      const errHeader = rep.headers?.get("Nats-Service-Error-Code");
+      if (errHeader) {
+        this.sendError(
+          id,
+          errHeader,
+          rep.headers?.get("Nats-Service-Error") ?? "list error",
+        );
+        return;
+      }
+      const body = JSON.parse(rep.string()) as { sessions: CcExecSessionSummary[] };
+      this.send({
+        kind: "ccexec-listed",
+        id,
+        controllerInstanceId,
+        sessions: body.sessions ?? [],
+      });
+    } catch (err) {
+      this.sendError(id, "ccexec_list_failed", (err as Error).message);
+    }
   }
 
   // ─── Auto-discovery via heartbeat wildcard ────────────────────────────────

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -209,9 +209,20 @@ export class Bridge {
               })),
             });
             break;
-          case "status":
-            this.send({ kind: "status", id: msg.id, status: ev.status });
+          case "status": {
+            // Inspect for our prefixed observability tokens before falling
+            // through to the generic status path. The agent encodes tool
+            // calls / results / cost as `<kind>:<json>` status strings so the
+            // wire stays §6.4-compliant; here we translate them into typed
+            // server messages the UI can render richly.
+            const structured = parseStructuredStatus(msg.id, ev.status);
+            if (structured) {
+              this.send(structured);
+            } else {
+              this.send({ kind: "status", id: msg.id, status: ev.status });
+            }
             break;
+          }
           case "query": {
             const key = queryKey(msg.id, ev.id);
             this.activeQueries.set(key, ev);
@@ -675,6 +686,64 @@ export class Bridge {
 
 function queryKey(promptId: string, queryId: string): string {
   return `${promptId}:${queryId}`;
+}
+
+/**
+ * Translate a `<prefix>:<json>` status payload into a typed server message.
+ * Returns null if the status doesn't match a known observability prefix —
+ * caller falls back to the generic `status` send.
+ */
+function parseStructuredStatus(promptId: string, status: string): ServerMessage | null {
+  const colonAt = status.indexOf(":");
+  if (colonAt < 0) return null;
+  const prefix = status.slice(0, colonAt);
+  const rest = status.slice(colonAt + 1);
+  switch (prefix) {
+    case "tool_use": {
+      const parsed = safeParse<{ id?: string; name?: string; input?: Record<string, unknown> }>(rest);
+      if (!parsed || typeof parsed.id !== "string" || typeof parsed.name !== "string") return null;
+      return {
+        kind: "tool-use",
+        id: promptId,
+        toolUseId: parsed.id,
+        toolName: parsed.name,
+        input: parsed.input ?? {},
+      };
+    }
+    case "tool_result": {
+      const parsed = safeParse<{ tool_use_id?: string; output?: string; is_error?: boolean }>(rest);
+      if (!parsed || typeof parsed.tool_use_id !== "string") return null;
+      return {
+        kind: "tool-result",
+        id: promptId,
+        toolUseId: parsed.tool_use_id,
+        output: typeof parsed.output === "string" ? parsed.output : "",
+        isError: parsed.is_error === true,
+      };
+    }
+    case "cost": {
+      const parsed = safeParse<{ turn_cost_usd?: number; total_cost_usd?: number }>(rest);
+      if (!parsed) return null;
+      return {
+        kind: "cost",
+        id: promptId,
+        turnCostUsd: typeof parsed.turn_cost_usd === "number" ? parsed.turn_cost_usd : 0,
+        totalCostUsd: typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : 0,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function safeParse<T>(text: string): T | null {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object") return parsed as T;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function toDTO(a: Agent): DiscoveredAgentDTO {

--- a/examples/agent-web-ui/server/wire.ts
+++ b/examples/agent-web-ui/server/wire.ts
@@ -70,6 +70,52 @@ export type PiExecSpawnDescriptor = {
   instance_id: string;
 };
 
+/** Summary of a claude-code-headless session as returned by the controller's `list` endpoint. */
+export type CcExecSessionSummary = {
+  session_id: string;
+  subject: string;
+  heartbeat_subject: string;
+  cwd: string;
+  model: string;
+  allowed_tools: string[];
+  permission_mode: string;
+  max_turns: number;
+  max_lifetime_s: number;
+  remaining_lifetime_s: number;
+  active_request: boolean;
+  queued_requests: number;
+  created_at: string;
+  last_activity: string;
+  /** SDK session id, populated after the first turn finishes (used for resume). */
+  sdk_session_id?: string;
+};
+
+/** Spec for spawning a claude-code-headless session; mirrors the `spawn` wire. */
+export type CcExecSpawnSpec = {
+  cwd: string;
+  session_id?: string;
+  model?: string;
+  allowed_tools?: string[];
+  permission_mode?: string;
+  max_turns?: number;
+  max_lifetime_s?: number;
+};
+
+/** Descriptor returned by a successful claude-code-headless `spawn`. */
+export type CcExecSpawnDescriptor = {
+  session_id: string;
+  subject: string;
+  heartbeat_subject: string;
+  cwd: string;
+  model: string;
+  allowed_tools: string[];
+  permission_mode: string;
+  max_turns: number;
+  max_lifetime_s: number;
+  created_at: string;
+  instance_id: string;
+};
+
 // ─── Client → Server ─────────────────────────────────────────────────────────
 
 export type ClientMessage =
@@ -97,6 +143,23 @@ export type ClientMessage =
     }
   | {
       kind: "piexec-list";
+      id: string;
+      controllerInstanceId: string;
+    }
+  | {
+      kind: "ccexec-spawn";
+      id: string;
+      controllerInstanceId: string;
+      spec: CcExecSpawnSpec;
+    }
+  | {
+      kind: "ccexec-stop";
+      id: string;
+      controllerInstanceId: string;
+      sessionId: string;
+    }
+  | {
+      kind: "ccexec-list";
       id: string;
       controllerInstanceId: string;
     };
@@ -163,7 +226,23 @@ export type ServerMessage =
       agent: DiscoveredAgentDTO;
     }
   | {
-      /** Pushed when an agent is removed (e.g. stopped via pi-headless). */
+      /** Pushed when an agent is removed (e.g. stopped via pi-headless or claude-code-headless). */
       kind: "agent-removed";
       instanceId: string;
+    }
+  | {
+      kind: "ccexec-spawned";
+      id: string;
+      descriptor: CcExecSpawnDescriptor;
+    }
+  | {
+      kind: "ccexec-stopped";
+      id: string;
+      sessionId: string;
+    }
+  | {
+      kind: "ccexec-listed";
+      id: string;
+      controllerInstanceId: string;
+      sessions: CcExecSessionSummary[];
     };

--- a/examples/agent-web-ui/server/wire.ts
+++ b/examples/agent-web-ui/server/wire.ts
@@ -88,6 +88,10 @@ export type CcExecSessionSummary = {
   last_activity: string;
   /** SDK session id, populated after the first turn finishes (used for resume). */
   sdk_session_id?: string;
+  /** Cumulative USD cost across all completed turns. */
+  total_cost_usd: number;
+  /** Number of completed turns. */
+  turn_count: number;
 };
 
 /** Spec for spawning a claude-code-headless session; mirrors the `spawn` wire. */
@@ -114,6 +118,8 @@ export type CcExecSpawnDescriptor = {
   max_lifetime_s: number;
   created_at: string;
   instance_id: string;
+  total_cost_usd: number;
+  turn_count: number;
 };
 
 // ─── Client → Server ─────────────────────────────────────────────────────────
@@ -186,6 +192,29 @@ export type ServerMessage =
       queryId: string;
       prompt: string;
       attachments?: WireAttachment[];
+    }
+  | {
+      /** A tool call started (Claude Code etc.). The same toolUseId will appear in a later tool-result. */
+      kind: "tool-use";
+      id: string;
+      toolUseId: string;
+      toolName: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      /** A previously-emitted tool call's result. */
+      kind: "tool-result";
+      id: string;
+      toolUseId: string;
+      output: string;
+      isError: boolean;
+    }
+  | {
+      /** Per-turn + cumulative cost, emitted when a turn completes. */
+      kind: "cost";
+      id: string;
+      turnCostUsd: number;
+      totalCostUsd: number;
     }
   | { kind: "done"; id: string }
   | {

--- a/examples/agent-web-ui/src/App.vue
+++ b/examples/agent-web-ui/src/App.vue
@@ -21,6 +21,7 @@ import {
   type Message,
 } from "./stores/chat.ts";
 import { fileToAttachment, useBridge } from "./composables/useBridge.ts";
+import { randomUUID } from "./uuid.ts";
 
 type ViewMode = "chat" | "piexec" | "ccexec";
 const STORAGE_KEY = "testui:view-mode";
@@ -112,7 +113,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
   }
 
   const userMsg = appendMessage(agent.instanceId, {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     role: "user",
     content: text,
     streaming: false,
@@ -122,7 +123,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
     userMsg.attachments = attachments.map((a) => ({ filename: a.filename, base64: a.base64 }));
   }
 
-  let currentAgentMsgId = crypto.randomUUID();
+  let currentAgentMsgId = randomUUID();
   appendMessage(agent.instanceId, {
     id: currentAgentMsgId,
     role: "agent",
@@ -134,7 +135,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
   let promptId = "";
 
   function newAgentBubble(): void {
-    currentAgentMsgId = crypto.randomUUID();
+    currentAgentMsgId = randomUUID();
     appendMessage(agent.instanceId, {
       id: currentAgentMsgId,
       role: "agent",
@@ -167,7 +168,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
       const prev = findMessage(agent.instanceId, currentAgentMsgId);
       if (prev) prev.streaming = false;
       appendMessage(agent.instanceId, {
-        id: crypto.randomUUID(),
+        id: randomUUID(),
         role: "query",
         content: queryPrompt,
         streaming: false,

--- a/examples/agent-web-ui/src/App.vue
+++ b/examples/agent-web-ui/src/App.vue
@@ -16,6 +16,7 @@ import {
 import {
   appendMessage,
   findMessage,
+  findMessageByToolId,
   getSession,
   messagesFor,
   type Message,
@@ -179,6 +180,32 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
         attachments: queryAttachments,
       });
       newAgentBubble();
+    },
+    onToolUse(toolUseId, toolName, input) {
+      // Close current agent bubble, drop a tool card in chronological order,
+      // open a fresh agent bubble for whatever Claude says next.
+      const prev = findMessage(agent.instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(agent.instanceId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+      });
+      newAgentBubble();
+    },
+    onToolResult(toolUseId, output, isError) {
+      const m = findMessageByToolId(agent.instanceId, toolUseId);
+      if (m && m.tool) {
+        m.tool.result = output;
+        m.tool.isError = isError;
+      }
+    },
+    onCost(turnCostUsd) {
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
+      if (m) m.costUsd = turnCostUsd;
     },
     onDone() {
       const m = findMessage(agent.instanceId, currentAgentMsgId);

--- a/examples/agent-web-ui/src/App.vue
+++ b/examples/agent-web-ui/src/App.vue
@@ -5,8 +5,14 @@ import AgentList from "./components/AgentList.vue";
 import MessageList from "./components/MessageList.vue";
 import PromptArea from "./components/PromptArea.vue";
 import PiExecView from "./components/piexec/PiExecView.vue";
+import CcExecView from "./components/ccexec/CcExecView.vue";
 import { bridgeState } from "./stores/bridge.ts";
-import { agentsState, piexecControllers, selectedAgent } from "./stores/agents.ts";
+import {
+  agentsState,
+  ccexecControllers,
+  piexecControllers,
+  selectedAgent,
+} from "./stores/agents.ts";
 import {
   appendMessage,
   findMessage,
@@ -16,17 +22,21 @@ import {
 } from "./stores/chat.ts";
 import { fileToAttachment, useBridge } from "./composables/useBridge.ts";
 
-type ViewMode = "chat" | "piexec";
+type ViewMode = "chat" | "piexec" | "ccexec";
 const STORAGE_KEY = "testui:view-mode";
 const loadedMode =
   typeof localStorage !== "undefined"
     ? (localStorage.getItem(STORAGE_KEY) as ViewMode | null)
     : null;
-const viewMode = ref<ViewMode>(loadedMode === "piexec" ? "piexec" : "chat");
+const viewMode = ref<ViewMode>(
+  loadedMode === "piexec" || loadedMode === "ccexec" ? loadedMode : "chat",
+);
 const piexecAvailable = computed(() => piexecControllers.value.length > 0);
+const ccexecAvailable = computed(() => ccexecControllers.value.length > 0);
 
 function setMode(mode: ViewMode): void {
   if (mode === "piexec" && !piexecAvailable.value) return;
+  if (mode === "ccexec" && !ccexecAvailable.value) return;
   viewMode.value = mode;
   try {
     localStorage.setItem(STORAGE_KEY, mode);
@@ -35,9 +45,12 @@ function setMode(mode: ViewMode): void {
   }
 }
 
-// Fall back to chat when no controllers exist; stay in piexec when they appear.
+// Fall back to chat when the active mode's controllers vanish; stay otherwise.
 watch(piexecAvailable, (available) => {
   if (!available && viewMode.value === "piexec") viewMode.value = "chat";
+});
+watch(ccexecAvailable, (available) => {
+  if (!available && viewMode.value === "ccexec") viewMode.value = "chat";
 });
 
 const bridge = useBridge();
@@ -223,11 +236,20 @@ onMounted(() => {
           :title="piexecAvailable ? 'Spawn &amp; fan-out PI sessions' : 'start pi-headless to enable'"
           @click="setMode('piexec')"
         >PI Exec<span v-if="piexecAvailable" class="count">{{ piexecControllers.length }}</span></button>
+        <button
+          type="button"
+          class="mode-btn"
+          :class="{ active: viewMode === 'ccexec' }"
+          :disabled="!ccexecAvailable"
+          :title="ccexecAvailable ? 'Spawn Claude Code sessions' : 'start claude-code-headless to enable'"
+          @click="setMode('ccexec')"
+        >CC Exec<span v-if="ccexecAvailable" class="count">{{ ccexecControllers.length }}</span></button>
       </nav>
     </template>
   </ConnectionBar>
   <div v-if="error" class="global-error mono">{{ error }}</div>
   <PiExecView v-if="viewMode === 'piexec'" />
+  <CcExecView v-else-if="viewMode === 'ccexec'" />
   <main v-else class="shell">
     <AgentList />
     <section class="chat-pane">

--- a/examples/agent-web-ui/src/components/MessageBubble.vue
+++ b/examples/agent-web-ui/src/components/MessageBubble.vue
@@ -15,6 +15,32 @@ const bubbleRef = ref<HTMLElement | null>(null);
 const isUser = computed(() => props.message.role === "user");
 const isAgent = computed(() => props.message.role === "agent");
 const isQuery = computed(() => props.message.role === "query");
+const isTool = computed(() => props.message.role === "tool");
+
+const toolInputJson = computed(() => {
+  const t = props.message.tool;
+  if (!t) return "";
+  try {
+    return JSON.stringify(t.input, null, 2);
+  } catch {
+    return String(t.input);
+  }
+});
+
+const toolStatusGlyph = computed(() => {
+  const t = props.message.tool;
+  if (!t) return "";
+  if (t.isError) return "✗";
+  if (t.result !== undefined) return "✓";
+  return "…";
+});
+
+const formattedCost = computed(() => {
+  const c = props.message.costUsd;
+  if (c === undefined || c === null) return "";
+  if (c < 0.0001) return "<$0.0001";
+  return `$${c.toFixed(4)}`;
+});
 
 const freeText = ref("");
 
@@ -79,6 +105,8 @@ onBeforeUnmount(() => bubbleRef.value?.removeEventListener("click", handleClick)
       user: isUser,
       agent: isAgent,
       query: isQuery,
+      tool: isTool,
+      'tool-error': isTool && message.tool?.isError,
       streaming: message.streaming,
       errored: !!message.error,
     }"
@@ -95,6 +123,23 @@ onBeforeUnmount(() => bubbleRef.value?.removeEventListener("click", handleClick)
       <span class="role">agent asks</span>
       <span class="time mono">{{ time }}</span>
     </header>
+
+    <div v-if="isTool && message.tool" class="tool-card">
+      <header class="tool-header">
+        <span class="tool-glyph mono">{{ toolStatusGlyph }}</span>
+        <span class="tool-name mono">{{ message.tool.name }}</span>
+        <span class="time mono">{{ time }}</span>
+      </header>
+      <details class="tool-section" open>
+        <summary class="tool-summary mono">input</summary>
+        <pre class="tool-pre mono">{{ toolInputJson }}</pre>
+      </details>
+      <details v-if="message.tool.result !== undefined" class="tool-section" :open="message.tool.isError">
+        <summary class="tool-summary mono">{{ message.tool.isError ? "result (error)" : "result" }}</summary>
+        <pre class="tool-pre mono">{{ message.tool.result }}</pre>
+      </details>
+      <div v-else class="tool-pending mono">running…</div>
+    </div>
 
     <div v-if="isUser && message.attachments && message.attachments.length" class="attachments">
       <span v-for="a in message.attachments" :key="a.filename" class="attachment mono">📎 {{ a.filename }}</span>
@@ -131,6 +176,7 @@ onBeforeUnmount(() => bubbleRef.value?.removeEventListener("click", handleClick)
     </div>
 
     <footer v-if="message.statusNote" class="status-note mono">{{ message.statusNote }}</footer>
+    <footer v-if="formattedCost" class="cost-note mono">cost: {{ formattedCost }}</footer>
     <footer v-if="message.error" class="error mono">{{ message.error }}</footer>
 
     <footer v-if="isUser" class="user-time">
@@ -171,6 +217,74 @@ onBeforeUnmount(() => bubbleRef.value?.removeEventListener("click", handleClick)
   background: var(--accent-glow);
   border: 1px solid var(--accent-primary);
   border-radius: var(--border-radius-lg);
+}
+
+.bubble.tool {
+  align-self: flex-start;
+  max-width: 92%;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-primary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+}
+.bubble.tool-error {
+  border-color: var(--error);
+}
+
+.tool-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+.tool-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+.tool-glyph {
+  font-weight: 700;
+  color: var(--accent-primary);
+}
+.bubble.tool-error .tool-glyph { color: var(--error); }
+.tool-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.tool-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tool-summary {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  user-select: none;
+}
+.tool-summary:hover { color: var(--text-secondary); }
+.tool-pre {
+  margin: 2px 0 0 0;
+  padding: 6px 8px;
+  background: var(--bg-deep);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius-sm);
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.tool-pending {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .query-reply {
@@ -306,6 +420,11 @@ onBeforeUnmount(() => bubbleRef.value?.removeEventListener("click", handleClick)
   font-size: var(--text-xs);
   color: var(--text-muted);
   font-style: italic;
+}
+.cost-note {
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
 }
 .error {
   font-size: var(--text-xs);

--- a/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
+++ b/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
@@ -4,12 +4,14 @@ import { useBridge, fileToAttachment } from "../../composables/useBridge.ts";
 import { agentsState, ccexecControllers, selectAgent } from "../../stores/agents.ts";
 import {
   autoPickCcController,
+  bumpCcSessionCost,
   ccexecState,
   selectedCcController,
 } from "../../stores/ccexec.ts";
 import {
   appendMessage,
   findMessage,
+  findMessageByToolId,
   getSession,
   messagesFor,
   type Message,
@@ -90,31 +92,87 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
       : {}),
   });
 
-  const agentMsgId = randomUUID();
+  let currentAgentMsgId = randomUUID();
   appendMessage(agent.instanceId, {
-    id: agentMsgId,
+    id: currentAgentMsgId,
     role: "agent",
     content: "",
     streaming: true,
     timestamp: Date.now(),
   });
 
-  const promptId = bridge.prompt(agent.instanceId, text, attachments, {
+  function newAgentBubble(): void {
+    currentAgentMsgId = randomUUID();
+    appendMessage(agent.instanceId, {
+      id: currentAgentMsgId,
+      role: "agent",
+      content: "",
+      streaming: true,
+      timestamp: Date.now(),
+    });
+  }
+
+  let promptId = "";
+  promptId = bridge.prompt(agent.instanceId, text, attachments, {
     onResponse(chunk) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) m.content += chunk;
     },
     onStatus(status) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m && status === "stopped") m.statusNote = "(stopped)";
     },
+    onQuery(queryId, queryPrompt, queryAttachments) {
+      const prev = findMessage(agent.instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(agent.instanceId, {
+        id: randomUUID(),
+        role: "query",
+        content: queryPrompt,
+        streaming: false,
+        timestamp: Date.now(),
+        queryId,
+        promptId,
+        replied: false,
+        attachments: queryAttachments,
+      });
+      newAgentBubble();
+    },
+    onToolUse(toolUseId, toolName, input) {
+      const prev = findMessage(agent.instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(agent.instanceId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+      });
+      newAgentBubble();
+    },
+    onToolResult(toolUseId, output, isError) {
+      const m = findMessageByToolId(agent.instanceId, toolUseId);
+      if (m && m.tool) {
+        m.tool.result = output;
+        m.tool.isError = isError;
+      }
+    },
+    onCost(turnCostUsd, totalCostUsd) {
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
+      if (m) m.costUsd = turnCostUsd;
+      // The session id equals the spawned agent's `name` token (see
+      // claude-code-headless ManagedSession registration). Keep the session
+      // summary in sync so the SessionList card reflects the running total.
+      bumpCcSessionCost(agent.name, totalCostUsd);
+    },
     onDone() {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) m.streaming = false;
       session.activePromptId = null;
     },
     onError(message, code) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) {
         const detail = code ? ` [${code}]` : "";
         m.error = `${message}${detail}`;
@@ -133,9 +191,7 @@ function onStop(): void {
   if (s.activePromptId) bridge.cancel(s.activePromptId);
 }
 
-function _onQueryReply(message: Message, answer: string): void {
-  // Sessions may emit queries (e.g. permission prompts surfaced as protocol §7
-  // chunks once that wiring lands). Reuse chat flow's reply primitive.
+function onQueryReply(message: Message, answer: string): void {
   if (message.replied) return;
   if (!message.promptId || !message.queryId) return;
   bridge.queryReply(message.promptId, message.queryId, answer);
@@ -171,7 +227,7 @@ function _onQueryReply(message: Message, answer: string): void {
           </div>
           <div class="sub mono">{{ selected.promptEndpoint.subject }}</div>
         </header>
-        <MessageList :messages="currentMessages" @reply="_onQueryReply" />
+        <MessageList :messages="currentMessages" @reply="onQueryReply" />
         <PromptArea
           :busy="busy"
           :disabled="false"

--- a/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
+++ b/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import { computed, onMounted, watch } from "vue";
+import { useBridge, fileToAttachment } from "../../composables/useBridge.ts";
+import { agentsState, ccexecControllers, selectAgent } from "../../stores/agents.ts";
+import {
+  autoPickCcController,
+  ccexecState,
+  selectedCcController,
+} from "../../stores/ccexec.ts";
+import {
+  appendMessage,
+  findMessage,
+  getSession,
+  messagesFor,
+  type Message,
+} from "../../stores/chat.ts";
+
+import ControllerSelector from "./ControllerSelector.vue";
+import SpawnForm from "./SpawnForm.vue";
+import SessionList from "./SessionList.vue";
+import MessageList from "../MessageList.vue";
+import PromptArea from "../PromptArea.vue";
+
+const bridge = useBridge();
+
+const selected = computed(() => {
+  const id = agentsState.selectedInstanceId;
+  if (!id) return null;
+  return agentsState.list.find((a) => a.instanceId === id) ?? null;
+});
+
+const isSessionSelected = computed(() => {
+  const s = selected.value;
+  if (!s) return false;
+  return s.metadata?.["spawner"] === "claude-code-headless";
+});
+
+const currentMessages = computed(() =>
+  selected.value && isSessionSelected.value ? messagesFor(selected.value.instanceId) : [],
+);
+
+const busy = computed(() => {
+  const s = selected.value;
+  if (!s) return false;
+  return getSession(s.instanceId).activePromptId !== null;
+});
+
+const attachmentsOk = computed(
+  () => selected.value?.promptEndpoint.attachmentsOk === true,
+);
+const maxPayloadBytes = computed(() => selected.value?.promptEndpoint.maxPayloadBytes);
+
+// Auto-pick a controller on first load or when the list changes.
+watch(
+  () => ccexecControllers.value.length,
+  () => autoPickCcController(),
+  { immediate: true },
+);
+
+onMounted(() => {
+  autoPickCcController();
+});
+
+async function onSubmit(text: string, files: File[]): Promise<void> {
+  const agent = selected.value;
+  if (!agent || !isSessionSelected.value) return;
+  const session = getSession(agent.instanceId);
+
+  let attachments: Awaited<ReturnType<typeof fileToAttachment>>[] | undefined;
+  if (files.length > 0) {
+    try {
+      attachments = await Promise.all(files.map(fileToAttachment));
+    } catch (e) {
+      ccexecState.lastError = `failed to read file: ${(e as Error).message}`;
+      return;
+    }
+  }
+
+  appendMessage(agent.instanceId, {
+    id: crypto.randomUUID(),
+    role: "user",
+    content: text,
+    streaming: false,
+    timestamp: Date.now(),
+    ...(attachments
+      ? {
+          attachments: attachments.map((a) => ({ filename: a.filename, base64: a.base64 })),
+        }
+      : {}),
+  });
+
+  const agentMsgId = crypto.randomUUID();
+  appendMessage(agent.instanceId, {
+    id: agentMsgId,
+    role: "agent",
+    content: "",
+    streaming: true,
+    timestamp: Date.now(),
+  });
+
+  const promptId = bridge.prompt(agent.instanceId, text, attachments, {
+    onResponse(chunk) {
+      const m = findMessage(agent.instanceId, agentMsgId);
+      if (m) m.content += chunk;
+    },
+    onStatus(status) {
+      const m = findMessage(agent.instanceId, agentMsgId);
+      if (m && status === "stopped") m.statusNote = "(stopped)";
+    },
+    onDone() {
+      const m = findMessage(agent.instanceId, agentMsgId);
+      if (m) m.streaming = false;
+      session.activePromptId = null;
+    },
+    onError(message, code) {
+      const m = findMessage(agent.instanceId, agentMsgId);
+      if (m) {
+        const detail = code ? ` [${code}]` : "";
+        m.error = `${message}${detail}`;
+        m.streaming = false;
+      }
+      session.activePromptId = null;
+    },
+  });
+  session.activePromptId = promptId;
+}
+
+function onStop(): void {
+  const agent = selected.value;
+  if (!agent) return;
+  const s = getSession(agent.instanceId);
+  if (s.activePromptId) bridge.cancel(s.activePromptId);
+}
+
+function _onQueryReply(message: Message, answer: string): void {
+  // Sessions may emit queries (e.g. permission prompts surfaced as protocol §7
+  // chunks once that wiring lands). Reuse chat flow's reply primitive.
+  if (message.replied) return;
+  if (!message.promptId || !message.queryId) return;
+  bridge.queryReply(message.promptId, message.queryId, answer);
+  message.replied = true;
+  message.replyValue = answer;
+}
+</script>
+
+<template>
+  <ControllerSelector />
+  <main class="grid">
+    <section class="col-left">
+      <SpawnForm @spawned="(d) => selectAgent(d.instance_id)" />
+      <SessionList />
+    </section>
+    <section class="col-mid">
+      <div v-if="!selectedCcController" class="placeholder">
+        <h2>No claude-code-headless controller</h2>
+        <p>
+          Run <code class="mono">bun run start</code> in <code class="mono">examples/claude-code-headless</code> and hit Refresh.
+        </p>
+      </div>
+      <div v-else-if="!selected || !isSessionSelected" class="placeholder">
+        <h2>Pick a session</h2>
+        <p>Spawn a session or click one in the list to prompt it.</p>
+      </div>
+      <template v-else>
+        <header class="chat-head">
+          <div class="title">
+            <span class="agent-tag mono">cc</span>
+            <span class="name">{{ selected.name }}</span>
+            <span class="owner mono">@{{ selected.owner }}</span>
+          </div>
+          <div class="sub mono">{{ selected.promptEndpoint.subject }}</div>
+        </header>
+        <MessageList :messages="currentMessages" @reply="_onQueryReply" />
+        <PromptArea
+          :busy="busy"
+          :disabled="false"
+          :attachments-ok="attachmentsOk"
+          :max-payload-bytes="maxPayloadBytes"
+          @submit="onSubmit"
+          @stop="onStop"
+        />
+      </template>
+    </section>
+  </main>
+</template>
+
+<style scoped>
+.grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.col-left,
+.col-mid {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+.col-left {
+  padding: var(--space-md);
+  gap: var(--space-md);
+  background: var(--bg-primary);
+  border-right: var(--border-subtle);
+  overflow-y: auto;
+}
+.col-mid {
+  background: var(--bg-deep);
+}
+
+.placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xl);
+  color: var(--text-muted);
+  text-align: center;
+}
+.placeholder h2 { color: var(--text-secondary); margin-bottom: var(--space-md); }
+.placeholder p { font-size: var(--text-sm); max-width: 360px; line-height: var(--leading-relaxed); }
+.placeholder code { color: var(--accent-primary); }
+
+.chat-head {
+  padding: var(--space-md) var(--space-lg);
+  background: var(--bg-primary);
+  border-bottom: var(--border-subtle);
+}
+.title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+.agent-tag {
+  font-size: var(--text-xs);
+  color: var(--accent-primary);
+  background: var(--accent-glow);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.owner { color: var(--text-muted); font-size: var(--text-xs); }
+.sub { color: var(--text-dim); font-size: var(--text-xs); margin-top: 2px; }
+</style>

--- a/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
+++ b/examples/agent-web-ui/src/components/ccexec/CcExecView.vue
@@ -20,6 +20,7 @@ import SpawnForm from "./SpawnForm.vue";
 import SessionList from "./SessionList.vue";
 import MessageList from "../MessageList.vue";
 import PromptArea from "../PromptArea.vue";
+import { randomUUID } from "../../uuid.ts";
 
 const bridge = useBridge();
 
@@ -77,7 +78,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
   }
 
   appendMessage(agent.instanceId, {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     role: "user",
     content: text,
     streaming: false,
@@ -89,7 +90,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
       : {}),
   });
 
-  const agentMsgId = crypto.randomUUID();
+  const agentMsgId = randomUUID();
   appendMessage(agent.instanceId, {
     id: agentMsgId,
     role: "agent",

--- a/examples/agent-web-ui/src/components/ccexec/ControllerSelector.vue
+++ b/examples/agent-web-ui/src/components/ccexec/ControllerSelector.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { ccexecControllers } from "../../stores/agents.ts";
+import { ccexecState } from "../../stores/ccexec.ts";
+
+const options = computed(() => ccexecControllers.value);
+
+function onChange(e: Event): void {
+  const sel = (e.target as HTMLSelectElement).value;
+  ccexecState.selectedControllerId = sel === "" ? null : sel;
+}
+</script>
+
+<template>
+  <div class="wrap">
+    <label class="label mono">Controller</label>
+    <select
+      class="select mono"
+      :value="ccexecState.selectedControllerId ?? ''"
+      :disabled="options.length === 0"
+      @change="onChange"
+    >
+      <option v-if="options.length === 0" value="">no claude-code-headless controller discovered</option>
+      <option v-for="c in options" :key="c.instanceId" :value="c.instanceId">
+        {{ c.agent }} / {{ c.owner }} / {{ c.name }} — {{ c.instanceId.slice(0, 8) }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<style scoped>
+.wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-primary);
+  border-bottom: var(--border-subtle);
+  flex-shrink: 0;
+}
+.label {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.select {
+  flex: 1;
+  min-width: 0;
+  height: 32px;
+  padding: 0 var(--space-sm);
+  background: var(--bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+.select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+.select:disabled { opacity: 0.6; }
+</style>

--- a/examples/agent-web-ui/src/components/ccexec/SessionList.vue
+++ b/examples/agent-web-ui/src/components/ccexec/SessionList.vue
@@ -85,6 +85,12 @@ function fmtTools(summary: CcExecSessionSummary | undefined, agent: DiscoveredAg
   if (tools.length <= 3) return tools.join(",");
   return `${tools.slice(0, 3).join(",")}+${tools.length - 3}`;
 }
+
+function fmtCost(summary: CcExecSessionSummary | undefined): string {
+  if (!summary || summary.total_cost_usd <= 0) return "-";
+  if (summary.total_cost_usd < 0.0001) return "<$0.0001";
+  return `$${summary.total_cost_usd.toFixed(4)}`;
+}
 </script>
 
 <template>
@@ -127,6 +133,10 @@ function fmtTools(summary: CcExecSessionSummary | undefined, agent: DiscoveredAg
             <span class="meta-val mono">{{ fmtTools(summary, agent) }}</span>
             <span class="meta-key mono">ttl</span>
             <span class="meta-val mono">{{ fmtRemaining(summary) }}</span>
+            <span class="meta-key mono">cost</span>
+            <span class="meta-val mono">{{ fmtCost(summary) }}</span>
+            <span v-if="summary && summary.turn_count > 0" class="meta-key mono">turns</span>
+            <span v-if="summary && summary.turn_count > 0" class="meta-val mono">{{ summary.turn_count }}</span>
             <span v-if="summary && summary.queued_requests > 0" class="meta-key mono">queue</span>
             <span v-if="summary && summary.queued_requests > 0" class="meta-val mono">{{ summary.queued_requests }}</span>
           </div>

--- a/examples/agent-web-ui/src/components/ccexec/SessionList.vue
+++ b/examples/agent-web-ui/src/components/ccexec/SessionList.vue
@@ -1,0 +1,294 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useBridge } from "../../composables/useBridge.ts";
+import { agentsState, selectAgent } from "../../stores/agents.ts";
+import {
+  ccexecState,
+  mergeCcSummaries,
+  onCcStopped,
+  selectedCcController,
+  visibleCcSessions,
+} from "../../stores/ccexec.ts";
+import AgentStatusDot from "../AgentStatusDot.vue";
+import type { DiscoveredAgentDTO, CcExecSessionSummary } from "../../wire.ts";
+
+const bridge = useBridge();
+const stoppingIds = ref<Set<string>>(new Set());
+let tick: ReturnType<typeof setInterval> | null = null;
+
+const rows = computed(() =>
+  visibleCcSessions.value.map((agent) => {
+    const summary = ccexecState.summaries.get(agent.name);
+    return { agent, summary };
+  }),
+);
+
+const selectedInstanceId = computed(() => agentsState.selectedInstanceId);
+
+async function refresh(): Promise<void> {
+  const controller = selectedCcController.value;
+  if (!controller || ccexecState.refreshing) return;
+  ccexecState.refreshing = true;
+  try {
+    const list = await bridge.ccexecList(controller.instanceId);
+    mergeCcSummaries(list);
+  } catch (err) {
+    ccexecState.lastError = `list failed: ${(err as Error).message}`;
+  } finally {
+    ccexecState.refreshing = false;
+  }
+}
+
+async function onStop(agent: DiscoveredAgentDTO): Promise<void> {
+  const controller = selectedCcController.value;
+  if (!controller) return;
+  if (!confirm(`Stop session ${agent.name}? In-flight prompts will be cut off.`)) return;
+  stoppingIds.value.add(agent.name);
+  try {
+    await bridge.ccexecStop(controller.instanceId, agent.name);
+    onCcStopped(agent.name);
+  } catch (err) {
+    ccexecState.lastError = `stop failed: ${(err as Error).message}`;
+  } finally {
+    stoppingIds.value.delete(agent.name);
+  }
+}
+
+onMounted(() => {
+  tick = setInterval(() => void refresh(), 5_000);
+  void refresh();
+});
+
+onUnmounted(() => {
+  if (tick) clearInterval(tick);
+});
+
+function fmtRemaining(summary: CcExecSessionSummary | undefined): string {
+  if (!summary) return "";
+  if (summary.max_lifetime_s === 0) return "∞";
+  const r = summary.remaining_lifetime_s;
+  if (r <= 0) return "expired";
+  if (r >= 3600) return `${Math.floor(r / 3600)}h ${Math.floor((r % 3600) / 60)}m`;
+  if (r >= 60) return `${Math.floor(r / 60)}m ${r % 60}s`;
+  return `${r}s`;
+}
+
+function lifetimePercent(summary: CcExecSessionSummary | undefined): number {
+  if (!summary || summary.max_lifetime_s === 0) return 0;
+  const used = summary.max_lifetime_s - summary.remaining_lifetime_s;
+  return Math.max(0, Math.min(100, (used / summary.max_lifetime_s) * 100));
+}
+
+function fmtTools(summary: CcExecSessionSummary | undefined, agent: DiscoveredAgentDTO): string {
+  const tools = summary?.allowed_tools ?? agent.metadata?.["allowed_tools"]?.split(",") ?? [];
+  if (tools.length === 0) return "-";
+  if (tools.length <= 3) return tools.join(",");
+  return `${tools.slice(0, 3).join(",")}+${tools.length - 3}`;
+}
+</script>
+
+<template>
+  <section class="panel">
+    <div class="head">
+      <h3 class="heading">Sessions</h3>
+      <button
+        type="button"
+        class="refresh-btn mono"
+        :disabled="ccexecState.refreshing || !selectedCcController"
+        @click="refresh"
+      >{{ ccexecState.refreshing ? '…' : '↻' }}</button>
+    </div>
+    <div v-if="!selectedCcController" class="empty mono">select a controller</div>
+    <div v-else-if="rows.length === 0" class="empty">No sessions. Spawn one to get started.</div>
+    <ul v-else class="list">
+      <li
+        v-for="{ agent, summary } in rows"
+        :key="agent.instanceId"
+        class="row"
+        :class="{ selected: selectedInstanceId === agent.instanceId }"
+      >
+        <button
+          type="button"
+          class="row-body"
+          @click="selectAgent(agent.instanceId)"
+        >
+          <div class="title">
+            <AgentStatusDot class="dot" :instance-id="agent.instanceId" />
+            <span class="sid mono">{{ agent.name }}</span>
+            <span v-if="summary?.active_request" class="running-tag">running</span>
+          </div>
+          <div class="cwd mono">{{ summary?.cwd ?? agent.metadata?.['cwd'] ?? '?' }}</div>
+          <div class="meta">
+            <span class="meta-key mono">model</span>
+            <span class="meta-val mono">{{ summary?.model ?? agent.metadata?.['model'] ?? '-' }}</span>
+            <span class="meta-key mono">perm</span>
+            <span class="meta-val mono">{{ summary?.permission_mode ?? agent.metadata?.['permission_mode'] ?? '-' }}</span>
+            <span class="meta-key mono">tools</span>
+            <span class="meta-val mono">{{ fmtTools(summary, agent) }}</span>
+            <span class="meta-key mono">ttl</span>
+            <span class="meta-val mono">{{ fmtRemaining(summary) }}</span>
+            <span v-if="summary && summary.queued_requests > 0" class="meta-key mono">queue</span>
+            <span v-if="summary && summary.queued_requests > 0" class="meta-val mono">{{ summary.queued_requests }}</span>
+          </div>
+          <div v-if="summary && summary.max_lifetime_s > 0" class="progress">
+            <div class="progress-fill" :style="{ width: `${lifetimePercent(summary)}%` }" />
+          </div>
+        </button>
+        <button
+          type="button"
+          class="stop-btn"
+          :disabled="stoppingIds.has(agent.name)"
+          title="Stop session"
+          @click="onStop(agent)"
+        >✕</button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 0;
+  flex: 1;
+}
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.heading {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.refresh-btn {
+  height: 24px;
+  width: 28px;
+  border: var(--border-subtle);
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+.refresh-btn:disabled { opacity: 0.4; }
+.refresh-btn:hover:not(:disabled) {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+.empty {
+  padding: var(--space-md);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius);
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 2px;
+}
+.row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-xs);
+  background: var(--bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  transition: border-color var(--transition-fast);
+}
+.row.selected {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-glow);
+}
+.row:hover { border-color: rgba(255, 255, 255, 0.15); }
+
+.row-body {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-sm) var(--space-md);
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+.dot { width: 8px; height: 8px; }
+.sid {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+.running-tag {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: var(--border-radius-sm);
+  background: var(--accent-glow);
+  color: var(--accent-primary);
+}
+.cwd {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px var(--space-xs);
+  margin-top: 2px;
+  font-size: 10px;
+  line-height: 1.3;
+}
+.meta-key { color: var(--text-dim); text-transform: uppercase; }
+.meta-val { color: var(--text-secondary); }
+
+.progress {
+  margin-top: var(--space-xs);
+  height: 2px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--accent-gradient);
+  transition: width 1s linear;
+}
+
+.stop-btn {
+  padding: 0 var(--space-sm);
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: var(--text-base);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.stop-btn:hover:not(:disabled) {
+  background: var(--error-dim);
+  color: var(--error);
+}
+.stop-btn:disabled { opacity: 0.4; cursor: wait; }
+</style>

--- a/examples/agent-web-ui/src/components/ccexec/SpawnForm.vue
+++ b/examples/agent-web-ui/src/components/ccexec/SpawnForm.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useBridge } from "../../composables/useBridge.ts";
+import {
+  ccexecState,
+  onCcSpawned,
+  selectedCcController,
+} from "../../stores/ccexec.ts";
+import type { CcExecSpawnDescriptor, CcExecSpawnSpec } from "../../wire.ts";
+
+const emit = defineEmits<{
+  spawned: [descriptor: CcExecSpawnDescriptor];
+}>();
+
+const bridge = useBridge();
+
+const cwd = ref("");
+const sessionId = ref("");
+const model = ref("");
+const allowedTools = ref("");
+const permissionMode = ref("");
+const maxTurns = ref("");
+const maxLifetime = ref("1800");
+const submitting = ref(false);
+
+const disabled = computed(() => !selectedCcController.value);
+
+// Mirrors the SDK's PermissionMode enum. Empty string = use controller default.
+const permissionOptions = ["", "default", "dontAsk", "acceptEdits", "bypassPermissions", "plan", "auto"];
+
+async function onSubmit(e: Event): Promise<void> {
+  e.preventDefault();
+  if (disabled.value || submitting.value) return;
+  const controller = selectedCcController.value!;
+
+  const spec: CcExecSpawnSpec = { cwd: cwd.value.trim() };
+  if (!spec.cwd) {
+    ccexecState.lastError = "cwd is required";
+    return;
+  }
+  if (sessionId.value.trim()) spec.session_id = sessionId.value.trim();
+  if (model.value.trim()) spec.model = model.value.trim();
+  const tools = allowedTools.value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (tools.length > 0) spec.allowed_tools = tools;
+  if (permissionMode.value) spec.permission_mode = permissionMode.value;
+  if (maxTurns.value.trim()) {
+    const n = Number(maxTurns.value);
+    if (Number.isInteger(n) && n > 0) spec.max_turns = n;
+  }
+  const lifetime = Number(maxLifetime.value);
+  if (Number.isFinite(lifetime) && lifetime >= 0) spec.max_lifetime_s = lifetime;
+
+  submitting.value = true;
+  ccexecState.lastError = null;
+  try {
+    const descriptor = await bridge.ccexecSpawn(controller.instanceId, spec);
+    onCcSpawned(descriptor);
+    emit("spawned", descriptor);
+    // Reset just the dynamic fields; keep model / tools / mode / turns / lifetime for next spawn.
+    cwd.value = "";
+    sessionId.value = "";
+  } catch (err) {
+    ccexecState.lastError = `spawn failed: ${(err as Error).message}`;
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<template>
+  <form class="form" @submit="onSubmit">
+    <h3 class="heading">Spawn session</h3>
+
+    <label class="field">
+      <span class="label mono">cwd *</span>
+      <input v-model="cwd" class="input mono" placeholder="/abs/path" :disabled="disabled" />
+    </label>
+
+    <label class="field">
+      <span class="label mono">session id</span>
+      <input v-model="sessionId" class="input mono" placeholder="(auto-generated)" :disabled="disabled" />
+    </label>
+
+    <label class="field">
+      <span class="label mono">model</span>
+      <input
+        v-model="model"
+        class="input mono"
+        placeholder="(controller default, e.g. claude-sonnet-4-6)"
+        :disabled="disabled"
+      />
+    </label>
+
+    <label class="field">
+      <span class="label mono">allowed tools</span>
+      <input
+        v-model="allowedTools"
+        class="input mono"
+        placeholder="(controller default, e.g. Read,Glob,Grep,Edit)"
+        :disabled="disabled"
+      />
+    </label>
+
+    <label class="field">
+      <span class="label mono">permission mode</span>
+      <select v-model="permissionMode" class="input mono" :disabled="disabled">
+        <option v-for="opt in permissionOptions" :key="opt" :value="opt">
+          {{ opt === "" ? "(controller default)" : opt }}
+        </option>
+      </select>
+    </label>
+
+    <label class="field">
+      <span class="label mono">max turns</span>
+      <input
+        v-model="maxTurns"
+        class="input mono"
+        type="number"
+        min="1"
+        placeholder="(controller default)"
+        :disabled="disabled"
+      />
+    </label>
+
+    <label class="field">
+      <span class="label mono">max lifetime (s)</span>
+      <input
+        v-model="maxLifetime"
+        class="input mono"
+        type="number"
+        min="0"
+        :disabled="disabled"
+      />
+    </label>
+
+    <div class="footer">
+      <span v-if="ccexecState.lastError" class="error mono">{{ ccexecState.lastError }}</span>
+      <button
+        type="submit"
+        class="btn"
+        :disabled="disabled || submitting || !cwd.trim()"
+      >
+        {{ submitting ? "spawning..." : "Spawn" }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+}
+.heading {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  margin-bottom: var(--space-xs);
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.label {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.input {
+  height: 32px;
+  padding: 0 var(--space-sm);
+  background: var(--bg-primary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+.input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+.error {
+  font-size: var(--text-xs);
+  color: var(--error);
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+.btn {
+  height: 32px;
+  padding: 0 var(--space-md);
+  background: var(--accent-gradient);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn:hover:not(:disabled) { filter: brightness(1.1); }
+</style>

--- a/examples/agent-web-ui/src/components/piexec/FanoutPanel.vue
+++ b/examples/agent-web-ui/src/components/piexec/FanoutPanel.vue
@@ -13,6 +13,7 @@ import {
   type FanoutRun,
 } from "../../stores/piexec.ts";
 import FanoutRunCard from "./FanoutRunCard.vue";
+import { randomUUID } from "../../uuid.ts";
 
 const bridge = useBridge();
 
@@ -126,7 +127,7 @@ async function onSubmit(e: Event): Promise<void> {
 
   try {
     const runs: FanoutRun[] = targets.map((cwd) => ({
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       cwd,
       status: "pending",
       content: "",

--- a/examples/agent-web-ui/src/components/piexec/PiExecView.vue
+++ b/examples/agent-web-ui/src/components/piexec/PiExecView.vue
@@ -10,6 +10,7 @@ import {
 import {
   appendMessage,
   findMessage,
+  findMessageByToolId,
   getSession,
   messagesFor,
   type Message,
@@ -91,31 +92,83 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
       : {}),
   });
 
-  const agentMsgId = randomUUID();
+  let currentAgentMsgId = randomUUID();
   appendMessage(agent.instanceId, {
-    id: agentMsgId,
+    id: currentAgentMsgId,
     role: "agent",
     content: "",
     streaming: true,
     timestamp: Date.now(),
   });
 
-  const promptId = bridge.prompt(agent.instanceId, text, attachments, {
+  function newAgentBubble(): void {
+    currentAgentMsgId = randomUUID();
+    appendMessage(agent.instanceId, {
+      id: currentAgentMsgId,
+      role: "agent",
+      content: "",
+      streaming: true,
+      timestamp: Date.now(),
+    });
+  }
+
+  let promptId = "";
+  promptId = bridge.prompt(agent.instanceId, text, attachments, {
     onResponse(chunk) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) m.content += chunk;
     },
     onStatus(status) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m && status === "stopped") m.statusNote = "(stopped)";
     },
+    onQuery(queryId, queryPrompt, queryAttachments) {
+      const prev = findMessage(agent.instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(agent.instanceId, {
+        id: randomUUID(),
+        role: "query",
+        content: queryPrompt,
+        streaming: false,
+        timestamp: Date.now(),
+        queryId,
+        promptId,
+        replied: false,
+        attachments: queryAttachments,
+      });
+      newAgentBubble();
+    },
+    onToolUse(toolUseId, toolName, input) {
+      const prev = findMessage(agent.instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(agent.instanceId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+      });
+      newAgentBubble();
+    },
+    onToolResult(toolUseId, output, isError) {
+      const m = findMessageByToolId(agent.instanceId, toolUseId);
+      if (m && m.tool) {
+        m.tool.result = output;
+        m.tool.isError = isError;
+      }
+    },
+    onCost(turnCostUsd) {
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
+      if (m) m.costUsd = turnCostUsd;
+    },
     onDone() {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) m.streaming = false;
       session.activePromptId = null;
     },
     onError(message, code) {
-      const m = findMessage(agent.instanceId, agentMsgId);
+      const m = findMessage(agent.instanceId, currentAgentMsgId);
       if (m) {
         const detail = code ? ` [${code}]` : "";
         m.error = `${message}${detail}`;
@@ -134,9 +187,7 @@ function onStop(): void {
   if (s.activePromptId) bridge.cancel(s.activePromptId);
 }
 
-function _onQueryReply(message: Message, answer: string): void {
-  // Sessions may emit queries via pi tooling permission prompts; reuse chat
-  // flow's reply primitive. No-op when message isn't a query.
+function onQueryReply(message: Message, answer: string): void {
   if (message.replied) return;
   if (!message.promptId || !message.queryId) return;
   bridge.queryReply(message.promptId, message.queryId, answer);
@@ -172,7 +223,7 @@ function _onQueryReply(message: Message, answer: string): void {
           </div>
           <div class="sub mono">{{ selected.promptEndpoint.subject }}</div>
         </header>
-        <MessageList :messages="currentMessages" @reply="_onQueryReply" />
+        <MessageList :messages="currentMessages" @reply="onQueryReply" />
         <PromptArea
           :busy="busy"
           :disabled="false"

--- a/examples/agent-web-ui/src/components/piexec/PiExecView.vue
+++ b/examples/agent-web-ui/src/components/piexec/PiExecView.vue
@@ -21,6 +21,7 @@ import SessionList from "./SessionList.vue";
 import FanoutPanel from "./FanoutPanel.vue";
 import MessageList from "../MessageList.vue";
 import PromptArea from "../PromptArea.vue";
+import { randomUUID } from "../../uuid.ts";
 
 const bridge = useBridge();
 
@@ -78,7 +79,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
   }
 
   appendMessage(agent.instanceId, {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     role: "user",
     content: text,
     streaming: false,
@@ -90,7 +91,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
       : {}),
   });
 
-  const agentMsgId = crypto.randomUUID();
+  const agentMsgId = randomUUID();
   appendMessage(agent.instanceId, {
     id: agentMsgId,
     role: "agent",

--- a/examples/agent-web-ui/src/composables/useBridge.ts
+++ b/examples/agent-web-ui/src/composables/useBridge.ts
@@ -23,6 +23,12 @@ export type StreamHandlers = {
   onResponse?: (text: string, attachments?: WireAttachment[]) => void;
   onStatus?: (status: string) => void;
   onQuery?: (queryId: string, prompt: string, attachments?: WireAttachment[]) => void;
+  /** Claude Code surfaces tool calls (Bash, Read, Edit, etc.) — agent emitted a tool_use. */
+  onToolUse?: (toolUseId: string, toolName: string, input: Record<string, unknown>) => void;
+  /** Result of a previously-emitted tool_use, paired by toolUseId. */
+  onToolResult?: (toolUseId: string, output: string, isError: boolean) => void;
+  /** Per-turn cost notification, fires when each turn completes. */
+  onCost?: (turnCostUsd: number, totalCostUsd: number) => void;
   onDone?: () => void;
   onError?: (message: string, code?: string | number, details?: Record<string, unknown>) => void;
 };
@@ -123,6 +129,15 @@ function handleServerMessage(msg: ServerMessage): void {
       break;
     case "query":
       streams.get(msg.id)?.onQuery?.(msg.queryId, msg.prompt, msg.attachments);
+      break;
+    case "tool-use":
+      streams.get(msg.id)?.onToolUse?.(msg.toolUseId, msg.toolName, msg.input);
+      break;
+    case "tool-result":
+      streams.get(msg.id)?.onToolResult?.(msg.toolUseId, msg.output, msg.isError);
+      break;
+    case "cost":
+      streams.get(msg.id)?.onCost?.(msg.turnCostUsd, msg.totalCostUsd);
       break;
     case "done":
       streams.get(msg.id)?.onDone?.();

--- a/examples/agent-web-ui/src/composables/useBridge.ts
+++ b/examples/agent-web-ui/src/composables/useBridge.ts
@@ -6,6 +6,9 @@ import { bridgeState } from "../stores/bridge.ts";
 import { addAgent, removeAgent, setAgents } from "../stores/agents.ts";
 import { recordHeartbeat } from "../stores/heartbeats.ts";
 import type {
+  CcExecSessionSummary,
+  CcExecSpawnDescriptor,
+  CcExecSpawnSpec,
   ClientMessage,
   DiscoveredAgentDTO,
   PiExecSessionSummary,
@@ -157,6 +160,30 @@ function handleServerMessage(msg: ServerMessage): void {
       }
       break;
     }
+    case "ccexec-spawned": {
+      const entry = pendingControl.get(msg.id);
+      if (entry) {
+        pendingControl.delete(msg.id);
+        entry.resolve(msg.descriptor);
+      }
+      break;
+    }
+    case "ccexec-stopped": {
+      const entry = pendingControl.get(msg.id);
+      if (entry) {
+        pendingControl.delete(msg.id);
+        entry.resolve(msg.sessionId);
+      }
+      break;
+    }
+    case "ccexec-listed": {
+      const entry = pendingControl.get(msg.id);
+      if (entry) {
+        pendingControl.delete(msg.id);
+        entry.resolve(msg.sessions);
+      }
+      break;
+    }
     case "error": {
       if (msg.id && streams.has(msg.id)) {
         streams.get(msg.id)!.onError?.(msg.message, msg.code, msg.details);
@@ -219,7 +246,7 @@ function queryReply(id: string, queryId: string, answer: string): void {
   send({ kind: "query-reply", id, queryId, answer });
 }
 
-function piexecRequest<T>(msg: ClientMessage & { id: string }): Promise<T> {
+function controlRequest<T>(msg: ClientMessage & { id: string }): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     pendingControl.set(msg.id, {
       resolve: resolve as (value: unknown) => void,
@@ -237,7 +264,7 @@ function piexecSpawn(
   spec: PiExecSpawnSpec,
 ): Promise<PiExecSpawnDescriptor> {
   const id = crypto.randomUUID();
-  return piexecRequest<PiExecSpawnDescriptor>({
+  return controlRequest<PiExecSpawnDescriptor>({
     kind: "piexec-spawn",
     id,
     controllerInstanceId,
@@ -247,7 +274,7 @@ function piexecSpawn(
 
 function piexecStop(controllerInstanceId: string, sessionId: string): Promise<string> {
   const id = crypto.randomUUID();
-  return piexecRequest<string>({
+  return controlRequest<string>({
     kind: "piexec-stop",
     id,
     controllerInstanceId,
@@ -259,8 +286,42 @@ function piexecList(
   controllerInstanceId: string,
 ): Promise<PiExecSessionSummary[]> {
   const id = crypto.randomUUID();
-  return piexecRequest<PiExecSessionSummary[]>({
+  return controlRequest<PiExecSessionSummary[]>({
     kind: "piexec-list",
+    id,
+    controllerInstanceId,
+  });
+}
+
+function ccexecSpawn(
+  controllerInstanceId: string,
+  spec: CcExecSpawnSpec,
+): Promise<CcExecSpawnDescriptor> {
+  const id = crypto.randomUUID();
+  return controlRequest<CcExecSpawnDescriptor>({
+    kind: "ccexec-spawn",
+    id,
+    controllerInstanceId,
+    spec,
+  });
+}
+
+function ccexecStop(controllerInstanceId: string, sessionId: string): Promise<string> {
+  const id = crypto.randomUUID();
+  return controlRequest<string>({
+    kind: "ccexec-stop",
+    id,
+    controllerInstanceId,
+    sessionId,
+  });
+}
+
+function ccexecList(
+  controllerInstanceId: string,
+): Promise<CcExecSessionSummary[]> {
+  const id = crypto.randomUUID();
+  return controlRequest<CcExecSessionSummary[]>({
+    kind: "ccexec-list",
     id,
     controllerInstanceId,
   });
@@ -277,6 +338,9 @@ export function useBridge() {
     piexecSpawn,
     piexecStop,
     piexecList,
+    ccexecSpawn,
+    ccexecStop,
+    ccexecList,
   };
 }
 

--- a/examples/agent-web-ui/src/composables/useBridge.ts
+++ b/examples/agent-web-ui/src/composables/useBridge.ts
@@ -5,6 +5,7 @@
 import { bridgeState } from "../stores/bridge.ts";
 import { addAgent, removeAgent, setAgents } from "../stores/agents.ts";
 import { recordHeartbeat } from "../stores/heartbeats.ts";
+import { randomUUID } from "../uuid.ts";
 import type {
   CcExecSessionSummary,
   CcExecSpawnDescriptor,
@@ -227,7 +228,7 @@ function prompt(
   attachments: WireAttachment[] | undefined,
   handlers: StreamHandlers,
 ): string {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   streams.set(id, handlers);
   const payload: ClientMessage = { kind: "prompt", id, instanceId, text };
   if (attachments && attachments.length > 0) payload.attachments = attachments;
@@ -263,7 +264,7 @@ function piexecSpawn(
   controllerInstanceId: string,
   spec: PiExecSpawnSpec,
 ): Promise<PiExecSpawnDescriptor> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<PiExecSpawnDescriptor>({
     kind: "piexec-spawn",
     id,
@@ -273,7 +274,7 @@ function piexecSpawn(
 }
 
 function piexecStop(controllerInstanceId: string, sessionId: string): Promise<string> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<string>({
     kind: "piexec-stop",
     id,
@@ -285,7 +286,7 @@ function piexecStop(controllerInstanceId: string, sessionId: string): Promise<st
 function piexecList(
   controllerInstanceId: string,
 ): Promise<PiExecSessionSummary[]> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<PiExecSessionSummary[]>({
     kind: "piexec-list",
     id,
@@ -297,7 +298,7 @@ function ccexecSpawn(
   controllerInstanceId: string,
   spec: CcExecSpawnSpec,
 ): Promise<CcExecSpawnDescriptor> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<CcExecSpawnDescriptor>({
     kind: "ccexec-spawn",
     id,
@@ -307,7 +308,7 @@ function ccexecSpawn(
 }
 
 function ccexecStop(controllerInstanceId: string, sessionId: string): Promise<string> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<string>({
     kind: "ccexec-stop",
     id,
@@ -319,7 +320,7 @@ function ccexecStop(controllerInstanceId: string, sessionId: string): Promise<st
 function ccexecList(
   controllerInstanceId: string,
 ): Promise<CcExecSessionSummary[]> {
-  const id = crypto.randomUUID();
+  const id = randomUUID();
   return controlRequest<CcExecSessionSummary[]>({
     kind: "ccexec-list",
     id,

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -71,3 +71,13 @@ export const piexecControllers = computed<DiscoveredAgentDTO[]>(() =>
 export const piexecSessions = computed<DiscoveredAgentDTO[]>(() =>
   agentsState.list.filter((a) => a.metadata?.["spawner"] === "pi-headless"),
 );
+
+/** Discovered claude-code-headless controllers (agents flagged via `metadata.role`). */
+export const ccexecControllers = computed<DiscoveredAgentDTO[]>(() =>
+  agentsState.list.filter((a) => a.metadata?.["role"] === "claude-code-headless-controller"),
+);
+
+/** Discovered claude-code-headless sessions (spawned by a controller; identified via `metadata.spawner`). */
+export const ccexecSessions = computed<DiscoveredAgentDTO[]>(() =>
+  agentsState.list.filter((a) => a.metadata?.["spawner"] === "claude-code-headless"),
+);

--- a/examples/agent-web-ui/src/stores/ccexec.ts
+++ b/examples/agent-web-ui/src/stores/ccexec.ts
@@ -1,0 +1,84 @@
+// Reactive state for the CC-Exec workspace (claude-code-headless control plane).
+//
+// Mirrors the shape of `piexec.ts` but typed for claude-code-headless: spawn
+// descriptors / session summaries carry CC-specific fields (allowed_tools,
+// permission_mode, max_turns) instead of PI's thinking_level. Discovery and
+// chat surface remain shared with the rest of the UI; only the spawn / list /
+// stop endpoints are CC-specific.
+
+import { computed, reactive } from "vue";
+import { ccexecControllers, ccexecSessions } from "./agents.ts";
+import type {
+  CcExecSessionSummary,
+  CcExecSpawnDescriptor,
+} from "../wire.ts";
+
+export const ccexecState = reactive<{
+  selectedControllerId: string | null;
+  summaries: Map<string, CcExecSessionSummary>; // keyed by session_id
+  refreshing: boolean;
+  lastError: string | null;
+}>({
+  selectedControllerId: null,
+  summaries: new Map(),
+  refreshing: false,
+  lastError: null,
+});
+
+export const selectedCcController = computed(() => {
+  const id = ccexecState.selectedControllerId;
+  if (!id) return null;
+  return ccexecControllers.value.find((a) => a.instanceId === id) ?? null;
+});
+
+/** Auto-select the first controller if none is picked yet. */
+export function autoPickCcController(): void {
+  if (ccexecState.selectedControllerId) {
+    const still = ccexecControllers.value.some(
+      (a) => a.instanceId === ccexecState.selectedControllerId,
+    );
+    if (still) return;
+  }
+  const first = ccexecControllers.value[0];
+  ccexecState.selectedControllerId = first?.instanceId ?? null;
+}
+
+/**
+ * Sessions that belong to the selected controller's owner+agent tuple. Derived
+ * live from `agentsState` so heartbeat liveness stays accurate even between
+ * explicit `list` refreshes.
+ */
+export const visibleCcSessions = computed(() => {
+  const controller = selectedCcController.value;
+  if (!controller) return [];
+  return ccexecSessions.value.filter((a) => a.owner === controller.owner);
+});
+
+export function mergeCcSummaries(sessions: ReadonlyArray<CcExecSessionSummary>): void {
+  const next = new Map<string, CcExecSessionSummary>();
+  for (const s of sessions) next.set(s.session_id, s);
+  ccexecState.summaries = next;
+}
+
+export function onCcSpawned(descriptor: CcExecSpawnDescriptor): void {
+  ccexecState.summaries.set(descriptor.session_id, {
+    session_id: descriptor.session_id,
+    subject: descriptor.subject,
+    heartbeat_subject: descriptor.heartbeat_subject,
+    cwd: descriptor.cwd,
+    model: descriptor.model,
+    allowed_tools: descriptor.allowed_tools,
+    permission_mode: descriptor.permission_mode,
+    max_turns: descriptor.max_turns,
+    max_lifetime_s: descriptor.max_lifetime_s,
+    remaining_lifetime_s: descriptor.max_lifetime_s,
+    active_request: false,
+    queued_requests: 0,
+    created_at: descriptor.created_at,
+    last_activity: descriptor.created_at,
+  });
+}
+
+export function onCcStopped(sessionId: string): void {
+  ccexecState.summaries.delete(sessionId);
+}

--- a/examples/agent-web-ui/src/stores/ccexec.ts
+++ b/examples/agent-web-ui/src/stores/ccexec.ts
@@ -76,7 +76,16 @@ export function onCcSpawned(descriptor: CcExecSpawnDescriptor): void {
     queued_requests: 0,
     created_at: descriptor.created_at,
     last_activity: descriptor.created_at,
+    total_cost_usd: descriptor.total_cost_usd,
+    turn_count: descriptor.turn_count,
   });
+}
+
+/** Update the summary's running cost as `cost` events stream in for a session. */
+export function bumpCcSessionCost(sessionId: string, totalCostUsd: number): void {
+  const s = ccexecState.summaries.get(sessionId);
+  if (!s) return;
+  s.total_cost_usd = totalCostUsd;
 }
 
 export function onCcStopped(sessionId: string): void {

--- a/examples/agent-web-ui/src/stores/chat.ts
+++ b/examples/agent-web-ui/src/stores/chat.ts
@@ -1,7 +1,17 @@
 import { reactive } from "vue";
 import type { WireAttachment } from "../wire.ts";
 
-export type MessageRole = "user" | "agent" | "query";
+export type MessageRole = "user" | "agent" | "query" | "tool";
+
+export type ToolCallInfo = {
+  /** Stable id assigned by the agent's SDK; same id will appear on the result. */
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+  /** Result text, populated when the matching tool_result chunk arrives. */
+  result?: string;
+  isError?: boolean;
+};
 
 export type Message = {
   id: string;
@@ -17,6 +27,10 @@ export type Message = {
   promptId?: string;
   replied?: boolean;
   replyValue?: string;
+  // Populated on role === "tool" only.
+  tool?: ToolCallInfo;
+  // Optional per-turn cost annotation, set on the agent bubble that closed the turn.
+  costUsd?: number;
 };
 
 export type Session = {
@@ -48,6 +62,11 @@ export function appendMessage(instanceId: string, msg: Message): Message {
 
 export function findMessage(instanceId: string, id: string): Message | undefined {
   return getSession(instanceId).messages.find((m) => m.id === id);
+}
+
+/** Locate a tool message by its agent-assigned tool_use id (used to pair results). */
+export function findMessageByToolId(instanceId: string, toolUseId: string): Message | undefined {
+  return getSession(instanceId).messages.find((m) => m.role === "tool" && m.tool?.id === toolUseId);
 }
 
 export function clearSession(instanceId: string): void {

--- a/examples/agent-web-ui/src/uuid.ts
+++ b/examples/agent-web-ui/src/uuid.ts
@@ -1,0 +1,19 @@
+// Polyfill for `crypto.randomUUID()` in non-secure HTTP contexts.
+//
+// Browsers expose `crypto.randomUUID()` only in secure contexts — HTTPS or
+// `localhost`. When this UI is served over plain HTTP to a non-localhost
+// host (e.g. `http://tux64.lan:5173/`), the native call throws. The
+// `crypto.getRandomValues()` API IS available in all contexts, so we
+// generate an RFC 4122 v4 UUID by hand when the native call is missing.
+
+export function randomUUID(): string {
+  const c = globalThis.crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  const bytes = new Uint8Array(16);
+  c.getRandomValues(bytes);
+  // RFC 4122 §4.4: set version bits to 0100 on byte 6, variant to 10 on byte 8.
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}

--- a/examples/claude-code-headless/LICENSE
+++ b/examples/claude-code-headless/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Synadia Communications
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -8,7 +8,7 @@ In short: one process, many Claude Code sessions, all first-class NATS agents.
 
 This example is the Claude Code analogue of [`examples/pi-headless/`](../pi-headless) and is wire-compatible with the same callers — including the [`examples/agent-web-ui/`](../agent-web-ui) browser workspace.
 
-> **Status.** Spike example proving multi-session Claude Code can be fronted by the protocol. Surfaces only the assistant's text output today (tool calls / permission queries are not yet relayed as protocol §7 query chunks). See **Roadmap** below.
+> **Status.** Demo-quality reference. Streams text per-token, surfaces tool calls + results inline, asks for permission via protocol §7 query chunks, and tracks cost per session. See **Features** below for the wire shapes; **Roadmap** for what's still ahead.
 
 ## Quickstart
 
@@ -206,14 +206,60 @@ Session prompt endpoints follow protocol §9.
 - **Session resumption.** Each prompt after the first is sent to the SDK with `resume: <sdkSessionId>` so context carries forward within a session for its full lifetime.
 - **Lifetime & pruning.** `max_lifetime_s` bounds a session's wall-clock life; pending requests older than 30 min are evicted (active requests are never evicted).
 - **Attachments.** Base64 attachments are decoded to `~/.claude-code-headless/attachments/<session_id>/<uuid>/` and their absolute paths are prepended to the prompt text, matching the staging pattern used by `agents/pi/` and `examples/pi-headless/`.
+- **Tool-call payload sizes.** Tool result outputs are truncated to 4 KB before encoding into a status chunk to stay well under `max_payload`. The truncation marker is `…[truncated]`.
+- **Permission timeout.** A pending §7 permission query is denied after 2 minutes of caller silence, so a vanished UI doesn't park a session forever.
+
+## Features
+
+What this example showcases beyond the bare wire-compat proof:
+
+### Per-token streaming
+
+The SDK's `includePartialMessages` option is on — text deltas arrive as they're generated and are forwarded as individual `response` chunks. Web-UI clients see Claude "type" in real time instead of a wall of text per turn. No knob, no opt-in; it's the default.
+
+### Tool-call observability
+
+Every `tool_use` block Claude emits is forwarded as a status chunk with a prefix-tagged JSON payload:
+
+```
+{"type": "status", "data": "tool_use:{\"id\":\"...\",\"name\":\"Bash\",\"input\":{\"command\":\"ls /tmp\"}}"}
+```
+
+Tool results come back the same way:
+
+```
+{"type": "status", "data": "tool_result:{\"tool_use_id\":\"...\",\"output\":\"file1\\nfile2\",\"is_error\":false}"}
+```
+
+Encoding inside `status.data` keeps the wire spec-compliant (§6.4 says `data` is a string). SDK callers that don't recognize the prefix just see opaque status tokens; the agent-web-ui bridge translates them into typed events and renders them as collapsible tool cards.
+
+### Interactive permissions via §7 queries
+
+When the spawn spec uses `permission_mode: "default"` (or any mode other than `dontAsk`/`bypassPermissions`), the SDK calls our `canUseTool` callback for each tool not already in `allowed_tools`. We turn each call into a protocol §7 query chunk:
+
+```
+{"type": "query", "data": {"id": "...", "reply_subject": "...", "prompt": "Claude wants to use tool: Bash\n{\"command\":\"ls /tmp\"}\n\nReply 'yes' to allow or 'no' to deny."}}
+```
+
+Then we wait (up to 2 minutes) for a single reply on `reply_subject`. The reply text is normalised: `yes/y/allow/approve/ok` → allow, `no/n/deny/reject/cancel` → deny, anything else → deny with the reply preserved as the reason. The SDK proceeds (or doesn't) based on what the user answered.
+
+### Cost tracking
+
+Each successful turn emits a final `cost` status chunk with the per-turn and cumulative costs:
+
+```
+{"type": "status", "data": "cost:{\"turn_cost_usd\":0.0123,\"total_cost_usd\":0.0456}"}
+```
+
+Both values flow into the session summary (`total_cost_usd`, `turn_count`) and the UI surfaces them on each agent bubble (per-turn) and the session-list card (running total).
 
 ## Roadmap
 
-This spike intentionally ships the smallest end-to-end loop. Likely next steps, roughly in priority order:
+What's still ahead, roughly in priority order:
 
-1. **Stream tool calls / permission queries as protocol §7 chunks.** Today only assistant text is forwarded; tool_use blocks and permission decisions are filtered out.
-2. **Per-token streaming** via the SDK's partial-message option, so the response arrives chunk-by-chunk instead of one assistant message at a time.
-3. **Programmatic MCP server attachment** through the spawn spec (`mcp_servers` field).
-4. **System prompt / append-system-prompt** override per spawn.
-5. **Cost tracking** — surface `total_cost_usd` from each `result` event in the session summary.
-6. **Session-file cleanup** — periodic pruning of the SDK's on-disk session store so a long-running host doesn't accumulate state forever.
+1. **Programmatic MCP server attachment** through the spawn spec (`mcp_servers` field) — bring your own tools per session.
+2. **System prompt / append-system-prompt** override per spawn — useful for personas (code reviewer, test writer, security auditor, …).
+3. **"Always allow" stickiness for permissions** — the SDK exposes `updatedPermissions` on the canUseTool result; we currently ignore it. Wiring it would let users approve once per tool/per session.
+4. **Tool result truncation policy** — we cap result output at 4 KB to keep payloads manageable; for large outputs (file dumps, build logs) a streaming or paginated approach would be nicer than `…[truncated]`.
+5. **Session-file cleanup** — periodic pruning of the SDK's on-disk session store so a long-running host doesn't accumulate state forever.
+6. **Bedrock / Vertex / Azure auth ergonomics** — works today via the SDK's standard env vars but undocumented here; could surface in config + status badge.

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -58,7 +58,8 @@ Optional defaults live in `~/.claude-code-headless/config.json`:
   "defaultPermissionMode": "dontAsk",
   "defaultAllowedTools": ["Read", "Glob", "Grep"],
   "defaultMaxTurns": 50,
-  "defaultMaxLifetimeS": 1800
+  "defaultMaxLifetimeS": 1800,
+  "claudeCodePath": "/home/you/.local/bin/claude"
 }
 ```
 
@@ -70,6 +71,23 @@ Env overrides:
 - `CLAUDE_CODE_HEADLESS_DEFAULT_ALLOWED_TOOLS` (comma-separated)
 - `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_TURNS`
 - `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_LIFETIME`
+- `CLAUDE_CODE_HEADLESS_CLAUDE_PATH`
+
+CLI flag: `--claude-code-path /abs/path/to/claude` (alias `--claude-path`).
+
+### Claude Code binary
+
+The Claude Agent SDK ships per-platform native binaries via optional npm packages, but auto-detection sometimes picks a variant that isn't installed (e.g. `linux-x64-musl` on glibc machines). When that happens you'll see `Claude Code native binary not found at .../claude-agent-sdk-<platform>/claude` on the first spawn.
+
+This entry point side-steps that by resolving an explicit path on startup, in priority order:
+
+1. `--claude-code-path` CLI flag
+2. `CLAUDE_CODE_HEADLESS_CLAUDE_PATH` env var
+3. `claudeCodePath` field in `~/.claude-code-headless/config.json`
+4. Auto-detected via `which claude` on PATH (typically the binary installed by the official Claude Code installer at `~/.local/bin/claude`)
+5. None of the above → the SDK falls back to its bundled native binary, which is where the failure mode above shows up
+
+The active path is logged at startup. If you need to override it, the CLI flag is the quickest route.
 
 ### Anthropic auth
 

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -1,0 +1,192 @@
+# claude-code-headless
+
+A headless NATS agent host that spawns [Claude Code](https://docs.claude.com/en/docs/claude-code) sessions on demand via the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) and exposes each one as a first-class NATS Agent Protocol v0.2.0-draft instance.
+
+Each spawned session registers as its own NATS agent under `agents.cc.<owner>.<session_id>` — discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.cc.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle — `spawn`, `stop`, `list` — alongside the protocol-required `prompt` endpoint (which returns help text).
+
+In short: one process, many Claude Code sessions, all first-class NATS agents.
+
+This example is the Claude Code analogue of [`examples/pi-headless/`](../pi-headless) and is wire-compatible with the same callers — including the [`examples/agent-web-ui/`](../agent-web-ui) browser workspace.
+
+> **Status.** Spike example proving multi-session Claude Code can be fronted by the protocol. Surfaces only the assistant's text output today (tool calls / permission queries are not yet relayed as protocol §7 query chunks). See **Roadmap** below.
+
+## Quickstart
+
+```bash
+# 1. Build the SDK once (workspace sibling, referenced via file:).
+cd ../../client-sdk/typescript
+bun install
+bun run build
+
+# 2. Install + run claude-code-headless.
+cd ../../examples/claude-code-headless
+bun install
+export ANTHROPIC_API_KEY=sk-...                  # required
+bun run start                                    # connects via $NATS_CONTEXT or NATS_URL
+# claude-code-headless: controller listening on agents.cc.<you>.exec
+# claude-code-headless: extra endpoints — …exec.spawn  …exec.stop  …exec.list
+
+# 3. Spawn a session + prompt + stop, from another shell.
+bun run scripts/spawn.ts \
+  --cwd /tmp/cc-sandbox \
+  --prompt "list the files here and tell me what you see" \
+  --allowed-tools "Read,Glob,Grep" \
+  --stop-after
+```
+
+## Configuration
+
+Either a NATS [context](https://docs.nats.io/using-nats/nats-tools/nats_cli/context) or an explicit URL:
+
+```bash
+NATS_CONTEXT=localhost bun run start
+# or
+NATS_URL=nats://127.0.0.1:4222 bun run start
+# or
+bun run start --context localhost
+```
+
+Optional defaults live in `~/.claude-code-headless/config.json`:
+
+```json
+{
+  "context": "localhost",
+  "name": "exec",
+  "defaultModel": "claude-sonnet-4-6",
+  "defaultPermissionMode": "dontAsk",
+  "defaultAllowedTools": ["Read", "Glob", "Grep"],
+  "defaultMaxTurns": 50,
+  "defaultMaxLifetimeS": 1800
+}
+```
+
+Env overrides:
+- `CLAUDE_CODE_HEADLESS_OWNER`
+- `CLAUDE_CODE_HEADLESS_NAME`
+- `CLAUDE_CODE_HEADLESS_DEFAULT_MODEL`
+- `CLAUDE_CODE_HEADLESS_DEFAULT_PERMISSION_MODE`
+- `CLAUDE_CODE_HEADLESS_DEFAULT_ALLOWED_TOOLS` (comma-separated)
+- `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_TURNS`
+- `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_LIFETIME`
+
+Anthropic auth comes from `ANTHROPIC_API_KEY` (the standard SDK env var). Bedrock / Vertex deployments work too — set the SDK's standard provider env vars before launch.
+
+### Defaults rationale
+
+The out-of-the-box defaults are deliberately conservative for a public reference:
+
+| Setting | Default | Why |
+| --- | --- | --- |
+| `permission_mode` | `dontAsk` | Deterministic, headless-friendly. Never hangs on a permission prompt. Anything not in `allowed_tools` is denied. |
+| `allowed_tools` | `["Read", "Glob", "Grep"]` | Read-only out of the box. Callers expand per-spawn for write/edit/bash. |
+| `model` | `claude-sonnet-4-6` | Right cost/quality balance for a per-request spawner. |
+| `max_turns` | `50` | Safety cap — runaway loops fail visibly instead of silently. |
+| `max_lifetime_s` | `1800` | Sessions auto-expire after 30 min unless overridden. |
+
+## Subject layout
+
+```
+agents.cc.<owner>.<name>                    ← controller prompt endpoint (help text)
+agents.cc.<owner>.<name>.spawn              ← POST JSON → session descriptor
+agents.cc.<owner>.<name>.stop               ← POST { session_id } → { ok: true }
+agents.cc.<owner>.<name>.list               ← (empty) → { sessions: [...] }
+agents.cc.<owner>.<name>.heartbeat          ← §8 heartbeat (30s)
+
+agents.cc.<owner>.<session_id>              ← spawned session prompt (§5/§6)
+agents.cc.<owner>.<session_id>.heartbeat    ← §8 heartbeat (30s)
+```
+
+The `cc` token is shared with [`agents/claude-code/`](../../agents/claude-code), which speaks the inverse direction (Claude Code as MCP-driven NATS *client*). They co-exist because the controller name and per-session ids disambiguate the 4th subject token.
+
+## Wire examples
+
+### Spawn
+
+```bash
+nats req agents.cc.$USER.exec.spawn \
+  '{"cwd":"/tmp/cc-sandbox","model":"claude-sonnet-4-6","allowed_tools":["Read","Glob","Grep","Edit"],"permission_mode":"acceptEdits","max_lifetime_s":900}' \
+  --timeout=15s
+# → { "session_id":"sess-a1b2c3d4", "subject":"agents.cc.$USER.sess-a1b2c3d4", ... }
+```
+
+### Prompt (protocol-standard — no custom format)
+
+```bash
+nats req agents.cc.$USER.sess-a1b2c3d4 \
+  'list the files here and summarise what you see' --replies=0 --timeout=120s
+# → {"type":"status","data":"ack"}
+# → {"type":"response","data":"There are three files: …"}
+# → (empty terminator)
+```
+
+Programmatically with the SDK:
+
+```ts
+import { connect } from "@nats-io/transport-node";
+import { Agents } from "@synadia-ai/agents";
+
+const nc = await connect({ servers: "nats://localhost:4222" });
+const agents = new Agents({ nc });
+
+const all = await agents.discover();
+const session = all.find((a) => a.name === "sess-a1b2c3d4")!;
+for await (const ev of await session.prompt("summarise the files here")) {
+  if (ev.type === "response") process.stdout.write(ev.text);
+}
+
+await agents.close();
+await nc.close();
+```
+
+### Stop
+
+```bash
+nats req agents.cc.$USER.exec.stop '{"session_id":"sess-a1b2c3d4"}'
+# → { "ok": true, "session_id":"sess-a1b2c3d4" }
+```
+
+### List
+
+```bash
+nats req agents.cc.$USER.exec.list ''
+# → { "sessions": [ { "session_id":"sess-a1b2c3d4", "cwd":"/tmp/cc-sandbox", "remaining_lifetime_s": 867, ... } ] }
+```
+
+## Errors
+
+Custom endpoints respond with NATS micro-service error headers (`Nats-Service-Error-Code` / `Nats-Service-Error`):
+
+| Code | When                                                                                          |
+|------|-----------------------------------------------------------------------------------------------|
+| 400  | Bad JSON, missing/invalid cwd, bad session_id, unknown permission_mode, bad allowed_tools     |
+| 404  | `stop` for an unknown session                                                                 |
+| 500  | Claude Agent SDK threw during a prompt turn                                                   |
+
+Session prompt endpoints follow protocol §9.
+
+## CLI helpers
+
+- `bun run scripts/spawn.ts --cwd /path [--prompt …] [--stop-after]` — end-to-end smoke test.
+- `bun run scripts/list.ts` — print active sessions from every reachable controller.
+- `bun run scripts/stop.ts SESSION_ID` — dispose a session.
+
+## Notes
+
+- **Session identity.** The 4th subject token is the session id; `metadata.session` echoes it. Controllers use `name = "exec"` by default.
+- **Metadata marker.** The controller carries `metadata.role = "claude-code-headless-controller"` so clients can tell it apart from other `cc` agents.
+- **One controller per `(owner, name)`.** The custom `spawn` / `stop` / `list` endpoints are NATS micro-service endpoints, which load-balance across all instances sharing the same subject. If you need multiple controllers side-by-side, give each one a distinct `--name` (e.g. `--name exec-a`, `--name exec-b`).
+- **Serial drain per session.** Per session, prompts are queued and processed one at a time; the Claude Agent SDK's `query()` is one full multi-turn round-trip per call, and concurrent re-entry into the same session would interleave context.
+- **Session resumption.** Each prompt after the first is sent to the SDK with `resume: <sdkSessionId>` so context carries forward within a session for its full lifetime.
+- **Lifetime & pruning.** `max_lifetime_s` bounds a session's wall-clock life; pending requests older than 30 min are evicted (active requests are never evicted).
+- **Attachments.** Base64 attachments are decoded to `~/.claude-code-headless/attachments/<session_id>/<uuid>/` and their absolute paths are prepended to the prompt text, matching the staging pattern used by `agents/pi/` and `examples/pi-headless/`.
+
+## Roadmap
+
+This spike intentionally ships the smallest end-to-end loop. Likely next steps, roughly in priority order:
+
+1. **Stream tool calls / permission queries as protocol §7 chunks.** Today only assistant text is forwarded; tool_use blocks and permission decisions are filtered out.
+2. **Per-token streaming** via the SDK's partial-message option, so the response arrives chunk-by-chunk instead of one assistant message at a time.
+3. **Programmatic MCP server attachment** through the spawn spec (`mcp_servers` field).
+4. **System prompt / append-system-prompt** override per spawn.
+5. **Cost tracking** — surface `total_cost_usd` from each `result` event in the session summary.
+6. **Session-file cleanup** — periodic pruning of the SDK's on-disk session store so a long-running host doesn't accumulate state forever.

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -21,9 +21,7 @@ bun run build
 # 2. Install + run claude-code-headless.
 cd ../../examples/claude-code-headless
 bun install
-# Anthropic auth: either of these works (see "Anthropic auth" below).
-#   export ANTHROPIC_API_KEY=sk-...
-#   ...OR you've already run `claude login` on this machine.
+export ANTHROPIC_API_KEY=sk-...
 bun run start                                    # connects via $NATS_CONTEXT or NATS_URL
 # claude-code-headless: controller listening on agents.cc.<you>.exec
 # claude-code-headless: extra endpoints — …exec.spawn  …exec.stop  …exec.list
@@ -91,12 +89,9 @@ The active path is logged at startup. If you need to override it, the CLI flag i
 
 ### Anthropic auth
 
-Two paths work — pick whichever fits the deployment:
+Set `ANTHROPIC_API_KEY` in env before launching. The SDK uses the API key in preference to any `~/.claude/` credentials when both are present.
 
-- **Local OAuth (subscription).** If you've already run `claude login` on this machine, the Claude Agent SDK picks up your subscription credentials from `~/.claude` automatically — no env var needed. Best for laptop / single-user dev. Sessions are billed against your subscription and rate-limited by your subscription tier.
-- **`ANTHROPIC_API_KEY` (API account).** Required for unattended / server deployments where there's no `claude login` flow. Set it in env before launch. Takes precedence over OAuth when both are configured. Sessions are billed against the API account.
-
-Bedrock / Vertex deployments work too — set the SDK's standard provider env vars before launch (`CLAUDE_CODE_USE_BEDROCK=1` etc).
+Bedrock / Vertex / Azure deployments work too — set the SDK's standard provider env vars (`CLAUDE_CODE_USE_BEDROCK=1` etc) and they take precedence.
 
 ### Defaults rationale
 

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -21,7 +21,9 @@ bun run build
 # 2. Install + run claude-code-headless.
 cd ../../examples/claude-code-headless
 bun install
-export ANTHROPIC_API_KEY=sk-...                  # required
+# Anthropic auth: either of these works (see "Anthropic auth" below).
+#   export ANTHROPIC_API_KEY=sk-...
+#   ...OR you've already run `claude login` on this machine.
 bun run start                                    # connects via $NATS_CONTEXT or NATS_URL
 # claude-code-headless: controller listening on agents.cc.<you>.exec
 # claude-code-headless: extra endpoints — …exec.spawn  …exec.stop  …exec.list
@@ -69,7 +71,14 @@ Env overrides:
 - `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_TURNS`
 - `CLAUDE_CODE_HEADLESS_DEFAULT_MAX_LIFETIME`
 
-Anthropic auth comes from `ANTHROPIC_API_KEY` (the standard SDK env var). Bedrock / Vertex deployments work too — set the SDK's standard provider env vars before launch.
+### Anthropic auth
+
+Two paths work — pick whichever fits the deployment:
+
+- **Local OAuth (subscription).** If you've already run `claude login` on this machine, the Claude Agent SDK picks up your subscription credentials from `~/.claude` automatically — no env var needed. Best for laptop / single-user dev. Sessions are billed against your subscription and rate-limited by your subscription tier.
+- **`ANTHROPIC_API_KEY` (API account).** Required for unattended / server deployments where there's no `claude login` flow. Set it in env before launch. Takes precedence over OAuth when both are configured. Sessions are billed against the API account.
+
+Bedrock / Vertex deployments work too — set the SDK's standard provider env vars before launch (`CLAUDE_CODE_USE_BEDROCK=1` etc).
 
 ### Defaults rationale
 

--- a/examples/claude-code-headless/bun.lock
+++ b/examples/claude-code-headless/bun.lock
@@ -1,0 +1,253 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@synadia-ai/nats-claude-code-headless",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "latest",
+        "@nats-io/services": "^3.3.1",
+        "@nats-io/transport-node": "^3.3.1",
+        "@synadia-ai/agents": "^0.1.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.119", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119", "", { "os": "darwin", "cpu": "x64" }, "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119", "", { "os": "linux", "cpu": "x64" }, "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119", "", { "os": "linux", "cpu": "x64" }, "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119", "", { "os": "win32", "cpu": "arm64" }, "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119", "", { "os": "win32", "cpu": "x64" }, "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@nats-io/nats-core": ["@nats-io/nats-core@3.3.1", "", { "dependencies": { "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "2.0.3" } }, "sha512-myFXGTo4cCfKrsLDjkoEz7FjjjvSfBRjun7Qx3n3Z5OzW4JUY8Ou7VQsGAdXLQxHN3ae/XNXvmXxshDoFPex4w=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
+
+    "@nats-io/nuid": ["@nats-io/nuid@2.0.3", "", {}, "sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew=="],
+
+    "@nats-io/services": ["@nats-io/services@3.3.1", "", { "dependencies": { "@nats-io/nats-core": "3.3.1" } }, "sha512-beAwjir4HmluuU1mN3Rt6LMUxUsLH6Vb2KBl8wVpjFFhD1awFevVOeuZrQNnu8WXr8sQ8LXzb03/JN3uXCZ74Q=="],
+
+    "@nats-io/transport-node": ["@nats-io/transport-node@3.3.1", "", { "dependencies": { "@nats-io/nats-core": "3.3.1", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "2.0.3" } }, "sha512-GBvY0VcvyQEILgy5bjpqU1GpDYmSF06bW59I7cewZuNGS9u3AoV/gf+a+3ep45T/Z+UC661atq/b7x+QV12w+Q=="],
+
+    "@synadia-ai/agents": ["@synadia-ai/agents@0.1.1", "", { "dependencies": { "@nats-io/nats-core": "^3.3.0", "@nats-io/services": "^3.3.0", "@nats-io/transport-node": "^3.3.0" } }, "sha512-+P6vsNZcgr2J8UuVCIZi8hOja7yBir9UT+bPL/h1NRDbkktPsC6IGbvxvQTM7fIPQqtbgnfM7IHhxxCLtlQSrw=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/examples/claude-code-headless/package.json
+++ b/examples/claude-code-headless/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@synadia-ai/nats-claude-code-headless",
+  "version": "0.1.0",
+  "description": "Headless NATS agent host that spawns, prompts, and stops Claude Code sessions as first-class NATS Agent Protocol (v0.2.0-draft) instances. Each session registers as agents.cc.<owner>.<session_id>; a small controller service adds spawn/stop/list custom endpoints.",
+  "keywords": [
+    "nats",
+    "agents",
+    "agent-protocol",
+    "claude",
+    "claude-code",
+    "anthropic",
+    "synadia-agents"
+  ],
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "examples/claude-code-headless"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/examples/claude-code-headless",
+  "bugs": {
+    "url": "https://github.com/synadia-ai/synadia-agents/issues"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "type": "module",
+  "files": [
+    "src",
+    "scripts",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "@nats-io/services": "^3.3.1",
+    "@nats-io/transport-node": "^3.3.1",
+    "@synadia-ai/agents": "^0.1.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/claude-code-headless/scripts/_common.ts
+++ b/examples/claude-code-headless/scripts/_common.ts
@@ -1,0 +1,161 @@
+// Small shared helpers for the CLI scripts. Not exported publicly.
+
+import { connect as natsConnect } from "@nats-io/transport-node";
+import type { NatsConnection } from "@nats-io/nats-core";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import { Agents, loadContextOptions, type Agent } from "@synadia-ai/agents";
+
+export interface CliArgs {
+  readonly context?: string;
+  readonly natsUrl?: string;
+  readonly owner?: string;
+  readonly name?: string; // controller name, default "exec"
+  readonly rest: ReadonlyMap<string, string>;
+  readonly positional: ReadonlyArray<string>;
+}
+
+export function parseArgs(argv: ReadonlyArray<string>): CliArgs {
+  const rest = new Map<string, string>();
+  const positional: string[] = [];
+  let context: string | undefined;
+  let natsUrl: string | undefined;
+  let owner: string | undefined;
+  let name: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg) continue;
+    if (!arg.startsWith("--")) {
+      positional.push(arg);
+      continue;
+    }
+    let key: string;
+    let value: string | undefined;
+    const eq = arg.indexOf("=");
+    if (eq >= 0) {
+      key = arg.slice(2, eq);
+      value = arg.slice(eq + 1);
+    } else {
+      key = arg.slice(2);
+      value = argv[i + 1];
+      if (value !== undefined && value.startsWith("--")) value = undefined;
+      else if (value !== undefined) i += 1;
+    }
+    if (value === undefined) {
+      rest.set(key, "true");
+      continue;
+    }
+    switch (key) {
+      case "context":
+        context = value;
+        break;
+      case "url":
+      case "nats-url":
+        natsUrl = value;
+        break;
+      case "owner":
+        owner = value;
+        break;
+      case "name":
+        name = value;
+        break;
+      default:
+        rest.set(key, value);
+    }
+  }
+  return {
+    ...(context ? { context } : {}),
+    ...(natsUrl ? { natsUrl } : {}),
+    ...(owner ? { owner } : {}),
+    ...(name ? { name } : {}),
+    rest,
+    positional,
+  };
+}
+
+export async function openNats(args: CliArgs): Promise<NatsConnection> {
+  const context = args.context ?? process.env["NATS_CONTEXT"];
+  const url = args.natsUrl ?? process.env["NATS_URL"];
+  let opts: NodeConnectionOptions;
+  if (context) {
+    opts = { ...(await loadContextOptions(context)), name: "claude-code-headless-cli" };
+  } else if (url) {
+    opts = { servers: url, name: "claude-code-headless-cli" };
+  } else {
+    throw new Error("provide --context or --url (or set NATS_CONTEXT / NATS_URL)");
+  }
+  return natsConnect(opts);
+}
+
+export function ownerFilter(args: CliArgs): string {
+  return args.owner ?? process.env["USER"] ?? "";
+}
+
+export function nameFilter(args: CliArgs): string {
+  return args.name ?? "exec";
+}
+
+export async function findController(agents: Agents, args: CliArgs): Promise<Agent> {
+  const found = await agents.discover();
+  const owner = ownerFilter(args);
+  const name = nameFilter(args);
+  const candidates = found.filter((a) => {
+    if (a.agent !== "cc") return false;
+    if (a.metadata["role"] !== "claude-code-headless-controller") return false;
+    if (owner && a.owner !== owner) return false;
+    if (name && a.name !== name) return false;
+    return true;
+  });
+  if (candidates.length === 0) {
+    throw new Error(
+      `no claude-code-headless controller found (owner=${owner || "*"} name=${name}). Is it running?`,
+    );
+  }
+  if (candidates.length > 1) {
+    process.stderr.write(
+      `claude-code-headless-cli: ${candidates.length} controllers found; using ${candidates[0]!.instanceId}\n`,
+    );
+  }
+  return candidates[0]!;
+}
+
+export async function waitForSession(
+  agents: Agents,
+  instanceId: string,
+  retries = 10,
+  delayMs = 200,
+): Promise<Agent> {
+  for (let i = 0; i < retries; i++) {
+    const found = await agents.discover();
+    const match = found.find((a) => a.instanceId === instanceId);
+    if (match) return match;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`spawned session ${instanceId} not discoverable after ${retries} tries`);
+}
+
+export interface CliClient {
+  readonly nc: NatsConnection;
+  readonly agents: Agents;
+  close(): Promise<void>;
+}
+
+export async function openCliClient(args: CliArgs): Promise<CliClient> {
+  const nc = await openNats(args);
+  const agents = new Agents({ nc });
+  return {
+    nc,
+    agents,
+    async close() {
+      try {
+        await agents.close();
+      } catch {
+        /* noop */
+      }
+      try {
+        await nc.close();
+      } catch {
+        /* noop */
+      }
+    },
+  };
+}

--- a/examples/claude-code-headless/scripts/list.ts
+++ b/examples/claude-code-headless/scripts/list.ts
@@ -1,0 +1,68 @@
+// CLI helper: list active claude-code-headless sessions on every reachable controller.
+//
+// Usage:
+//   bun run scripts/list.ts [--owner USER] [--name exec]
+//                           [--context demo | --url nats://...]
+
+import process from "node:process";
+
+import { openCliClient, parseArgs, ownerFilter, nameFilter } from "./_common.js";
+
+interface SessionSummary {
+  session_id: string;
+  subject: string;
+  cwd: string;
+  model: string;
+  permission_mode: string;
+  max_lifetime_s: number;
+  remaining_lifetime_s: number;
+  active_request: boolean;
+  queued_requests: number;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const cli = await openCliClient(args);
+  try {
+    const agents = await cli.agents.discover();
+    const owner = ownerFilter(args);
+    const name = nameFilter(args);
+    const controllers = agents.filter(
+      (a) =>
+        a.agent === "cc" &&
+        a.metadata["role"] === "claude-code-headless-controller" &&
+        (!owner || a.owner === owner) &&
+        (!name || a.name === name),
+    );
+    if (controllers.length === 0) {
+      process.stderr.write("no claude-code-headless controllers found\n");
+      process.exit(0);
+    }
+    for (const controller of controllers) {
+      const listSubject = `${controller.promptEndpoint.subject}.list`;
+      const rep = await cli.nc.request(listSubject, "", { timeout: 5_000 });
+      const body = JSON.parse(rep.string()) as { sessions: SessionSummary[] };
+      process.stdout.write(
+        `# ${controller.promptEndpoint.subject} (instance ${controller.instanceId})\n`,
+      );
+      if (body.sessions.length === 0) {
+        process.stdout.write("  (no sessions)\n");
+        continue;
+      }
+      for (const s of body.sessions) {
+        const busy = s.active_request ? "*" : " ";
+        const rem = s.max_lifetime_s === 0 ? "∞" : `${s.remaining_lifetime_s}s`;
+        process.stdout.write(
+          `  ${busy} ${s.session_id}  cwd=${s.cwd}  model=${s.model}  perm=${s.permission_mode}  ttl=${rem}  queued=${s.queued_requests}\n`,
+        );
+      }
+    }
+  } finally {
+    await cli.close();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`claude-code-headless-cli: ${(err as Error).message}\n`);
+  process.exit(1);
+});

--- a/examples/claude-code-headless/scripts/spawn.ts
+++ b/examples/claude-code-headless/scripts/spawn.ts
@@ -1,0 +1,99 @@
+// CLI helper: spawn a claude-code-headless session, optionally send an initial
+// prompt, optionally stop the session after the prompt finishes.
+//
+// Usage:
+//   bun run scripts/spawn.ts --cwd /path [--prompt "..."] [--model claude-sonnet-4-6]
+//                            [--allowed-tools "Read,Glob,Grep,Edit"]
+//                            [--permission-mode "acceptEdits"]
+//                            [--max-turns 50] [--max-lifetime-s 1800]
+//                            [--session-id name] [--stop-after]
+//                            [--context demo | --url nats://...]
+
+import process from "node:process";
+
+import { openCliClient, findController, parseArgs, waitForSession } from "./_common.js";
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const cwd = args.rest.get("cwd");
+  if (!cwd) {
+    process.stderr.write("usage: spawn.ts --cwd PATH [--prompt TEXT] [--stop-after]\n");
+    process.exit(2);
+  }
+
+  const prompt = args.rest.get("prompt");
+  const stopAfter = args.rest.get("stop-after") === "true";
+
+  const spec: Record<string, unknown> = { cwd };
+  const sessionIdArg = args.rest.get("session-id");
+  if (sessionIdArg) spec["session_id"] = sessionIdArg;
+  const model = args.rest.get("model");
+  if (model) spec["model"] = model;
+  const allowedTools = args.rest.get("allowed-tools");
+  if (allowedTools) {
+    spec["allowed_tools"] = allowedTools.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  const permissionMode = args.rest.get("permission-mode");
+  if (permissionMode) spec["permission_mode"] = permissionMode;
+  const maxTurns = args.rest.get("max-turns");
+  if (maxTurns) spec["max_turns"] = Number(maxTurns);
+  const maxLifetime = args.rest.get("max-lifetime-s");
+  if (maxLifetime) spec["max_lifetime_s"] = Number(maxLifetime);
+
+  const cli = await openCliClient(args);
+  try {
+    const controller = await findController(cli.agents, args);
+    const spawnSubject = `${controller.promptEndpoint.subject}.spawn`;
+    process.stderr.write(`claude-code-headless-cli: calling ${spawnSubject}\n`);
+
+    const rep = await cli.nc.request(spawnSubject, JSON.stringify(spec), { timeout: 15_000 });
+    const errCode = rep.headers?.get("Nats-Service-Error-Code");
+    if (errCode) {
+      const errMsg = rep.headers?.get("Nats-Service-Error") ?? "unknown error";
+      process.stderr.write(`spawn failed [${errCode}]: ${errMsg}\n`);
+      process.exit(1);
+    }
+    const descriptor = JSON.parse(rep.string()) as {
+      session_id: string;
+      subject: string;
+      instance_id: string;
+    };
+    process.stderr.write(
+      `claude-code-headless-cli: spawned ${descriptor.session_id} @ ${descriptor.subject}\n`,
+    );
+    process.stdout.write(`${JSON.stringify(descriptor, null, 2)}\n`);
+
+    if (prompt) {
+      const session = await waitForSession(cli.agents, descriptor.instance_id);
+      process.stderr.write(
+        `claude-code-headless-cli: prompting ${session.promptEndpoint.subject}\n`,
+      );
+      const stream = await session.prompt(prompt);
+      for await (const ev of stream) {
+        if (ev.type === "response") {
+          process.stdout.write(ev.text);
+        } else if (ev.type === "status") {
+          process.stderr.write(`[status] ${ev.status}\n`);
+        }
+      }
+      process.stdout.write("\n");
+
+      if (stopAfter) {
+        const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+        await cli.nc.request(
+          stopSubject,
+          JSON.stringify({ session_id: descriptor.session_id }),
+          { timeout: 5_000 },
+        );
+        process.stderr.write(`claude-code-headless-cli: stopped ${descriptor.session_id}\n`);
+      }
+    }
+  } finally {
+    await cli.close();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`claude-code-headless-cli: ${(err as Error).message}\n`);
+  process.exit(1);
+});

--- a/examples/claude-code-headless/scripts/stop.ts
+++ b/examples/claude-code-headless/scripts/stop.ts
@@ -1,0 +1,43 @@
+// CLI helper: stop a claude-code-headless session.
+//
+// Usage:
+//   bun run scripts/stop.ts SESSION_ID [--owner USER] [--name exec]
+//                                      [--context demo | --url nats://...]
+
+import process from "node:process";
+
+import { openCliClient, findController, parseArgs } from "./_common.js";
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const sessionId = args.positional[0];
+  if (!sessionId) {
+    process.stderr.write("usage: stop.ts SESSION_ID\n");
+    process.exit(2);
+  }
+
+  const cli = await openCliClient(args);
+  try {
+    const controller = await findController(cli.agents, args);
+    const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+    const rep = await cli.nc.request(
+      stopSubject,
+      JSON.stringify({ session_id: sessionId }),
+      { timeout: 5_000 },
+    );
+    const errCode = rep.headers?.get("Nats-Service-Error-Code");
+    if (errCode) {
+      const errMsg = rep.headers?.get("Nats-Service-Error") ?? "unknown error";
+      process.stderr.write(`stop failed [${errCode}]: ${errMsg}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${rep.string()}\n`);
+  } finally {
+    await cli.close();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`claude-code-headless-cli: ${(err as Error).message}\n`);
+  process.exit(1);
+});

--- a/examples/claude-code-headless/src/attachments.ts
+++ b/examples/claude-code-headless/src/attachments.ts
@@ -1,0 +1,73 @@
+// Attachment staging for spawned Claude Code sessions.
+//
+// Each attachment decodes to disk under
+// `~/.claude-code-headless/attachments/<session_id>/<uuid>/<filename>` and
+// the absolute paths are prepended to the prompt text. This mirrors the
+// pattern used by `agents/pi/` and `examples/pi-headless/`.
+
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve as pathResolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ParsedAttachment } from "./envelope.js";
+
+const ROOT = join(homedir(), ".claude-code-headless", "attachments");
+
+export interface StagedAttachmentGroup {
+  /** Absolute directory created for this prompt; safe to delete when done. */
+  readonly dir: string;
+  /** Absolute file paths in order, matching the attachment array. */
+  readonly paths: ReadonlyArray<string>;
+}
+
+export async function stageAttachments(
+  sessionId: string,
+  attachments: ReadonlyArray<ParsedAttachment>,
+): Promise<StagedAttachmentGroup> {
+  const dir = pathResolve(join(ROOT, sessionId, randomUUID()));
+  await mkdir(dir, { recursive: true });
+  const paths: string[] = [];
+  for (const att of attachments) {
+    const safeName = sanitizeFilename(att.filename);
+    const filePath = join(dir, safeName);
+    const bytes = decodeBase64Strict(att.base64);
+    await writeFile(filePath, bytes);
+    paths.push(filePath);
+  }
+  return { dir, paths };
+}
+
+export async function cleanupStaged(group: StagedAttachmentGroup): Promise<void> {
+  try {
+    await rm(group.dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Prepend attachment paths as a simple header block so Claude can reference them. */
+export function decorateWithAttachments(prompt: string, paths: ReadonlyArray<string>): string {
+  if (paths.length === 0) return prompt;
+  const header = [
+    "[Attachments available at the following absolute paths]",
+    ...paths.map((p) => `- ${p}`),
+    "",
+  ].join("\n");
+  return `${header}\n${prompt}`;
+}
+
+// Reject URL-safe base64 / whitespace per §5.2.
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+function decodeBase64Strict(input: string): Uint8Array {
+  if (!BASE64_RE.test(input)) {
+    throw new Error("attachment content is not valid RFC 4648 §4 base64");
+  }
+  return Uint8Array.from(Buffer.from(input, "base64"));
+}
+
+// No path traversal, no separators.
+function sanitizeFilename(name: string): string {
+  const base = name.replace(/[^A-Za-z0-9._-]+/g, "_");
+  return base.replace(/^\.+/, "_").slice(0, 255) || "file";
+}

--- a/examples/claude-code-headless/src/chunk-encoder.ts
+++ b/examples/claude-code-headless/src/chunk-encoder.ts
@@ -1,0 +1,27 @@
+// Typed-chunk helpers for the v0.2.0-draft response wire (§6).
+//
+// Every non-terminating chunk is `{"type": "...", "data": ...}`; the
+// stream ends with an empty-body no-headers message (§6.5). Errors are
+// sent via NATS micro service error headers by the framework
+// (`msg.respondError`) — they don't live in this module.
+
+const encoder = new TextEncoder();
+
+function encodeChunk(type: string, data: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify({ type, data }));
+}
+
+/** §6.4 — request accepted, work in progress; resets caller inactivity timeout. */
+export function statusAck(): Uint8Array {
+  return encodeChunk("status", "ack");
+}
+
+/** Arbitrary status token (SDK callers tolerate unrecognized values). */
+export function status(token: string): Uint8Array {
+  return encodeChunk("status", token);
+}
+
+/** §6.3 — a piece of response text. Multiple `response` chunks concatenate. */
+export function responseText(text: string): Uint8Array {
+  return encodeChunk("response", text);
+}

--- a/examples/claude-code-headless/src/chunk-encoder.ts
+++ b/examples/claude-code-headless/src/chunk-encoder.ts
@@ -47,13 +47,28 @@ export function queryChunk(id: string, replySubject: string, prompt: string): Ui
  * Tool-call observability: a status chunk whose data string is
  * `tool_use:<json>`. The bridge detects the prefix and re-emits as a
  * structured server message; raw SDK callers see it as an opaque token.
+ *
+ * Inputs are bounded the same way `tool_result` outputs are — a Write/Bash
+ * call with a large argument would otherwise blow past the session's
+ * `max_payload` and the chunk would silently drop. When the serialised form
+ * exceeds the cap, swap `input` for a truncation marker that preserves the
+ * record shape so the bridge's parsing stays uniform.
  */
 export function toolUseStatus(
   toolUseId: string,
   name: string,
   input: Record<string, unknown>,
 ): Uint8Array {
-  const payload = JSON.stringify({ id: toolUseId, name, input });
+  const inputJson = JSON.stringify(input);
+  let safeInput: Record<string, unknown> = input;
+  if (inputJson.length > 4_000) {
+    safeInput = {
+      _truncated: true,
+      _original_size_bytes: inputJson.length,
+      _preview: inputJson.slice(0, 1_000) + "…[truncated]",
+    };
+  }
+  const payload = JSON.stringify({ id: toolUseId, name, input: safeInput });
   return encodeChunk("status", `tool_use:${payload}`);
 }
 

--- a/examples/claude-code-headless/src/chunk-encoder.ts
+++ b/examples/claude-code-headless/src/chunk-encoder.ts
@@ -4,6 +4,14 @@
 // stream ends with an empty-body no-headers message (§6.5). Errors are
 // sent via NATS micro service error headers by the framework
 // (`msg.respondError`) — they don't live in this module.
+//
+// In addition to the protocol-standard `status` / `response` / `query`
+// chunks, we encode tool-call observability as **status chunks with a
+// structured prefix in the data string** (`tool_use:<json>` and
+// `tool_result:<json>`). This keeps the wire spec-compliant — `status.data`
+// is a string per §6.4 — while letting our bridge translate the prefix
+// into a richer UI event for the web client. SDK callers that don't know
+// the prefix just see them as opaque status tokens.
 
 const encoder = new TextEncoder();
 
@@ -24,4 +32,58 @@ export function status(token: string): Uint8Array {
 /** §6.3 — a piece of response text. Multiple `response` chunks concatenate. */
 export function responseText(text: string): Uint8Array {
   return encodeChunk("response", text);
+}
+
+/**
+ * §7 — interactive query. The agent emits this and listens on `replySubject`
+ * for a single text reply. Used here to surface SDK `canUseTool` permission
+ * requests so the human caller can approve/deny each tool in flight.
+ */
+export function queryChunk(id: string, replySubject: string, prompt: string): Uint8Array {
+  return encodeChunk("query", { id, reply_subject: replySubject, prompt });
+}
+
+/**
+ * Tool-call observability: a status chunk whose data string is
+ * `tool_use:<json>`. The bridge detects the prefix and re-emits as a
+ * structured server message; raw SDK callers see it as an opaque token.
+ */
+export function toolUseStatus(
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+): Uint8Array {
+  const payload = JSON.stringify({ id: toolUseId, name, input });
+  return encodeChunk("status", `tool_use:${payload}`);
+}
+
+/**
+ * Tool-result observability: a status chunk whose data string is
+ * `tool_result:<json>`. The output is truncated to keep the chunk small
+ * (a giant `cat` result would otherwise blow through max_payload).
+ */
+export function toolResultStatus(
+  toolUseId: string,
+  output: string,
+  isError: boolean,
+): Uint8Array {
+  const truncated = output.length > 4_000 ? output.slice(0, 4_000) + "…[truncated]" : output;
+  const payload = JSON.stringify({
+    tool_use_id: toolUseId,
+    output: truncated,
+    is_error: isError,
+  });
+  return encodeChunk("status", `tool_result:${payload}`);
+}
+
+/**
+ * Cost notification: emitted after each turn completes with the per-turn
+ * and cumulative cost, so the UI can keep a running tally per session.
+ */
+export function costStatus(turnCostUsd: number, totalCostUsd: number): Uint8Array {
+  const payload = JSON.stringify({
+    turn_cost_usd: turnCostUsd,
+    total_cost_usd: totalCostUsd,
+  });
+  return encodeChunk("status", `cost:${payload}`);
 }

--- a/examples/claude-code-headless/src/claude-session-manager.ts
+++ b/examples/claude-code-headless/src/claude-session-manager.ts
@@ -1,0 +1,275 @@
+// Aggregate state + spawn/stop/list operations for all headless Claude Code
+// sessions.
+//
+// Owns the Map<session_id, ManagedSession>, the lifetime-expiry loop, and
+// stale-request pruning. The controller calls through to this.
+
+import { existsSync, statSync } from "node:fs";
+import { resolve as pathResolve } from "node:path";
+
+import type { NatsConnection } from "@nats-io/nats-core";
+import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+
+import { ManagedSession, type SessionSummary } from "./managed-session.js";
+import { generateSessionId, validateSessionId } from "./subjects.js";
+
+const LIFETIME_CHECK_INTERVAL_MS = 30_000;
+const STALE_PRUNE_INTERVAL_MS = 60_000;
+const STALE_REQUEST_CUTOFF_MS = 30 * 60 * 1000;
+
+const VALID_PERMISSION_MODES: ReadonlyArray<PermissionMode> = [
+  "default",
+  "acceptEdits",
+  "bypassPermissions",
+  "plan",
+  "dontAsk",
+  "auto",
+];
+
+export interface SpawnSpec {
+  readonly cwd: string;
+  readonly session_id?: string;
+  readonly model?: string;
+  readonly allowed_tools?: ReadonlyArray<string>;
+  readonly permission_mode?: string;
+  readonly max_turns?: number;
+  readonly max_lifetime_s?: number;
+}
+
+export interface SpawnDescriptor {
+  readonly session_id: string;
+  readonly subject: string;
+  readonly heartbeat_subject: string;
+  readonly cwd: string;
+  readonly model: string;
+  readonly allowed_tools: ReadonlyArray<string>;
+  readonly permission_mode: PermissionMode;
+  readonly max_turns: number;
+  readonly max_lifetime_s: number;
+  readonly created_at: string;
+  readonly instance_id: string;
+}
+
+export type SpawnError =
+  | { code: 400; message: string }
+  | { code: 409; message: string; session_id: string };
+
+export interface ClaudeSessionManagerOptions {
+  readonly nc: NatsConnection;
+  readonly owner: string;
+  readonly defaultModel: string;
+  readonly defaultPermissionMode: string;
+  readonly defaultAllowedTools: ReadonlyArray<string>;
+  readonly defaultMaxTurns: number;
+  readonly defaultMaxLifetimeS: number;
+  readonly logger?: (line: string) => void;
+}
+
+const defaultLogger = (line: string) => process.stderr.write(`${line}\n`);
+
+export class ClaudeSessionManager {
+  private readonly sessions = new Map<string, ManagedSession>();
+  private readonly creating = new Set<string>();
+  private readonly options: ClaudeSessionManagerOptions;
+  private readonly log: (line: string) => void;
+
+  private lifetimeTimer: ReturnType<typeof setInterval> | null = null;
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
+  private stopping = false;
+
+  constructor(options: ClaudeSessionManagerOptions) {
+    this.options = options;
+    this.log = options.logger ?? defaultLogger;
+    // Validate default permission mode at construction time so misconfig
+    // surfaces at startup, not on first spawn.
+    if (!isPermissionMode(options.defaultPermissionMode)) {
+      throw new Error(
+        `claude-code-headless: invalid defaultPermissionMode "${options.defaultPermissionMode}" (must be one of ${VALID_PERMISSION_MODES.join(", ")})`,
+      );
+    }
+  }
+
+  async start(): Promise<void> {
+    this.lifetimeTimer = setInterval(() => this.checkLifetimes(), LIFETIME_CHECK_INTERVAL_MS);
+    this.lifetimeTimer.unref?.();
+    this.pruneTimer = setInterval(() => this.pruneStale(), STALE_PRUNE_INTERVAL_MS);
+    this.pruneTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopping) return;
+    this.stopping = true;
+
+    if (this.lifetimeTimer) clearInterval(this.lifetimeTimer);
+    if (this.pruneTimer) clearInterval(this.pruneTimer);
+    this.lifetimeTimer = null;
+    this.pruneTimer = null;
+
+    const all = Array.from(this.sessions.values());
+    this.sessions.clear();
+    await Promise.all(all.map((m) => m.dispose().catch(() => undefined)));
+  }
+
+  list(): ReadonlyArray<SessionSummary> {
+    return Array.from(this.sessions.values()).map((m) => m.summary());
+  }
+
+  count(): number {
+    return this.sessions.size;
+  }
+
+  async spawn(spec: SpawnSpec): Promise<SpawnDescriptor | SpawnError> {
+    if (this.stopping) return { code: 400, message: "shutting down" };
+
+    if (!spec.cwd || typeof spec.cwd !== "string") {
+      return { code: 400, message: "cwd is required" };
+    }
+    const absCwd = pathResolve(spec.cwd);
+    if (!existsSync(absCwd) || !statSync(absCwd).isDirectory()) {
+      return { code: 400, message: `cwd not found or not a directory: ${absCwd}` };
+    }
+
+    let sessionId: string;
+    if (spec.session_id !== undefined) {
+      if (typeof spec.session_id !== "string" || spec.session_id.length === 0) {
+        return { code: 400, message: "session_id must be a non-empty string" };
+      }
+      const v = validateSessionId(spec.session_id);
+      if (!v.ok) {
+        return {
+          code: 400,
+          message: v.suggestion
+            ? `session_id must match [a-z0-9_-]+ (suggested: ${v.suggestion})`
+            : "session_id is empty after sanitization",
+        };
+      }
+      sessionId = v.sessionId;
+    } else {
+      sessionId = generateSessionId();
+      while (this.sessions.has(sessionId) || this.creating.has(sessionId)) {
+        sessionId = generateSessionId();
+      }
+    }
+
+    if (this.sessions.has(sessionId) || this.creating.has(sessionId)) {
+      return { code: 409, session_id: sessionId, message: "session already exists" };
+    }
+
+    const model = spec.model ?? this.options.defaultModel;
+    if (typeof model !== "string" || model.length === 0) {
+      return { code: 400, message: "model must be a non-empty string" };
+    }
+
+    let allowedTools: ReadonlyArray<string>;
+    if (spec.allowed_tools !== undefined) {
+      if (!Array.isArray(spec.allowed_tools)) {
+        return { code: 400, message: "allowed_tools must be an array of strings" };
+      }
+      for (const t of spec.allowed_tools) {
+        if (typeof t !== "string" || t.length === 0) {
+          return { code: 400, message: "allowed_tools entries must be non-empty strings" };
+        }
+      }
+      allowedTools = [...spec.allowed_tools];
+    } else {
+      allowedTools = [...this.options.defaultAllowedTools];
+    }
+
+    const permissionModeRaw = spec.permission_mode ?? this.options.defaultPermissionMode;
+    if (!isPermissionMode(permissionModeRaw)) {
+      return {
+        code: 400,
+        message: `invalid permission_mode: ${permissionModeRaw} (must be one of ${VALID_PERMISSION_MODES.join(", ")})`,
+      };
+    }
+    const permissionMode: PermissionMode = permissionModeRaw;
+
+    const maxTurns = Number(spec.max_turns ?? this.options.defaultMaxTurns);
+    if (!Number.isInteger(maxTurns) || maxTurns <= 0) {
+      return { code: 400, message: "max_turns must be a positive integer" };
+    }
+
+    const maxLifetimeS = Number(spec.max_lifetime_s ?? this.options.defaultMaxLifetimeS);
+    if (!Number.isFinite(maxLifetimeS) || maxLifetimeS < 0) {
+      return { code: 400, message: "max_lifetime_s must be a non-negative number" };
+    }
+
+    this.creating.add(sessionId);
+
+    const managed = new ManagedSession({
+      nc: this.options.nc,
+      owner: this.options.owner,
+      sessionId,
+      cwd: absCwd,
+      model,
+      allowedTools,
+      permissionMode,
+      maxTurns,
+      maxLifetimeS,
+    });
+
+    try {
+      await managed.start();
+    } catch (e) {
+      this.creating.delete(sessionId);
+      return {
+        code: 400,
+        message: `failed to register session agent: ${(e as Error).message}`,
+      };
+    }
+
+    this.sessions.set(sessionId, managed);
+    this.creating.delete(sessionId);
+    this.log(`claude-code-headless: spawned ${sessionId} (cwd=${absCwd}, model=${model})`);
+
+    return {
+      session_id: sessionId,
+      subject: managed.subject,
+      heartbeat_subject: managed.heartbeatSubject,
+      cwd: managed.cwd,
+      model: managed.model,
+      allowed_tools: managed.allowedTools,
+      permission_mode: managed.permissionMode,
+      max_turns: managed.maxTurns,
+      max_lifetime_s: managed.maxLifetimeS,
+      created_at: new Date(managed.createdAt).toISOString(),
+      instance_id: managed.instanceId,
+    };
+  }
+
+  async stopOne(
+    sessionId: string,
+  ): Promise<{ ok: true; session_id: string } | { code: 404; message: string }> {
+    const m = this.sessions.get(sessionId);
+    if (!m) return { code: 404, message: `no such session: ${sessionId}` };
+    this.sessions.delete(sessionId);
+    await m.dispose();
+    this.log(`claude-code-headless: stopped ${sessionId}`);
+    return { ok: true, session_id: sessionId };
+  }
+
+  // ─── Internal: lifetime + pruning ──────────────────────────────────────────
+
+  private checkLifetimes(): void {
+    if (this.stopping) return;
+    const now = Date.now();
+    for (const [sid, m] of this.sessions) {
+      if (m.expired(now)) {
+        this.sessions.delete(sid);
+        this.log(`claude-code-headless: session ${sid} expired`);
+        void m.dispose();
+      }
+    }
+  }
+
+  private pruneStale(): void {
+    if (this.stopping) return;
+    for (const m of this.sessions.values()) {
+      m.pruneStale(STALE_REQUEST_CUTOFF_MS);
+    }
+  }
+}
+
+function isPermissionMode(value: string): value is PermissionMode {
+  return (VALID_PERMISSION_MODES as ReadonlyArray<string>).includes(value);
+}

--- a/examples/claude-code-headless/src/claude-session-manager.ts
+++ b/examples/claude-code-headless/src/claude-session-manager.ts
@@ -48,6 +48,10 @@ export interface SpawnDescriptor {
   readonly max_lifetime_s: number;
   readonly created_at: string;
   readonly instance_id: string;
+  /** Cumulative cost so far. Always 0 at spawn time; included for shape parity with summary. */
+  readonly total_cost_usd: number;
+  /** Number of completed turns. Always 0 at spawn time; included for shape parity. */
+  readonly turn_count: number;
 }
 
 export type SpawnError =
@@ -237,6 +241,8 @@ export class ClaudeSessionManager {
       max_lifetime_s: managed.maxLifetimeS,
       created_at: new Date(managed.createdAt).toISOString(),
       instance_id: managed.instanceId,
+      total_cost_usd: 0,
+      turn_count: 0,
     };
   }
 

--- a/examples/claude-code-headless/src/claude-session-manager.ts
+++ b/examples/claude-code-headless/src/claude-session-manager.ts
@@ -62,6 +62,8 @@ export interface ClaudeSessionManagerOptions {
   readonly defaultAllowedTools: ReadonlyArray<string>;
   readonly defaultMaxTurns: number;
   readonly defaultMaxLifetimeS: number;
+  /** Absolute path to the `claude` binary; passed to the SDK as `pathToClaudeCodeExecutable`. */
+  readonly claudeCodePath?: string;
   readonly logger?: (line: string) => void;
 }
 
@@ -206,6 +208,7 @@ export class ClaudeSessionManager {
       permissionMode,
       maxTurns,
       maxLifetimeS,
+      ...(this.options.claudeCodePath ? { claudeCodePath: this.options.claudeCodePath } : {}),
     });
 
     try {

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -13,6 +13,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import { join } from "node:path";
 
+import { sanitizeToken } from "./subjects.js";
+
 export interface ClaudeCodeHeadlessConfig {
   /** NATS CLI context name. Empty/undefined means "use NATS_URL only". */
   readonly context?: string;
@@ -182,6 +184,20 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
   if (!context && !natsUrl) {
     throw new Error(
       "claude-code-headless: no NATS target configured. Set --context, NATS_CONTEXT, or NATS_URL.",
+    );
+  }
+
+  // Validate owner / name as NATS-safe subject tokens (§2.2). $USER values
+  // like `alice.b` would silently build invalid subjects later (the dot is a
+  // subject separator); fail fast at boot with a readable error instead.
+  if (sanitizeToken(owner) !== owner) {
+    throw new Error(
+      `claude-code-headless: invalid owner "${owner}" — must match [a-z0-9_-]{1,63}. Override with --owner or CLAUDE_CODE_HEADLESS_OWNER.`,
+    );
+  }
+  if (sanitizeToken(name) !== name) {
+    throw new Error(
+      `claude-code-headless: invalid name "${name}" — must match [a-z0-9_-]{1,63}. Override with --name or CLAUDE_CODE_HEADLESS_NAME.`,
     );
   }
 

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -1,0 +1,187 @@
+// Config loading for claude-code-headless.
+//
+// Precedence (high → low):
+//   1. CLI flags
+//   2. Environment variables
+//   3. ~/.claude-code-headless/config.json
+//   4. Built-in defaults
+//
+// NATS connectivity: a `context` name is preferred; if absent, `NATS_URL`
+// serves as a fallback.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+
+export interface ClaudeCodeHeadlessConfig {
+  /** NATS CLI context name. Empty/undefined means "use NATS_URL only". */
+  readonly context?: string;
+  /** Explicit NATS URL; used only when `context` is unset. */
+  readonly natsUrl?: string;
+  /** Owner token (3rd subject segment). Defaults to $USER. */
+  readonly owner: string;
+  /** Controller instance name (4th subject token for the controller). */
+  readonly name: string;
+  /** Default Claude model id for spawns that don't set one. */
+  readonly defaultModel: string;
+  /** Default permission mode for spawned sessions. */
+  readonly defaultPermissionMode: string;
+  /** Default tool allowlist for spawned sessions. */
+  readonly defaultAllowedTools: ReadonlyArray<string>;
+  /** Default safety cap on turns per prompt. */
+  readonly defaultMaxTurns: number;
+  /** Default session lifetime in seconds. 0 means unbounded. */
+  readonly defaultMaxLifetimeS: number;
+}
+
+const CONFIG_FILE = join(homedir(), ".claude-code-headless", "config.json");
+
+const BUILT_IN_DEFAULTS = {
+  name: "exec",
+  // Sonnet is the right cost/quality default for a per-request spawner;
+  // callers can override per-spawn or via config.json.
+  defaultModel: "claude-sonnet-4-6",
+  // `dontAsk` means: no permission prompts ever. Anything not in the
+  // allowlist is denied. Deterministic, headless-friendly default.
+  defaultPermissionMode: "dontAsk",
+  // Read-only by default; reference implementation should be safe out of
+  // the box. Callers can expand per-spawn.
+  defaultAllowedTools: ["Read", "Glob", "Grep"] as ReadonlyArray<string>,
+  defaultMaxTurns: 50,
+  defaultMaxLifetimeS: 1800,
+} as const;
+
+interface RawConfigFile {
+  context?: string;
+  name?: string;
+  defaultModel?: string;
+  defaultPermissionMode?: string;
+  defaultAllowedTools?: ReadonlyArray<string>;
+  defaultMaxTurns?: number;
+  defaultMaxLifetimeS?: number;
+}
+
+function readConfigFile(): RawConfigFile {
+  if (!existsSync(CONFIG_FILE)) return {};
+  try {
+    const raw = readFileSync(CONFIG_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as RawConfigFile;
+  } catch (e) {
+    process.stderr.write(
+      `claude-code-headless: failed to read ${CONFIG_FILE}: ${(e as Error).message}\n`,
+    );
+    return {};
+  }
+}
+
+export interface CliOverrides {
+  context?: string;
+  natsUrl?: string;
+  owner?: string;
+  name?: string;
+}
+
+/** Parse simple `--key value` / `--key=value` CLI flags. Unknown flags are ignored. */
+export function parseCliOverrides(argv: ReadonlyArray<string>): CliOverrides {
+  const out: CliOverrides = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg || !arg.startsWith("--")) continue;
+    let key: string;
+    let value: string | undefined;
+    const eq = arg.indexOf("=");
+    if (eq >= 0) {
+      key = arg.slice(2, eq);
+      value = arg.slice(eq + 1);
+    } else {
+      key = arg.slice(2);
+      value = argv[i + 1];
+      if (value !== undefined && value.startsWith("--")) value = undefined;
+      else if (value !== undefined) i += 1;
+    }
+    if (value === undefined) continue;
+    switch (key) {
+      case "context":
+        out.context = value;
+        break;
+      case "nats-url":
+      case "url":
+        out.natsUrl = value;
+        break;
+      case "owner":
+        out.owner = value;
+        break;
+      case "name":
+        out.name = value;
+        break;
+    }
+  }
+  return out;
+}
+
+function parseToolList(input: string | undefined): ReadonlyArray<string> | undefined {
+  if (!input) return undefined;
+  const items = input
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
+  const file = readConfigFile();
+  const env = process.env;
+
+  const owner =
+    cli.owner ??
+    env["CLAUDE_CODE_HEADLESS_OWNER"] ??
+    env["USER"] ??
+    userInfo().username ??
+    "anon";
+  const name =
+    cli.name ?? env["CLAUDE_CODE_HEADLESS_NAME"] ?? file.name ?? BUILT_IN_DEFAULTS.name;
+  const context = cli.context ?? env["NATS_CONTEXT"] ?? file.context;
+  const natsUrl = cli.natsUrl ?? env["NATS_URL"];
+  const defaultModel =
+    env["CLAUDE_CODE_HEADLESS_DEFAULT_MODEL"] ??
+    file.defaultModel ??
+    BUILT_IN_DEFAULTS.defaultModel;
+  const defaultPermissionMode =
+    env["CLAUDE_CODE_HEADLESS_DEFAULT_PERMISSION_MODE"] ??
+    file.defaultPermissionMode ??
+    BUILT_IN_DEFAULTS.defaultPermissionMode;
+  const defaultAllowedTools =
+    parseToolList(env["CLAUDE_CODE_HEADLESS_DEFAULT_ALLOWED_TOOLS"]) ??
+    file.defaultAllowedTools ??
+    BUILT_IN_DEFAULTS.defaultAllowedTools;
+  const maxTurnsEnv = env["CLAUDE_CODE_HEADLESS_DEFAULT_MAX_TURNS"];
+  const defaultMaxTurns =
+    (maxTurnsEnv ? Number(maxTurnsEnv) : undefined) ??
+    file.defaultMaxTurns ??
+    BUILT_IN_DEFAULTS.defaultMaxTurns;
+  const maxLifetimeEnv = env["CLAUDE_CODE_HEADLESS_DEFAULT_MAX_LIFETIME"];
+  const defaultMaxLifetimeS =
+    (maxLifetimeEnv ? Number(maxLifetimeEnv) : undefined) ??
+    file.defaultMaxLifetimeS ??
+    BUILT_IN_DEFAULTS.defaultMaxLifetimeS;
+
+  if (!context && !natsUrl) {
+    throw new Error(
+      "claude-code-headless: no NATS target configured. Set --context, NATS_CONTEXT, or NATS_URL.",
+    );
+  }
+
+  return {
+    ...(context ? { context } : {}),
+    ...(natsUrl ? { natsUrl } : {}),
+    owner,
+    name,
+    defaultModel,
+    defaultPermissionMode,
+    defaultAllowedTools,
+    defaultMaxTurns,
+    defaultMaxLifetimeS,
+  };
+}

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -189,13 +189,15 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
 
   // Validate owner / name as NATS-safe subject tokens (§2.2). $USER values
   // like `alice.b` would silently build invalid subjects later (the dot is a
-  // subject separator); fail fast at boot with a readable error instead.
-  if (sanitizeToken(owner) !== owner) {
+  // subject separator); fail fast at boot with a readable error instead. The
+  // explicit length check catches the empty-string case — sanitizeToken("")
+  // returns "" so the equality check alone wouldn't trip on it.
+  if (owner.length === 0 || sanitizeToken(owner) !== owner) {
     throw new Error(
       `claude-code-headless: invalid owner "${owner}" — must match [a-z0-9_-]{1,63}. Override with --owner or CLAUDE_CODE_HEADLESS_OWNER.`,
     );
   }
-  if (sanitizeToken(name) !== name) {
+  if (name.length === 0 || sanitizeToken(name) !== name) {
     throw new Error(
       `claude-code-headless: invalid name "${name}" — must match [a-z0-9_-]{1,63}. Override with --name or CLAUDE_CODE_HEADLESS_NAME.`,
     );

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -32,6 +32,12 @@ export interface ClaudeCodeHeadlessConfig {
   readonly defaultMaxTurns: number;
   /** Default session lifetime in seconds. 0 means unbounded. */
   readonly defaultMaxLifetimeS: number;
+  /**
+   * Absolute path to the `claude` executable to spawn. When unset, the entry
+   * point auto-detects via `which claude`; when that fails, the SDK falls
+   * back to the (possibly missing) bundled native binary.
+   */
+  readonly claudeCodePath?: string;
 }
 
 const CONFIG_FILE = join(homedir(), ".claude-code-headless", "config.json");
@@ -59,6 +65,7 @@ interface RawConfigFile {
   defaultAllowedTools?: ReadonlyArray<string>;
   defaultMaxTurns?: number;
   defaultMaxLifetimeS?: number;
+  claudeCodePath?: string;
 }
 
 function readConfigFile(): RawConfigFile {
@@ -81,6 +88,7 @@ export interface CliOverrides {
   natsUrl?: string;
   owner?: string;
   name?: string;
+  claudeCodePath?: string;
 }
 
 /** Parse simple `--key value` / `--key=value` CLI flags. Unknown flags are ignored. */
@@ -115,6 +123,10 @@ export function parseCliOverrides(argv: ReadonlyArray<string>): CliOverrides {
         break;
       case "name":
         out.name = value;
+        break;
+      case "claude-code-path":
+      case "claude-path":
+        out.claudeCodePath = value;
         break;
     }
   }
@@ -173,6 +185,9 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
     );
   }
 
+  const claudeCodePath =
+    cli.claudeCodePath ?? env["CLAUDE_CODE_HEADLESS_CLAUDE_PATH"] ?? file.claudeCodePath;
+
   return {
     ...(context ? { context } : {}),
     ...(natsUrl ? { natsUrl } : {}),
@@ -183,5 +198,6 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
     defaultAllowedTools,
     defaultMaxTurns,
     defaultMaxLifetimeS,
+    ...(claudeCodePath ? { claudeCodePath } : {}),
   };
 }

--- a/examples/claude-code-headless/src/controller.ts
+++ b/examples/claude-code-headless/src/controller.ts
@@ -1,0 +1,275 @@
+// claude-code-headless controller service.
+//
+// One protocol-compliant NATS agent that uses the 2nd subject token `cc`
+// and exposes four endpoints:
+//
+//   - `prompt`  (§5/§6-compliant)  — returns a help-text response, so the
+//                                    controller is usable with `nats req`.
+//   - `spawn`   (request/reply)    — creates a new Claude Code session,
+//                                    registers it as its own NATS agent.
+//   - `stop`    (request/reply)    — disposes a session.
+//   - `list`    (request/reply)    — returns an array of session summaries.
+//
+// Heartbeats go to `agents.cc.<owner>.<name>.heartbeat` every 30s (protocol §8).
+
+import type { NatsConnection } from "@nats-io/nats-core";
+import { Svcm, type Service, type ServiceMsg } from "@nats-io/services";
+import {
+  SDK_PROTOCOL_VERSION,
+  SERVICE_NAME,
+  PROMPT_QUEUE_GROUP,
+} from "@synadia-ai/agents";
+
+import { responseText, statusAck } from "./chunk-encoder.js";
+import {
+  controllerHeartbeatSubject,
+  controllerListSubject,
+  controllerPromptSubject,
+  controllerSpawnSubject,
+  controllerStopSubject,
+} from "./subjects.js";
+import type { ClaudeSessionManager, SpawnSpec } from "./claude-session-manager.js";
+
+export interface ControllerOptions {
+  readonly nc: NatsConnection;
+  readonly owner: string;
+  readonly name: string;
+  readonly version?: string;
+  readonly heartbeatIntervalS?: number;
+  readonly manager: ClaudeSessionManager;
+  readonly logger?: (line: string) => void;
+}
+
+const DEFAULT_VERSION = "0.1.0";
+const DEFAULT_HEARTBEAT_INTERVAL_S = 30;
+
+const helpText = (promptSubject: string): string =>
+  [
+    `claude-code-headless controller @ ${promptSubject}`,
+    "",
+    "This is a control-plane agent. It spawns, stops, and lists Claude Code",
+    "sessions backed by @anthropic-ai/claude-agent-sdk. Each spawned session",
+    "registers as its OWN NATS agent at `agents.cc.<owner>.<session_id>` and",
+    "speaks the standard NATS Agent Protocol v0.2.0-draft — discover it via",
+    "$SRV.INFO.agents and prompt it like any agent.",
+    "",
+    "Custom endpoints on this controller:",
+    `  spawn : ${promptSubject}.spawn`,
+    '    req : { "cwd": "/abs/path", "session_id"?: string,',
+    '            "model"?: "claude-sonnet-4-6", "allowed_tools"?: ["Read", ...],',
+    '            "permission_mode"?: "dontAsk|acceptEdits|bypassPermissions|plan|default",',
+    '            "max_turns"?: number, "max_lifetime_s"?: number }',
+    '    rep : { "session_id", "subject", "heartbeat_subject", "cwd", ... }',
+    "",
+    `  stop  : ${promptSubject}.stop`,
+    '    req : { "session_id": "..." }',
+    '    rep : { "ok": true, "session_id": "..." }',
+    "",
+    `  list  : ${promptSubject}.list`,
+    "    req : (empty)",
+    '    rep : { "sessions": [ { session_id, cwd, remaining_lifetime_s, ... } ] }',
+  ].join("\n");
+
+export class Controller {
+  private readonly opts: ControllerOptions;
+  private readonly log: (line: string) => void;
+  private readonly promptSubject: string;
+  private readonly heartbeatSubject: string;
+  private service: Service | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: ControllerOptions) {
+    this.opts = opts;
+    this.log = opts.logger ?? ((line) => process.stderr.write(`${line}\n`));
+    this.promptSubject = controllerPromptSubject(opts.owner, opts.name);
+    this.heartbeatSubject = controllerHeartbeatSubject(opts.owner, opts.name);
+  }
+
+  get instanceId(): string {
+    if (!this.service) throw new Error("Controller not started");
+    return this.service.info().id;
+  }
+
+  async start(): Promise<void> {
+    if (this.service) return;
+    const svcm = new Svcm(this.opts.nc);
+
+    const metadata: Record<string, string> = {
+      agent: "cc",
+      owner: this.opts.owner,
+      protocol_version: `${SDK_PROTOCOL_VERSION.major}.${SDK_PROTOCOL_VERSION.minor}`,
+      role: "claude-code-headless-controller",
+    };
+
+    this.service = await svcm.add({
+      name: SERVICE_NAME,
+      version: this.opts.version ?? DEFAULT_VERSION,
+      description: `claude-code-headless controller (${this.opts.owner}/${this.opts.name})`,
+      metadata,
+    });
+
+    // §5/§6 prompt endpoint — returns help text.
+    this.service.addEndpoint("prompt", {
+      subject: this.promptSubject,
+      queue: PROMPT_QUEUE_GROUP,
+      handler: (err, msg) => {
+        if (err) return;
+        void this.handleHelp(msg);
+      },
+      metadata: {
+        max_payload: "1MB",
+        attachments_ok: "false",
+      },
+    });
+
+    // Custom control endpoints — not protocol-standard, but allowed.
+    this.service.addEndpoint("spawn", {
+      subject: controllerSpawnSubject(this.opts.owner, this.opts.name),
+      handler: (err, msg) => {
+        if (err) return;
+        void this.handleSpawn(msg);
+      },
+    });
+
+    this.service.addEndpoint("stop", {
+      subject: controllerStopSubject(this.opts.owner, this.opts.name),
+      handler: (err, msg) => {
+        if (err) return;
+        void this.handleStop(msg);
+      },
+    });
+
+    this.service.addEndpoint("list", {
+      subject: controllerListSubject(this.opts.owner, this.opts.name),
+      handler: (err, msg) => {
+        if (err) return;
+        void this.handleList(msg);
+      },
+    });
+
+    this.startHeartbeats();
+    this.log(`claude-code-headless: controller listening on ${this.promptSubject}`);
+    this.log(
+      `claude-code-headless: extra endpoints — ${controllerSpawnSubject(this.opts.owner, this.opts.name)}, ${controllerStopSubject(this.opts.owner, this.opts.name)}, ${controllerListSubject(this.opts.owner, this.opts.name)}`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+    if (this.service) {
+      try {
+        await this.service.stop();
+      } catch {
+        /* noop */
+      }
+      this.service = null;
+    }
+  }
+
+  // ─── Handlers ──────────────────────────────────────────────────────────────
+
+  private async handleHelp(msg: ServiceMsg): Promise<void> {
+    try {
+      msg.respond(statusAck());
+      msg.respond(responseText(helpText(this.promptSubject)));
+    } catch {
+      /* noop */
+    } finally {
+      try {
+        msg.respond("");
+      } catch {
+        /* noop */
+      }
+    }
+  }
+
+  private async handleSpawn(msg: ServiceMsg): Promise<void> {
+    let spec: SpawnSpec;
+    try {
+      const raw = msg.string();
+      spec = raw.length === 0 ? ({ cwd: "" } as SpawnSpec) : (JSON.parse(raw) as SpawnSpec);
+    } catch (e) {
+      this.respondError(msg, 400, `invalid JSON: ${(e as Error).message}`);
+      return;
+    }
+
+    const result = await this.opts.manager.spawn(spec);
+    if ("code" in result) {
+      this.respondError(msg, result.code, result.message);
+      return;
+    }
+    try {
+      msg.respond(JSON.stringify(result));
+    } catch {
+      /* noop */
+    }
+  }
+
+  private async handleStop(msg: ServiceMsg): Promise<void> {
+    let sessionId: string;
+    try {
+      const raw = msg.string();
+      const parsed = raw.length === 0 ? {} : (JSON.parse(raw) as { session_id?: unknown });
+      const value = parsed.session_id;
+      if (typeof value !== "string" || value.length === 0) {
+        this.respondError(msg, 400, "session_id is required");
+        return;
+      }
+      sessionId = value;
+    } catch (e) {
+      this.respondError(msg, 400, `invalid JSON: ${(e as Error).message}`);
+      return;
+    }
+
+    const result = await this.opts.manager.stopOne(sessionId);
+    if ("code" in result) {
+      this.respondError(msg, result.code, result.message);
+      return;
+    }
+    try {
+      msg.respond(JSON.stringify(result));
+    } catch {
+      /* noop */
+    }
+  }
+
+  private async handleList(msg: ServiceMsg): Promise<void> {
+    const sessions = this.opts.manager.list();
+    try {
+      msg.respond(JSON.stringify({ sessions }));
+    } catch {
+      /* noop */
+    }
+  }
+
+  private respondError(msg: ServiceMsg, code: number, message: string): void {
+    try {
+      msg.respondError(code, message);
+    } catch {
+      /* noop */
+    }
+  }
+
+  private startHeartbeats(): void {
+    const intervalS = this.opts.heartbeatIntervalS ?? DEFAULT_HEARTBEAT_INTERVAL_S;
+    const publish = (): void => {
+      if (!this.service) return;
+      const payload = {
+        agent: "cc",
+        owner: this.opts.owner,
+        instance_id: this.service.info().id,
+        ts: new Date().toISOString(),
+        interval_s: intervalS,
+      };
+      try {
+        this.opts.nc.publish(this.heartbeatSubject, JSON.stringify(payload));
+      } catch {
+        /* noop */
+      }
+    };
+    publish();
+    this.heartbeatTimer = setInterval(publish, intervalS * 1000);
+    this.heartbeatTimer.unref?.();
+  }
+}

--- a/examples/claude-code-headless/src/envelope.ts
+++ b/examples/claude-code-headless/src/envelope.ts
@@ -1,0 +1,98 @@
+// Request envelope parser per protocol §5.
+//
+// The spec says: plain UTF-8 text is shorthand for { prompt: <text> }; a
+// payload beginning with `{` (after stripping leading whitespace) MUST be
+// parsed as JSON and MUST include a non-empty `prompt` string. A zero-byte
+// request is invalid.
+
+export interface ParsedEnvelope {
+  readonly prompt: string;
+  readonly attachments?: ReadonlyArray<ParsedAttachment>;
+}
+
+export interface ParsedAttachment {
+  readonly filename: string;
+  /** RFC 4648 §4 base64, as received on the wire. */
+  readonly base64: string;
+}
+
+export class EnvelopeError extends Error {
+  constructor(
+    public readonly code: 400,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EnvelopeError";
+  }
+}
+
+const WHITESPACE = new Set([0x09, 0x0a, 0x0d, 0x20]);
+
+function firstNonWhitespaceByte(bytes: Uint8Array): number | undefined {
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    if (b === undefined) return undefined;
+    if (!WHITESPACE.has(b)) return b;
+  }
+  return undefined;
+}
+
+/** Parse the raw request body. Throws EnvelopeError on §5.3 violations. */
+export function parseEnvelope(data: Uint8Array): ParsedEnvelope {
+  if (data.length === 0) {
+    throw new EnvelopeError(400, "empty payload");
+  }
+
+  const first = firstNonWhitespaceByte(data);
+  if (first === undefined) {
+    throw new EnvelopeError(400, "whitespace-only payload");
+  }
+
+  // Plain-text shorthand.
+  if (first !== 0x7b /* `{` */) {
+    const text = new TextDecoder().decode(data);
+    if (text.length === 0) throw new EnvelopeError(400, "empty plain-text payload");
+    return { prompt: text };
+  }
+
+  // JSON form.
+  const raw = new TextDecoder().decode(data);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new EnvelopeError(400, `invalid JSON envelope: ${(e as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new EnvelopeError(400, "envelope must be a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  const prompt = obj["prompt"];
+  if (typeof prompt !== "string" || prompt.length === 0) {
+    throw new EnvelopeError(400, "envelope.prompt must be a non-empty string");
+  }
+  const attachmentsIn = obj["attachments"];
+  if (attachmentsIn === undefined) {
+    return { prompt };
+  }
+  if (!Array.isArray(attachmentsIn)) {
+    throw new EnvelopeError(400, "envelope.attachments must be an array");
+  }
+  const attachments: ParsedAttachment[] = [];
+  for (const [i, raw] of attachmentsIn.entries()) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new EnvelopeError(400, `attachments[${i}] must be an object`);
+    }
+    const a = raw as Record<string, unknown>;
+    const filename = a["filename"];
+    const content = a["content"];
+    if (typeof filename !== "string" || filename.length === 0) {
+      throw new EnvelopeError(400, `attachments[${i}].filename must be a non-empty string`);
+    }
+    if (typeof content !== "string" || content.length === 0) {
+      throw new EnvelopeError(400, `attachments[${i}].content must be a non-empty base64 string`);
+    }
+    attachments.push({ filename, base64: content });
+  }
+  return { prompt, ...(attachments.length > 0 ? { attachments } : {}) };
+}

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -4,6 +4,7 @@
 // starts the ClaudeSessionManager and Controller, and wires graceful
 // shutdown on SIGINT/SIGTERM.
 
+import { existsSync } from "node:fs";
 import process from "node:process";
 
 import type { NatsConnection } from "@nats-io/nats-core";
@@ -47,6 +48,19 @@ async function main(): Promise<void> {
     );
   }
 
+  // Resolve the `claude` binary path. Configured > auto-detected (via
+  // `which`-equivalent on PATH) > undefined (let the SDK try its bundled
+  // native binary, which can fail when the installed musl/glibc variant
+  // doesn't match this machine).
+  const claudeCodePath = await resolveClaudeCodePath(config.claudeCodePath);
+  if (claudeCodePath) {
+    log(`claude-code-headless: using claude binary at ${claudeCodePath}`);
+  } else {
+    log(
+      "claude-code-headless: no claude binary found on PATH; SDK will use its bundled native binary (may fail if the installed variant doesn't match this platform — set --claude-code-path to override).",
+    );
+  }
+
   const connOpts = await resolveNatsOptions(config.context, config.natsUrl);
   log(
     `claude-code-headless: connecting (${config.context ? `context=${config.context}` : `url=${config.natsUrl}`})`,
@@ -62,6 +76,7 @@ async function main(): Promise<void> {
     defaultAllowedTools: config.defaultAllowedTools,
     defaultMaxTurns: config.defaultMaxTurns,
     defaultMaxLifetimeS: config.defaultMaxLifetimeS,
+    ...(claudeCodePath ? { claudeCodePath } : {}),
   });
   await manager.start();
 
@@ -127,6 +142,20 @@ async function main(): Promise<void> {
       /* status iterator ended */
     }
   })();
+}
+
+async function resolveClaudeCodePath(configured: string | undefined): Promise<string | undefined> {
+  if (configured) {
+    if (!existsSync(configured)) {
+      throw new Error(
+        `claude-code-headless: configured claudeCodePath does not exist: ${configured}`,
+      );
+    }
+    return configured;
+  }
+  // Bun.which is the cross-platform PATH lookup. Returns null when not found.
+  const found = Bun.which("claude");
+  return found ?? undefined;
 }
 
 main().catch((err) => {

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -1,0 +1,133 @@
+// claude-code-headless entry point.
+//
+// Loads config, connects to NATS (via `nats context` when available),
+// starts the ClaudeSessionManager and Controller, and wires graceful
+// shutdown on SIGINT/SIGTERM.
+
+import process from "node:process";
+
+import type { NatsConnection } from "@nats-io/nats-core";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { loadContextOptions } from "@synadia-ai/agents";
+
+import { ClaudeSessionManager } from "./claude-session-manager.js";
+import { Controller } from "./controller.js";
+import { loadConfig, parseCliOverrides } from "./config.js";
+
+const log = (line: string): void => {
+  process.stderr.write(`${line}\n`);
+};
+
+async function resolveNatsOptions(
+  context: string | undefined,
+  natsUrl: string | undefined,
+): Promise<NodeConnectionOptions> {
+  if (context) {
+    return { ...(await loadContextOptions(context)), name: "claude-code-headless" };
+  }
+  if (natsUrl) {
+    return { servers: natsUrl, name: "claude-code-headless" };
+  }
+
+  throw new Error("no NATS target configured (context / NATS_URL / --url)");
+}
+
+async function main(): Promise<void> {
+  const cli = parseCliOverrides(process.argv.slice(2));
+  const config = loadConfig(cli);
+
+  // Fail fast if Anthropic auth isn't set up — better than letting the first
+  // spawn fail with a confusing SDK error.
+  if (!process.env["ANTHROPIC_API_KEY"]) {
+    log(
+      "claude-code-headless: warning — ANTHROPIC_API_KEY is not set; spawned sessions will fail until it is.",
+    );
+  }
+
+  const connOpts = await resolveNatsOptions(config.context, config.natsUrl);
+  log(
+    `claude-code-headless: connecting (${config.context ? `context=${config.context}` : `url=${config.natsUrl}`})`,
+  );
+  const nc: NatsConnection = await natsConnect(connOpts);
+  log(`claude-code-headless: connected`);
+
+  const manager = new ClaudeSessionManager({
+    nc,
+    owner: config.owner,
+    defaultModel: config.defaultModel,
+    defaultPermissionMode: config.defaultPermissionMode,
+    defaultAllowedTools: config.defaultAllowedTools,
+    defaultMaxTurns: config.defaultMaxTurns,
+    defaultMaxLifetimeS: config.defaultMaxLifetimeS,
+  });
+  await manager.start();
+
+  const controller = new Controller({
+    nc,
+    owner: config.owner,
+    name: config.name,
+    manager,
+  });
+  await controller.start();
+
+  let shuttingDown = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log(
+      `claude-code-headless: received ${signal}, shutting down (${manager.count()} sessions)`,
+    );
+    // Force-exit guard — NATS close can occasionally hang.
+    const forceTimer = setTimeout(() => {
+      log("claude-code-headless: forced exit");
+      process.exit(1);
+    }, 5_000);
+    forceTimer.unref?.();
+    try {
+      await controller.stop();
+    } catch (e) {
+      log(`claude-code-headless: controller.stop error: ${(e as Error).message}`);
+    }
+    try {
+      await manager.stop();
+    } catch (e) {
+      log(`claude-code-headless: manager.stop error: ${(e as Error).message}`);
+    }
+    try {
+      await nc.drain();
+    } catch {
+      /* noop */
+    }
+    clearTimeout(forceTimer);
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  process.on("unhandledRejection", (err) => {
+    log(`claude-code-headless: unhandledRejection: ${err}`);
+  });
+  process.on("uncaughtException", (err) => {
+    log(`claude-code-headless: uncaughtException: ${err}`);
+  });
+
+  // Background: NATS connection status logging.
+  void (async () => {
+    try {
+      for await (const s of nc.status()) {
+        if (s.type === "disconnect") log(`claude-code-headless: NATS disconnected`);
+        else if (s.type === "reconnect") log(`claude-code-headless: NATS reconnected`);
+        else if (s.type === "error") log(`claude-code-headless: NATS error`);
+      }
+    } catch {
+      /* status iterator ended */
+    }
+  })();
+}
+
+main().catch((err) => {
+  log(`claude-code-headless: fatal: ${(err as Error).message}`);
+  process.exit(1);
+});

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -38,13 +38,11 @@ async function main(): Promise<void> {
   const cli = parseCliOverrides(process.argv.slice(2));
   const config = loadConfig(cli);
 
-  // Informational only: the SDK accepts either an API key OR the local OAuth
-  // credentials from `claude login`. We can't tell which is in play without
-  // first spawning a session, so just hint at the fallback when the env var
-  // is absent.
+  // Surface a startup hint when ANTHROPIC_API_KEY isn't set so misconfig
+  // shows up at boot rather than as a confusing SDK error on first spawn.
   if (!process.env["ANTHROPIC_API_KEY"]) {
     log(
-      "claude-code-headless: no ANTHROPIC_API_KEY in env — sessions will fall back to local Claude Code OAuth credentials (~/.claude) if you've run `claude login`.",
+      "claude-code-headless: ANTHROPIC_API_KEY is not set in env. See the README for the recommended auth setup.",
     );
   }
 

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -37,11 +37,13 @@ async function main(): Promise<void> {
   const cli = parseCliOverrides(process.argv.slice(2));
   const config = loadConfig(cli);
 
-  // Fail fast if Anthropic auth isn't set up — better than letting the first
-  // spawn fail with a confusing SDK error.
+  // Informational only: the SDK accepts either an API key OR the local OAuth
+  // credentials from `claude login`. We can't tell which is in play without
+  // first spawning a session, so just hint at the fallback when the env var
+  // is absent.
   if (!process.env["ANTHROPIC_API_KEY"]) {
     log(
-      "claude-code-headless: warning — ANTHROPIC_API_KEY is not set; spawned sessions will fail until it is.",
+      "claude-code-headless: no ANTHROPIC_API_KEY in env — sessions will fall back to local Claude Code OAuth credentials (~/.claude) if you've run `claude login`.",
     );
   }
 

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -228,6 +228,10 @@ export class ManagedSession {
       } catch (e) {
         try {
           msg.respondError(400, `failed to stage attachments: ${(e as Error).message}`);
+        } catch {
+          /* noop */
+        }
+        try {
           msg.respond("");
         } catch {
           /* noop */
@@ -490,6 +494,13 @@ export class ManagedSession {
         this.pendingRequests.delete(id);
         const qi = this.requestQueue.indexOf(id);
         if (qi >= 0) this.requestQueue.splice(qi, 1);
+        // Surface as an explicit timeout error so the caller's onError fires —
+        // a bare terminator would look identical to a successful completion.
+        try {
+          pr.msg.respondError(408, "request timed out in queue");
+        } catch {
+          /* noop */
+        }
         try {
           pr.msg.respond("");
         } catch {

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -461,7 +461,7 @@ export class ManagedSession {
       try {
         for await (const m of sub) {
           const reply = m.string().trim();
-          return interpretPermissionReply(reply);
+          return interpretPermissionReply(reply, input);
         }
         // Subscription ended without a message — timeout, abort, or stream end.
         return { behavior: "deny", message: "permission request timed out" };
@@ -612,9 +612,16 @@ function previewInput(input: Record<string, unknown>): string {
 const ALLOW_TOKENS = new Set(["yes", "y", "allow", "approve", "ok", "true"]);
 const DENY_TOKENS = new Set(["no", "n", "deny", "reject", "cancel", "false"]);
 
-function interpretPermissionReply(reply: string): PermissionResult {
+function interpretPermissionReply(
+  reply: string,
+  input: Record<string, unknown>,
+): PermissionResult {
   const norm = reply.toLowerCase().trim();
-  if (ALLOW_TOKENS.has(norm)) return { behavior: "allow" };
+  // The SDK's runtime Zod validator requires `updatedInput` on allow even
+  // though the TS type marks it optional — echo the original input back as
+  // the no-op "use as-is" case. (canUseTool can also rewrite tool inputs
+  // before they execute; we don't, but the field still has to be set.)
+  if (ALLOW_TOKENS.has(norm)) return { behavior: "allow", updatedInput: input };
   if (DENY_TOKENS.has(norm)) return { behavior: "deny", message: "user denied" };
   // Treat any other text as a denial reason — preserves operator intent
   // ("not in this directory") rather than silently allowing.

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -3,15 +3,31 @@
 // envelope parsing, request queueing for serial drain (the SDK's `query()`
 // is one full multi-turn round-trip per call, and concurrent re-entry into
 // the same logical session would interleave context), typed-chunk
-// streaming, error headers, and disposal.
+// streaming, error headers, tool-call observability, interactive
+// permission requests via §7 query chunks, per-token streaming, cost
+// tracking, and disposal.
 
+import { createInbox } from "@nats-io/nats-core";
 import type { NatsConnection } from "@nats-io/nats-core";
 import type { ServiceMsg } from "@nats-io/services";
 import { ReferenceAgent } from "@synadia-ai/agents/testing";
-import { query, type Options, type PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+import {
+  query,
+  type CanUseTool,
+  type Options,
+  type PermissionMode,
+  type PermissionResult,
+} from "@anthropic-ai/claude-agent-sdk";
 
 import { cleanupStaged, decorateWithAttachments, stageAttachments } from "./attachments.js";
-import { responseText, statusAck } from "./chunk-encoder.js";
+import {
+  costStatus,
+  queryChunk,
+  responseText,
+  statusAck,
+  toolResultStatus,
+  toolUseStatus,
+} from "./chunk-encoder.js";
 import { EnvelopeError, parseEnvelope, type ParsedAttachment } from "./envelope.js";
 import { sessionHeartbeatSubject, sessionPromptSubject } from "./subjects.js";
 
@@ -46,6 +62,10 @@ export interface SessionSummary {
   readonly last_activity: string;
   /** SDK session id, populated after the first turn finishes (used for resume). */
   readonly sdk_session_id?: string;
+  /** Cumulative USD cost across all completed turns in this session. */
+  readonly total_cost_usd: number;
+  /** Number of turns (SDK `query()` invocations) completed. */
+  readonly turn_count: number;
 }
 
 interface PendingRequest {
@@ -57,6 +77,7 @@ interface PendingRequest {
 }
 
 const HEARTBEAT_INTERVAL_S = 30;
+const PERMISSION_TIMEOUT_MS = 120_000; // 2 minutes for a user to decide
 
 export class ManagedSession {
   readonly sessionId: string;
@@ -81,6 +102,8 @@ export class ManagedSession {
   private lastActivity: number;
   private requestCounter = 0;
   private sdkSessionId: string | undefined;
+  private totalCostUsd = 0;
+  private turnCount = 0;
   private disposed = false;
 
   constructor(opts: ManagedSessionOptions) {
@@ -157,6 +180,8 @@ export class ManagedSession {
       created_at: new Date(this.createdAt).toISOString(),
       last_activity: new Date(this.lastActivity).toISOString(),
       ...(this.sdkSessionId ? { sdk_session_id: this.sdkSessionId } : {}),
+      total_cost_usd: this.totalCostUsd,
+      turn_count: this.turnCount,
     };
   }
 
@@ -241,6 +266,10 @@ export class ManagedSession {
     const abortController = new AbortController();
     this.activeAborts.add(abortController);
 
+    // Reply subject for chunks streamed back to the caller; also where any
+    // §7 query chunks emitted by canUseTool will land.
+    const replySubject = pr.msg.reply ?? "";
+
     try {
       try {
         pr.msg.respond(statusAck());
@@ -255,6 +284,14 @@ export class ManagedSession {
         permissionMode: this.permissionMode,
         maxTurns: this.maxTurns,
         abortController,
+        // Per-token streaming: the SDK emits stream_event partials for
+        // incremental text deltas in addition to the final assistant message.
+        includePartialMessages: true,
+        // Permission asking: the SDK calls this when it wants to use a tool
+        // that isn't auto-allowed by the current permissionMode + allowedTools.
+        // We surface it as a §7 query chunk, await the caller's reply, and
+        // resolve the SDK promise accordingly.
+        canUseTool: this.makeCanUseTool(replySubject, abortController.signal),
       };
       if (this.sdkSessionId) {
         queryOptions.resume = this.sdkSessionId;
@@ -269,26 +306,74 @@ export class ManagedSession {
           this.sdkSessionId = ev.session_id;
           continue;
         }
+        if (ev.type === "stream_event") {
+          // Per-token streaming: text deltas inside content_block_delta events.
+          // Other partial events (block start/stop, message_delta, etc.) we
+          // intentionally drop — UI cares only about visible text and we get
+          // the final blocks (incl. tool_use) via the assistant event below.
+          const text = extractPartialText(ev);
+          if (text && text.length > 0) {
+            try {
+              pr.msg.respond(responseText(text));
+            } catch {
+              /* noop */
+            }
+          }
+          continue;
+        }
         if (ev.type === "assistant") {
+          // Surface tool_use blocks for visibility. Text was already streamed
+          // via stream_event partials, so we skip text blocks here to avoid
+          // duplication.
           for (const block of ev.message.content) {
-            if (block.type === "text") {
-              const text = (block as { text?: unknown }).text;
-              if (typeof text === "string" && text.length > 0) {
+            if (block.type === "tool_use") {
+              const tu = block as { id: string; name: string; input: Record<string, unknown> };
+              try {
+                pr.msg.respond(toolUseStatus(tu.id, tu.name, tu.input));
+              } catch {
+                /* noop */
+              }
+            }
+            // text blocks: already streamed via partials; intentionally skip.
+          }
+          continue;
+        }
+        if (ev.type === "user") {
+          // Tool results arrive here as a synthetic user-role message whose
+          // content is an array of `tool_result` blocks paired by tool_use_id.
+          const userContent = (ev as { message?: { content?: unknown } }).message?.content;
+          if (Array.isArray(userContent)) {
+            for (const block of userContent) {
+              if (block && typeof block === "object" && (block as { type?: string }).type === "tool_result") {
+                const tr = block as {
+                  tool_use_id: string;
+                  content?: unknown;
+                  is_error?: boolean;
+                };
+                const output = stringifyToolResultContent(tr.content);
                 try {
-                  pr.msg.respond(responseText(text));
+                  pr.msg.respond(toolResultStatus(tr.tool_use_id, output, tr.is_error === true));
                 } catch {
                   /* noop */
                 }
               }
             }
-            // tool_use / thinking blocks intentionally suppressed in the spike.
-            // TODO: relay tool_use as protocol §7 query chunks.
           }
           continue;
         }
         if (ev.type === "result") {
           this.sdkSessionId = ev.session_id;
-          if (ev.subtype !== "success") {
+          this.turnCount += 1;
+          // Cost: only success carries `total_cost_usd`. Errors may not.
+          if (ev.subtype === "success") {
+            const turnCost = (ev as { total_cost_usd?: number }).total_cost_usd ?? 0;
+            this.totalCostUsd += turnCost;
+            try {
+              pr.msg.respond(costStatus(turnCost, this.totalCostUsd));
+            } catch {
+              /* noop */
+            }
+          } else {
             try {
               pr.msg.respondError(500, `claude-agent-sdk: ${ev.subtype}`);
             } catch {
@@ -327,6 +412,64 @@ export class ManagedSession {
         setImmediate(() => void this.drain());
       }
     }
+  }
+
+  /**
+   * Build a canUseTool callback bound to the active request's reply subject.
+   * Each invocation emits a fresh §7 query chunk on a unique inbox, awaits a
+   * single-message reply (with a 2-minute timeout), and translates the
+   * caller's text reply into a PermissionResult the SDK understands.
+   */
+  private makeCanUseTool(
+    replySubject: string,
+    abortSignal: AbortSignal,
+  ): CanUseTool {
+    return async (toolName, input, opts): Promise<PermissionResult> => {
+      // No reply subject means the caller bailed before we got here — deny.
+      if (!replySubject) {
+        return { behavior: "deny", message: "no active reply channel" };
+      }
+      const replyInbox = createInbox();
+      const sub = this.nc.subscribe(replyInbox, { max: 1 });
+      const promptText = buildPermissionPrompt(toolName, input, opts);
+      try {
+        this.nc.publish(replySubject, queryChunk(opts.toolUseID, replyInbox, promptText));
+        await this.nc.flush();
+      } catch (e) {
+        try {
+          sub.unsubscribe();
+        } catch {
+          /* noop */
+        }
+        return { behavior: "deny", message: `failed to emit query: ${(e as Error).message}` };
+      }
+      const timer = setTimeout(() => {
+        try {
+          sub.unsubscribe();
+        } catch {
+          /* noop */
+        }
+      }, PERMISSION_TIMEOUT_MS);
+      const onAbort = (): void => {
+        try {
+          sub.unsubscribe();
+        } catch {
+          /* noop */
+        }
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+      try {
+        for await (const m of sub) {
+          const reply = m.string().trim();
+          return interpretPermissionReply(reply);
+        }
+        // Subscription ended without a message — timeout, abort, or stream end.
+        return { behavior: "deny", message: "permission request timed out" };
+      } finally {
+        clearTimeout(timer);
+        abortSignal.removeEventListener("abort", onAbort);
+      }
+    };
   }
 
   // ─── Lifetime / pruning (called by ClaudeSessionManager) ───────────────────
@@ -393,4 +536,87 @@ export class ManagedSession {
       );
     }
   }
+}
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+function extractPartialText(ev: unknown): string | undefined {
+  // SDK shape: { type: "stream_event", event: BetaRawMessageStreamEvent, ... }
+  // Anthropic stream events: content_block_delta with delta.type === "text_delta"
+  // carry { delta: { type: "text_delta", text: "..." } }.
+  if (!ev || typeof ev !== "object") return undefined;
+  const inner = (ev as { event?: unknown }).event;
+  if (!inner || typeof inner !== "object") return undefined;
+  const e = inner as { type?: unknown; delta?: unknown };
+  if (e.type !== "content_block_delta") return undefined;
+  const delta = e.delta;
+  if (!delta || typeof delta !== "object") return undefined;
+  const d = delta as { type?: unknown; text?: unknown };
+  if (d.type !== "text_delta") return undefined;
+  return typeof d.text === "string" ? d.text : undefined;
+}
+
+function stringifyToolResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    // tool_result.content is often an array of {type:"text", text:"..."} blocks.
+    const parts: string[] = [];
+    for (const item of content) {
+      if (item && typeof item === "object") {
+        const obj = item as { type?: unknown; text?: unknown };
+        if (obj.type === "text" && typeof obj.text === "string") {
+          parts.push(obj.text);
+          continue;
+        }
+      }
+      parts.push(JSON.stringify(item));
+    }
+    return parts.join("\n");
+  }
+  if (content === undefined || content === null) return "";
+  return JSON.stringify(content);
+}
+
+function buildPermissionPrompt(
+  toolName: string,
+  input: Record<string, unknown>,
+  opts: { title?: string; description?: string },
+): string {
+  // Prefer the SDK's pre-rendered title when present (e.g. "Claude wants to
+  // read foo.txt"). Otherwise build a concise one from the tool name + input.
+  if (opts.title && typeof opts.title === "string") {
+    const lines = [opts.title];
+    if (opts.description) lines.push(opts.description);
+    lines.push("", `Reply 'yes' to allow or 'no' to deny.`);
+    return lines.join("\n");
+  }
+  const inputPreview = previewInput(input);
+  return [
+    `Claude wants to use tool: ${toolName}`,
+    inputPreview,
+    "",
+    "Reply 'yes' to allow or 'no' to deny.",
+  ]
+    .filter((l) => l.length > 0)
+    .join("\n");
+}
+
+function previewInput(input: Record<string, unknown>): string {
+  const keys = Object.keys(input);
+  if (keys.length === 0) return "";
+  const json = JSON.stringify(input, null, 2);
+  if (json.length <= 600) return json;
+  return json.slice(0, 600) + "…[truncated]";
+}
+
+const ALLOW_TOKENS = new Set(["yes", "y", "allow", "approve", "ok", "true"]);
+const DENY_TOKENS = new Set(["no", "n", "deny", "reject", "cancel", "false"]);
+
+function interpretPermissionReply(reply: string): PermissionResult {
+  const norm = reply.toLowerCase().trim();
+  if (ALLOW_TOKENS.has(norm)) return { behavior: "allow" };
+  if (DENY_TOKENS.has(norm)) return { behavior: "deny", message: "user denied" };
+  // Treat any other text as a denial reason — preserves operator intent
+  // ("not in this directory") rather than silently allowing.
+  return { behavior: "deny", message: reply || "user denied (no reason given)" };
 }

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -25,6 +25,8 @@ export interface ManagedSessionOptions {
   readonly permissionMode: PermissionMode;
   readonly maxTurns: number;
   readonly maxLifetimeS: number;
+  /** Absolute path to the `claude` binary, forwarded to the SDK. */
+  readonly claudeCodePath?: string;
 }
 
 export interface SessionSummary {
@@ -64,6 +66,7 @@ export class ManagedSession {
   readonly permissionMode: PermissionMode;
   readonly maxTurns: number;
   readonly maxLifetimeS: number;
+  readonly claudeCodePath: string | undefined;
   readonly createdAt: number;
   readonly subject: string;
   readonly heartbeatSubject: string;
@@ -90,6 +93,7 @@ export class ManagedSession {
     this.permissionMode = opts.permissionMode;
     this.maxTurns = opts.maxTurns;
     this.maxLifetimeS = opts.maxLifetimeS;
+    this.claudeCodePath = opts.claudeCodePath;
     this.createdAt = Date.now();
     this.lastActivity = this.createdAt;
     this.subject = sessionPromptSubject(this.owner, this.sessionId);
@@ -254,6 +258,9 @@ export class ManagedSession {
       };
       if (this.sdkSessionId) {
         queryOptions.resume = this.sdkSessionId;
+      }
+      if (this.claudeCodePath) {
+        queryOptions.pathToClaudeCodeExecutable = this.claudeCodePath;
       }
 
       const stream = query({ prompt: pr.body, options: queryOptions });

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -1,0 +1,389 @@
+// Per-session glue: bridges one Claude Agent SDK session to a SDK
+// `ReferenceAgent` registered on the protocol-standard subject. Handles
+// envelope parsing, request queueing for serial drain (the SDK's `query()`
+// is one full multi-turn round-trip per call, and concurrent re-entry into
+// the same logical session would interleave context), typed-chunk
+// streaming, error headers, and disposal.
+
+import type { NatsConnection } from "@nats-io/nats-core";
+import type { ServiceMsg } from "@nats-io/services";
+import { ReferenceAgent } from "@synadia-ai/agents/testing";
+import { query, type Options, type PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+
+import { cleanupStaged, decorateWithAttachments, stageAttachments } from "./attachments.js";
+import { responseText, statusAck } from "./chunk-encoder.js";
+import { EnvelopeError, parseEnvelope, type ParsedAttachment } from "./envelope.js";
+import { sessionHeartbeatSubject, sessionPromptSubject } from "./subjects.js";
+
+export interface ManagedSessionOptions {
+  readonly nc: NatsConnection;
+  readonly owner: string;
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly model: string;
+  readonly allowedTools: ReadonlyArray<string>;
+  readonly permissionMode: PermissionMode;
+  readonly maxTurns: number;
+  readonly maxLifetimeS: number;
+}
+
+export interface SessionSummary {
+  readonly session_id: string;
+  readonly subject: string;
+  readonly heartbeat_subject: string;
+  readonly cwd: string;
+  readonly model: string;
+  readonly allowed_tools: ReadonlyArray<string>;
+  readonly permission_mode: PermissionMode;
+  readonly max_turns: number;
+  readonly max_lifetime_s: number;
+  readonly remaining_lifetime_s: number;
+  readonly active_request: boolean;
+  readonly queued_requests: number;
+  readonly created_at: string;
+  readonly last_activity: string;
+  /** SDK session id, populated after the first turn finishes (used for resume). */
+  readonly sdk_session_id?: string;
+}
+
+interface PendingRequest {
+  readonly requestId: string;
+  readonly msg: ServiceMsg;
+  readonly body: string;
+  readonly createdAt: number;
+  readonly stagedDir: string | undefined;
+}
+
+const HEARTBEAT_INTERVAL_S = 30;
+
+export class ManagedSession {
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly model: string;
+  readonly allowedTools: ReadonlyArray<string>;
+  readonly permissionMode: PermissionMode;
+  readonly maxTurns: number;
+  readonly maxLifetimeS: number;
+  readonly createdAt: number;
+  readonly subject: string;
+  readonly heartbeatSubject: string;
+
+  private readonly nc: NatsConnection;
+  private readonly owner: string;
+  private readonly refAgent: ReferenceAgent;
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly requestQueue: string[] = [];
+  private readonly activeAborts = new Set<AbortController>();
+  private activeRequestId: string | null = null;
+  private lastActivity: number;
+  private requestCounter = 0;
+  private sdkSessionId: string | undefined;
+  private disposed = false;
+
+  constructor(opts: ManagedSessionOptions) {
+    this.nc = opts.nc;
+    this.owner = opts.owner;
+    this.sessionId = opts.sessionId;
+    this.cwd = opts.cwd;
+    this.model = opts.model;
+    this.allowedTools = opts.allowedTools;
+    this.permissionMode = opts.permissionMode;
+    this.maxTurns = opts.maxTurns;
+    this.maxLifetimeS = opts.maxLifetimeS;
+    this.createdAt = Date.now();
+    this.lastActivity = this.createdAt;
+    this.subject = sessionPromptSubject(this.owner, this.sessionId);
+    this.heartbeatSubject = sessionHeartbeatSubject(this.owner, this.sessionId);
+
+    const extraMetadata: Record<string, string> = {
+      spawner: "claude-code-headless",
+      cwd: this.cwd,
+      model: this.model,
+      permission_mode: this.permissionMode,
+      allowed_tools: this.allowedTools.join(","),
+      max_turns: String(this.maxTurns),
+      max_lifetime_s: String(this.maxLifetimeS),
+    };
+
+    this.refAgent = new ReferenceAgent({
+      nc: this.nc,
+      agent: "cc",
+      owner: this.owner,
+      name: this.sessionId,
+      session: this.sessionId,
+      description: `claude-code-headless session ${this.sessionId} (${this.cwd})`,
+      version: "0.1.0",
+      maxPayload: "1MB",
+      attachmentsOk: true,
+      heartbeatIntervalS: HEARTBEAT_INTERVAL_S,
+      extraMetadata,
+      promptHandler: (msg) => this.handlePrompt(msg),
+    });
+  }
+
+  async start(): Promise<void> {
+    await this.refAgent.start();
+  }
+
+  get instanceId(): string {
+    return this.refAgent.instanceId;
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  summary(): SessionSummary {
+    const now = Date.now();
+    const elapsed = Math.floor((now - this.createdAt) / 1000);
+    const remaining = this.maxLifetimeS > 0 ? Math.max(0, this.maxLifetimeS - elapsed) : 0;
+    return {
+      session_id: this.sessionId,
+      subject: this.subject,
+      heartbeat_subject: this.heartbeatSubject,
+      cwd: this.cwd,
+      model: this.model,
+      allowed_tools: this.allowedTools,
+      permission_mode: this.permissionMode,
+      max_turns: this.maxTurns,
+      max_lifetime_s: this.maxLifetimeS,
+      remaining_lifetime_s: remaining,
+      active_request: this.activeRequestId !== null,
+      queued_requests: this.requestQueue.length,
+      created_at: new Date(this.createdAt).toISOString(),
+      last_activity: new Date(this.lastActivity).toISOString(),
+      ...(this.sdkSessionId ? { sdk_session_id: this.sdkSessionId } : {}),
+    };
+  }
+
+  // ─── Prompt path ────────────────────────────────────────────────────────────
+
+  private async handlePrompt(msg: ServiceMsg): Promise<void> {
+    if (this.disposed) {
+      try {
+        msg.respond("");
+      } catch {
+        /* connection gone */
+      }
+      return;
+    }
+
+    let envelope;
+    try {
+      envelope = parseEnvelope(msg.data);
+    } catch (e) {
+      if (e instanceof EnvelopeError) {
+        try {
+          msg.respondError(e.code, e.message);
+        } catch {
+          /* noop */
+        }
+        try {
+          msg.respond("");
+        } catch {
+          /* noop */
+        }
+        return;
+      }
+      throw e;
+    }
+
+    let stagedDir: string | undefined;
+    let body = envelope.prompt;
+    const attachments = envelope.attachments;
+    if (attachments && attachments.length > 0) {
+      try {
+        const staged = await stageAttachments(this.sessionId, attachments as ParsedAttachment[]);
+        stagedDir = staged.dir;
+        body = decorateWithAttachments(body, staged.paths);
+      } catch (e) {
+        try {
+          msg.respondError(400, `failed to stage attachments: ${(e as Error).message}`);
+          msg.respond("");
+        } catch {
+          /* noop */
+        }
+        return;
+      }
+    }
+
+    const requestId = `${this.sessionId}-${++this.requestCounter}`;
+    this.pendingRequests.set(requestId, {
+      requestId,
+      msg,
+      body,
+      createdAt: Date.now(),
+      stagedDir,
+    });
+    this.requestQueue.push(requestId);
+    this.lastActivity = Date.now();
+    void this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    if (this.disposed) return;
+    if (this.activeRequestId !== null) return;
+    const next = this.requestQueue.shift();
+    if (!next) return;
+    const pr = this.pendingRequests.get(next);
+    if (!pr) {
+      void this.drain();
+      return;
+    }
+
+    this.activeRequestId = next;
+    this.lastActivity = Date.now();
+
+    const abortController = new AbortController();
+    this.activeAborts.add(abortController);
+
+    try {
+      try {
+        pr.msg.respond(statusAck());
+      } catch {
+        /* noop */
+      }
+
+      const queryOptions: Options = {
+        cwd: this.cwd,
+        model: this.model,
+        allowedTools: [...this.allowedTools],
+        permissionMode: this.permissionMode,
+        maxTurns: this.maxTurns,
+        abortController,
+      };
+      if (this.sdkSessionId) {
+        queryOptions.resume = this.sdkSessionId;
+      }
+
+      const stream = query({ prompt: pr.body, options: queryOptions });
+      for await (const ev of stream) {
+        if (ev.type === "system" && "subtype" in ev && ev.subtype === "init") {
+          this.sdkSessionId = ev.session_id;
+          continue;
+        }
+        if (ev.type === "assistant") {
+          for (const block of ev.message.content) {
+            if (block.type === "text") {
+              const text = (block as { text?: unknown }).text;
+              if (typeof text === "string" && text.length > 0) {
+                try {
+                  pr.msg.respond(responseText(text));
+                } catch {
+                  /* noop */
+                }
+              }
+            }
+            // tool_use / thinking blocks intentionally suppressed in the spike.
+            // TODO: relay tool_use as protocol §7 query chunks.
+          }
+          continue;
+        }
+        if (ev.type === "result") {
+          this.sdkSessionId = ev.session_id;
+          if (ev.subtype !== "success") {
+            try {
+              pr.msg.respondError(500, `claude-agent-sdk: ${ev.subtype}`);
+            } catch {
+              /* noop */
+            }
+          }
+          break;
+        }
+      }
+    } catch (e) {
+      const err = e as Error;
+      if (err.name === "AbortError" || abortController.signal.aborted) {
+        // Disposal aborted us; just terminate the reply.
+      } else {
+        try {
+          pr.msg.respondError(500, err.message || "agent error");
+        } catch {
+          /* noop */
+        }
+      }
+    } finally {
+      this.activeAborts.delete(abortController);
+      try {
+        pr.msg.respond("");
+      } catch {
+        /* noop */
+      }
+      if (pr.stagedDir) {
+        void cleanupStaged({ dir: pr.stagedDir, paths: [] });
+      }
+      this.pendingRequests.delete(next);
+      this.activeRequestId = null;
+      this.lastActivity = Date.now();
+
+      if (!this.disposed && this.requestQueue.length > 0) {
+        setImmediate(() => void this.drain());
+      }
+    }
+  }
+
+  // ─── Lifetime / pruning (called by ClaudeSessionManager) ───────────────────
+
+  /** Returns true if this session has outlived its maxLifetime. */
+  expired(now: number = Date.now()): boolean {
+    if (this.maxLifetimeS <= 0) return false;
+    return now - this.createdAt > this.maxLifetimeS * 1000;
+  }
+
+  /** Evict requests older than cutoffMs that aren't currently active. */
+  pruneStale(cutoffMs: number): number {
+    let removed = 0;
+    const cutoff = Date.now() - cutoffMs;
+    for (const [id, pr] of this.pendingRequests) {
+      if (id === this.activeRequestId) continue;
+      if (pr.createdAt < cutoff) {
+        this.pendingRequests.delete(id);
+        const qi = this.requestQueue.indexOf(id);
+        if (qi >= 0) this.requestQueue.splice(qi, 1);
+        try {
+          pr.msg.respond("");
+        } catch {
+          /* noop */
+        }
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  // ─── Disposal ──────────────────────────────────────────────────────────────
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    // Cancel any in-flight SDK queries so callers don't hang.
+    for (const ac of this.activeAborts) {
+      try {
+        ac.abort();
+      } catch {
+        /* noop */
+      }
+    }
+    this.activeAborts.clear();
+
+    // Terminate in-flight replies so callers don't hang.
+    for (const pr of this.pendingRequests.values()) {
+      try {
+        pr.msg.respond("");
+      } catch {
+        /* noop */
+      }
+    }
+    this.pendingRequests.clear();
+    this.requestQueue.length = 0;
+
+    try {
+      await this.refAgent.stop();
+    } catch (e) {
+      process.stderr.write(
+        `claude-code-headless: refAgent.stop() failed for ${this.sessionId}: ${(e as Error).message}\n`,
+      );
+    }
+  }
+}

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -528,8 +528,16 @@ export class ManagedSession {
     }
     this.activeAborts.clear();
 
-    // Terminate in-flight replies so callers don't hang.
+    // Terminate in-flight replies so callers don't hang. Mirror the
+    // pruneStale pattern: surface as a 503 error before the terminator so
+    // queued-but-not-active callers see onError("session stopped") rather
+    // than a misleading onDone identical to a clean completion.
     for (const pr of this.pendingRequests.values()) {
+      try {
+        pr.msg.respondError(503, "session stopped");
+      } catch {
+        /* noop */
+      }
       try {
         pr.msg.respond("");
       } catch {

--- a/examples/claude-code-headless/src/subjects.ts
+++ b/examples/claude-code-headless/src/subjects.ts
@@ -73,8 +73,11 @@ export function validateSessionId(
 
 /** Generate a short session id prefixed with `sess-`. URL-safe, 8 hex chars. */
 export function generateSessionId(): string {
-  const rand = Math.floor(Math.random() * 0xffffffff)
-    .toString(16)
-    .padStart(8, "0");
+  // crypto.getRandomValues is uniformly distributed and available in Bun and
+  // Node ≥ 19 without an import. Math.random would give the same nominal 32
+  // bits but with a biased distribution, so use the Web Crypto API instead.
+  const bytes = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(bytes);
+  const rand = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `sess-${rand}`;
 }

--- a/examples/claude-code-headless/src/subjects.ts
+++ b/examples/claude-code-headless/src/subjects.ts
@@ -1,0 +1,80 @@
+// Subject builders + session-id sanitizer for claude-code-headless.
+//
+// The controller lives at `agents.cc.<owner>.<name>` with three extra
+// endpoints on `.spawn`, `.stop`, `.list`. Each spawned session lives at
+// its own subject `agents.cc.<owner>.<session_id>` (registered by a
+// `ReferenceAgent` from the SDK's testing subpath), which means callers
+// can discover and prompt sessions using nothing but the standard
+// protocol.
+//
+// The `cc` token is shared with `agents/claude-code/` (Claude Code as
+// MCP-driven NATS client). They co-exist because the controller name
+// and per-session ids disambiguate the 4th subject token.
+
+export const AGENT_TOKEN = "cc";
+
+export function controllerPromptSubject(owner: string, name: string): string {
+  return `agents.${AGENT_TOKEN}.${owner}.${name}`;
+}
+
+export function controllerSpawnSubject(owner: string, name: string): string {
+  return `${controllerPromptSubject(owner, name)}.spawn`;
+}
+
+export function controllerStopSubject(owner: string, name: string): string {
+  return `${controllerPromptSubject(owner, name)}.stop`;
+}
+
+export function controllerListSubject(owner: string, name: string): string {
+  return `${controllerPromptSubject(owner, name)}.list`;
+}
+
+export function controllerHeartbeatSubject(owner: string, name: string): string {
+  return `${controllerPromptSubject(owner, name)}.heartbeat`;
+}
+
+export function sessionPromptSubject(owner: string, sessionId: string): string {
+  return `agents.${AGENT_TOKEN}.${owner}.${sessionId}`;
+}
+
+export function sessionHeartbeatSubject(owner: string, sessionId: string): string {
+  return `${sessionPromptSubject(owner, sessionId)}.heartbeat`;
+}
+
+// Tokens MUST follow §2.2: [a-z0-9_-], not starting with $, 1..63 chars.
+// We lowercase, replace everything else with `-`, collapse repeats, and trim
+// leading/trailing `-`. Empty input returns "" (caller decides what to do).
+const TOKEN_ALLOW_RE = /[^a-z0-9_-]+/g;
+const COLLAPSE_DASH_RE = /-{2,}/g;
+const TRIM_DASH_RE = /^-+|-+$/g;
+
+export function sanitizeToken(input: string): string {
+  const s = input
+    .toLowerCase()
+    .replace(TOKEN_ALLOW_RE, "-")
+    .replace(COLLAPSE_DASH_RE, "-")
+    .replace(TRIM_DASH_RE, "");
+  return s.slice(0, 63);
+}
+
+/**
+ * Validate a user-supplied session_id against §2.2 rules. Returns the
+ * sanitized form if it survives sanitization unchanged; otherwise returns
+ * null along with a suggestion.
+ */
+export function validateSessionId(
+  input: string,
+): { ok: true; sessionId: string } | { ok: false; suggestion: string } {
+  const s = sanitizeToken(input);
+  if (s.length === 0) return { ok: false, suggestion: "" };
+  if (s !== input) return { ok: false, suggestion: s };
+  return { ok: true, sessionId: s };
+}
+
+/** Generate a short session id prefixed with `sess-`. URL-safe, 8 hex chars. */
+export function generateSessionId(): string {
+  const rand = Math.floor(Math.random() * 0xffffffff)
+    .toString(16)
+    .padStart(8, "0");
+  return `sess-${rand}`;
+}

--- a/examples/claude-code-headless/tsconfig.json
+++ b/examples/claude-code-headless/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "types": ["bun", "node"]
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+}

--- a/examples/pi-headless/src/subjects.ts
+++ b/examples/pi-headless/src/subjects.ts
@@ -69,8 +69,11 @@ export function validateSessionId(
 
 /** Generate a short session id prefixed with `sess-`. URL-safe, 8 hex chars. */
 export function generateSessionId(): string {
-  const rand = Math.floor(Math.random() * 0xffffffff)
-    .toString(16)
-    .padStart(8, "0");
+  // crypto.getRandomValues is uniformly distributed and available in Bun and
+  // Node ≥ 19 without an import. Math.random would give the same nominal 32
+  // bits but with a biased distribution, so use the Web Crypto API instead.
+  const bytes = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(bytes);
+  const rand = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `sess-${rand}`;
 }


### PR DESCRIPTION
## Summary

Adds two co-evolved pieces:

- **`examples/claude-code-headless`** — a NATS-driven service that spawns Claude Code sessions on demand via `@anthropic-ai/claude-agent-sdk`. Each session registers as a first-class NATS Agent Protocol v0.2.0-draft instance at `agents.cc.<owner>.<session_id>`; a small controller at `agents.cc.<owner>.<name>` exposes `spawn` / `stop` / `list` endpoints. Streams text per token, surfaces tool calls + results inline, asks for permission via §7 query chunks, tracks per-turn and cumulative cost.
- **`examples/agent-web-ui`** — new "CC Exec" mode mirroring the existing PI Exec workspace. Controller selector + spawn form (cwd, model, allowed tools, permission mode, max turns, max lifetime) on the left; chat surface on the right with collapsible tool cards (name + input + result + success/error glyph) and Allow/Deny prompts when Claude wants a tool that isn't pre-approved. Per-turn cost on each agent bubble; cumulative cost + turn count on each session card.

Together they're a working "headless Claude Code in a browser tab" demo: spawn a session over NATS, prompt it, watch Claude type, approve tool calls one by one, see the running cost — all driven by clicks in a Vue 3 SPA backed by a Bun WebSocket bridge.

## What's in the diff

**Server side** (`examples/claude-code-headless/`):
- Controller registers a `cc`-token NATS micro service, exposes `spawn` / `stop` / `list` endpoints + a `prompt` endpoint that returns help text, publishes 30s heartbeats.
- Per-session bridge owns one Claude Agent SDK lifecycle behind a `ReferenceAgent`. Serial drain queue, ` query()` with `includePartialMessages`, cancellation via `AbortController`, session resume via `resume: <sdkSessionId>`.
- Permission flow: `canUseTool` callback emits a fresh `query` chunk on a unique inbox + awaits one reply (2 min timeout); `yes/y/allow/approve/ok` → allow, anything else → deny with reply preserved as the reason. Echoes the tool input back as `updatedInput` because the SDK's runtime Zod validator requires it (TS type marks it optional — mismatch noted below).
- Tool observability + cost as prefix-tagged status payloads (`tool_use:<json>`, `tool_result:<json>`, `cost:<json>`). Spec-compliant — `status.data` stays a string per §6.4. SDK callers without prefix knowledge see opaque status tokens.
- Resolves the bundled `claude` binary via CLI flag → env → config file → `Bun.which("claude")` → SDK fallback. Side-steps the SDK's per-platform-package auto-detect picking a variant that isn't installed.
- Conservative defaults: `permissionMode: "dontAsk"`, `allowedTools: [Read, Glob, Grep]`, `claude-sonnet-4-6`, 50-turn cap, 30-min lifetime — overridable per-spawn.

**Client side** (`examples/agent-web-ui/`):
- Bridge handlers translate the prefix-tagged status payloads into typed `tool-use` / `tool-result` / `cost` server messages.
- Generic `controlRequest<T>` helper replaces the PI-specific `piexecRequest`; CC Exec endpoints share the routing.
- New `tool` MessageRole + ToolCallInfo data model; `findMessageByToolId` pairs results back with their tool_use bubble.
- New CC Exec view (`src/components/ccexec/`): ControllerSelector, SpawnForm, SessionList, CcExecView. Mirrors PI Exec's shape; reuses the generic chat / message-list / prompt-area surface.
- App.vue: third "CC Exec" mode toggle, auto-shown when a controller is discovered, vanish-fallback to chat mode when it disappears.
- Drive-by fix: `crypto.randomUUID()` polyfill for non-secure HTTP origins (`src/uuid.ts`). Both PI Exec and CC Exec hit this when accessed from a LAN browser; without the polyfill the click handler died silently.

**Shared docs** (READMEs for both `examples/claude-code-headless` and `agents/claude-code`):
- API-key-only auth posture: `ANTHROPIC_API_KEY` recommended for both Claude Code wrappers regardless of deployment scope. The runtime fallback to `~/.claude` still works (the SDK uses the env var in preference when both are present), but the recommended path in docs is unambiguous to avoid the personal-use-vs-multi-user trap.

## Out of scope (roadmap)

Documented in the headless README's Roadmap section:
- Programmatic MCP server attachment per spawn (`mcp_servers` field).
- System prompt / append-system-prompt override per spawn (personas).
- "Always allow" stickiness for permissions (use SDK's `updatedPermissions`).
- Streaming or paginated tool results (currently truncated at 4 KB).
- Periodic cleanup of the SDK's on-disk session store.

## SDK quirks worth flagging upstream

1. **Native binary auto-detection picks the wrong variant** on some platforms (linux-x64-musl variant attempted on a glibc box where the musl optional dep wasn't installed). Worked around with explicit path resolution at startup.
2. **\`PermissionResult.updatedInput\` Zod-vs-TS mismatch** — TS type marks it optional, Zod validator requires a \`record\` on the allow branch. Returning \`{ behavior: "allow" }\` causes the SDK to reject the canUseTool reply with a \`ZodError\`. Worked around by echoing \`input\` back.

## Test plan

- [ ] \`bun run typecheck\` clean in \`examples/claude-code-headless\`
- [ ] \`bun run typecheck\` + \`bun run build\` clean in \`examples/agent-web-ui\`
- [ ] Bootstrap headless without NATS → graceful "connection refused" exit
- [ ] Bootstrap headless without \`ANTHROPIC_API_KEY\` → startup hint logged pointing at the README
- [ ] End-to-end via web UI:
  - [ ] CC Exec tab appears when a controller is discovered
  - [ ] Spawn a session with \`permission_mode: default\` + \`allowed_tools: Read,Glob,Grep\` succeeds
  - [ ] Prompt fires per-token text streaming + tool cards render inline
  - [ ] Permission prompt appears for a non-allowlisted tool (Write)
  - [ ] Allow click resolves canUseTool with \`updatedInput\`; tool actually executes
  - [ ] Cost annotation appears on agent bubbles + session card running total
  - [ ] Stop button cancels mid-turn cleanly
  - [ ] Multiple parallel sessions from one controller work independently
- [ ] PI Exec mode unaffected (regression check)
- [ ] Chat mode unaffected (regression check)