### PR TITLE
docs: surface reference agents + per-SDK demo scripts in root README/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,37 @@ the GitHub URL when reasoning about wire shape. Local
 `docs/protocol-mapping.md` files inside each SDK translate spec → impl;
 they are not the spec itself.
 
+## Reference agents — canonical implementations
+
+Every SDK in this repo ships a spec-compliant **reference agent** that
+implements the full §12 agent-checklist (service registration, prompt
+endpoint, status endpoint, heartbeats on `agents.hb.*.*.*`, terminator
+semantics). When reasoning about wire shape, expected on-the-wire
+behaviour, or testing a new SDK / agent, read these first — they are
+the authoritative on-the-wire counterpart to the spec doc.
+
+- **TypeScript**: `client-sdk/typescript/src/testing/reference-agent.ts`
+  — the `ReferenceAgent` class, importable from third-party packages
+  via `@synadia-ai/agents/testing`. Runnable script:
+  `client-sdk/typescript/examples/_run-reference-agent.ts`.
+- **Python**: `client-sdk/python/examples/_reference_agent.py` — a
+  runnable echo agent with conversation memory, used as the test
+  harness for the numbered demos and as a wire-compat counterparty.
+
+Each SDK also has a parallel set of numbered demo scripts that exercise
+discovery, prompting (text + attachments), mid-stream queries, and
+liveness against the reference agent — useful both as documentation
+and as a smoke surface:
+
+- TS: `client-sdk/typescript/examples/01-discover.ts` … `05-liveness.ts`.
+- Python: `client-sdk/python/examples/01-discover.py` … `05-liveness.py`,
+  plus `06-chat.py` (interactive REPL). See
+  `client-sdk/python/examples/README.md` for the full table.
+
+The Python interop test (`client-sdk/python/tests/test_interop_e2e.py`)
+runs the TS reference agent as a subprocess and validates wire
+compatibility between the two SDKs.
+
 ## Repository layout (and what's published)
 
 | Path | Package | Published as | Notes |
@@ -173,8 +204,17 @@ and publish to PyPI via `uv publish`.
 
 - `README.md` — repo overview, layout, subject namespace, wire
   shape.
+- `client-sdk/typescript/src/testing/reference-agent.ts` and
+  `client-sdk/python/examples/_reference_agent.py` — canonical
+  spec-compliant reference agents (see "Reference agents" section
+  above). Read these before touching anything wire-shape-y.
+- `client-sdk/typescript/examples/` and `client-sdk/python/examples/`
+  — parallel numbered demo scripts (`01-discover` …) that exercise
+  the SDKs end-to-end against the reference agent.
 - `client-sdk/typescript/CHANGELOG.md`, `client-sdk/python/CHANGELOG.md`
   — recent API moves (Keep a Changelog format).
 - `client-sdk/python/CLAUDE.md` — package-specific deep guide; mirror
   it if you need the same depth on the TS side.
 - `agents/*/README.md` — per-agent config, subject layout, install.
+- `examples/README.md` — runnable end-to-end demos in the monorepo
+  (browser test client, headless controllers, DSPy ReAct).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ synadia-agents/
 
 Each subtree has its own `README.md`. The index READMEs (`client-sdk/README.md`, `agents/README.md`, `examples/README.md`) describe what lives at each level.
 
+## Reference agents and demo scripts
+
+Both SDKs ship a **spec-compliant reference agent** plus a parallel set of numbered demo scripts. The reference agent is the canonical implementation of every §12 agent-checklist requirement — registration, heartbeats, status endpoint, stream-terminator semantics. Third-party SDKs and AI/LLM-generated tooling should test against it. The numbered demos are the fastest way to exercise either SDK end-to-end.
+
+| SDK | Reference agent | Demo scripts |
+| --- | --- | --- |
+| TypeScript | `ReferenceAgent` class — [`client-sdk/typescript/src/testing/reference-agent.ts`](client-sdk/typescript/src/testing/reference-agent.ts), importable as `@synadia-ai/agents/testing`. Runnable script: [`client-sdk/typescript/examples/_run-reference-agent.ts`](client-sdk/typescript/examples/_run-reference-agent.ts). | [`client-sdk/typescript/examples/`](client-sdk/typescript/examples/) — `01-discover.ts`, `02-prompt-text.ts`, `03-prompt-attachment.ts`, `04-query-reply.ts`, `05-liveness.ts`. |
+| Python | Runnable echo agent (with conversation memory) — [`client-sdk/python/examples/_reference_agent.py`](client-sdk/python/examples/_reference_agent.py). | [`client-sdk/python/examples/`](client-sdk/python/examples/) — `01-discover.py` through `05-liveness.py`, plus `06-chat.py` (interactive REPL). See the [examples README](client-sdk/python/examples/README.md). |
+
+The Python side also has [`tests/test_interop_e2e.py`](client-sdk/python/tests/test_interop_e2e.py), which runs the TS reference agent as a subprocess and validates wire compatibility between the two SDKs.
+
+For larger end-to-end examples — controllers that spawn ephemeral agents, a browser test client, a from-scratch DSPy ReAct agent — see [`examples/`](examples/) and its [README](examples/README.md).
+
 ## Subject namespace
 
 The protocol only requires an endpoint named `prompt` - the subject it's served on is up to each agent. For the agents in this repo we've chosen a single verb-first pattern (v0.3):


### PR DESCRIPTION
## Summary

The two SDKs each ship a spec-compliant reference agent and a parallel set of numbered demo scripts, but neither was discoverable from the root docs. An LLM (or human) reading just `README.md` could miss them entirely; the only existing mention was a single line in `CLAUDE.md` about the Python interop test.

This PR adds explicit pointers in two places:

- **`README.md`** — new section *"Reference agents and demo scripts"* between *"Repository layout"* and *"Subject namespace"*. A 2-row table names every reference-agent path (TS class + runnable script; Python runnable agent), lists the parallel `01-…` → `05-liveness` demo scripts (Python adds `06-chat`), and points at the Python interop test that runs the TS reference agent as a subprocess.
- **`CLAUDE.md`** — new dedicated *"Reference agents — canonical implementations"* section near the top (right after *"What this repo is"*), plus three new bullets in *"Where to look first"* (reference agents, demo scripts directories, examples README).

The motivating use case: when designing a new SDK, generating a new agent, or reasoning about wire-shape edge cases, the reference agents are the authoritative on-the-wire counterpart to the spec doc. Calling them out explicitly removes a tribal-knowledge gap.

## What's not in this PR

- No code changes — docs only.
- Sub-READMEs (e.g. `client-sdk/README.md`, `examples/README.md`) already reference `ReferenceAgent` in context; not adjusting those here to keep the diff small. Happy to expand if reviewer wants.
- The TS examples directory has no README; the file naming + per-file comments are enough today, so I haven't added one. Same call.

## Test plan

- [ ] Render the diffs on GitHub and verify the new `README.md` section, the new `CLAUDE.md` section, and the new `Where to look first` bullets all read cleanly.
- [ ] Confirm the linked file paths exist:
  - `client-sdk/typescript/src/testing/reference-agent.ts` ✓
  - `client-sdk/typescript/examples/_run-reference-agent.ts` ✓
  - `client-sdk/python/examples/_reference_agent.py` ✓
  - `client-sdk/python/tests/test_interop_e2e.py` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)