### PR TITLE
client-sdks: bump default discover stall 200ms → 750ms (#31 — WAN broker fix)

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -17,6 +17,15 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
   (`_INBOX.agents.>`) covers caller-side reply traffic regardless of
   language. The connection's `inbox_prefix` is no longer consulted for
   agents-SDK reply subjects; not user-overridable.
+- `DEFAULT_DISCOVER_STALL_S` bumped from `0.2` → `0.75` so the default
+  `discover()` (stall strategy) survives a transcontinental NATS
+  round-trip — e.g. demo.nats.io reports ~315 ms RTT from a non-US
+  client, which previously caused `discover()` to return an empty
+  list before the first reply arrived. Snappy on LAN brokers stays
+  true at 750 ms (still well under one perceptible UI tick); callers
+  wanting a tighter window can pass `stall=` to `agents.discover()` /
+  `discover_agents()`. Fixes [#31]. Mirrors the same constant change
+  in the TypeScript SDK so cross-SDK defaults stay aligned.
 
 ### Changed (breaking, public API)
 

--- a/client-sdk/python/src/synadia_ai/agents/discovery.py
+++ b/client-sdk/python/src/synadia_ai/agents/discovery.py
@@ -65,7 +65,14 @@ STATUS_QUEUE_GROUP = "agents"
 
 # Idle window after the most recent reply before discover() returns
 # (stall strategy). Mirrors TS DEFAULT_DISCOVER_STALL_MS.
-DEFAULT_DISCOVER_STALL_S: float = 0.2
+#
+# Sized to comfortably absorb a transcontinental NATS round-trip — e.g.
+# demo.nats.io reports ~315 ms RTT from a non-US client. At 750 ms we
+# still return well under one perceptible UI tick on a LAN, but no
+# longer time out before the first reply arrives on a WAN (the symptom
+# that issue #31 surfaced). Callers who want a snappier scan can pass
+# `stall=` to `agents.discover()` or `discover_agents()`.
+DEFAULT_DISCOVER_STALL_S: float = 0.75
 
 # Absolute safety cap when using the stall strategy. Mirrors TS
 # DEFAULT_DISCOVER_MAX_WAIT_MS.

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -112,6 +112,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   tests that exercise it cover the new endpoint automatically. The
   `subjectAgentToken` option is gone — agents declare a single
   `agent` token used in both metadata and the subject.
+- `DEFAULT_DISCOVER_STALL_MS` bumped from `200` → `750` so the default
+  `discover()` (stall strategy) survives a transcontinental NATS
+  round-trip — e.g. demo.nats.io reports ~315 ms RTT from a non-US
+  client, which previously caused `discover()` to return an empty
+  list before the first reply arrived. Snappy on LAN brokers stays
+  true at 750 ms (still well under one perceptible UI tick); callers
+  wanting a tighter window can pass `timeoutMs` (timer strategy) or
+  the lower-level `stallMs`. Fixes [#31].
 
 ### Anticipated companion work (this release)
 

--- a/client-sdk/typescript/src/discovery/srv-ping.ts
+++ b/client-sdk/typescript/src/discovery/srv-ping.ts
@@ -14,8 +14,18 @@ import { buildAgentInfo, type AgentInfo } from "./agent-info.js";
 
 /** Absolute safety cap when using the stall strategy (no explicit timeoutMs). */
 export const DEFAULT_DISCOVER_MAX_WAIT_MS = 2000;
-/** Idle window after the last reply before the stall strategy returns. */
-export const DEFAULT_DISCOVER_STALL_MS = 200;
+/**
+ * Idle window after the last reply before the stall strategy returns.
+ *
+ * Sized to comfortably absorb a transcontinental NATS round-trip
+ * (e.g. demo.nats.io reports ~315 ms RTT from a non-US client). At 750 ms
+ * we still return well under one perceptible UI tick on a LAN, but no
+ * longer time out before the first reply arrives on a WAN — the
+ * symptom that issue #31 surfaced. Callers who want a snappier scan on
+ * a known-fast broker can still pass `timeoutMs` (timer strategy) or
+ * call the lower-level helpers with their own `stall_s` / `stallMs`.
+ */
+export const DEFAULT_DISCOVER_STALL_MS = 750;
 
 export interface DiscoveryFilter {
   readonly agent?: string;


### PR DESCRIPTION
## Summary

Fixes [#31](https://github.com/synadia-ai/synadia-agents/issues/31). Both SDKs hardcode the same idle-window default for `discover()`'s stall strategy at **200 ms**. That's sized for a LAN broker. Against a WAN broker (issue surfaced this on `demo.nats.io`, ~315 ms RTT from a non-US client) `request_many_stall` times out *before* the first `\$SRV.INFO.agents` reply arrives, so `discover()` returns an empty list and the bundled `02-prompt-text.{ts,py}` example prints "no agents found" against a perfectly healthy agent.

Bumped the default to **750 ms** — comfortable margin over a transcontinental RTT (≥ 2× demo.nats.io's ~315 ms), still well under one perceptible UI tick on a LAN, still well under the existing 2 s `MAX_WAIT` safety cap. Callers that want a tighter window can still pass `timeoutMs` (timer strategy) or call the lower-level helper with their own `stall` / `stall_s`.

The change is wire-compat-safe — it's a client-side request-strategy constant, no protocol behaviour changes.

## What's in this PR (4 files)

| file | change |
|---|---|
| `client-sdk/typescript/src/discovery/srv-ping.ts` | `DEFAULT_DISCOVER_STALL_MS = 200 → 750` + docstring |
| `client-sdk/python/src/synadia_ai/agents/discovery.py` | `DEFAULT_DISCOVER_STALL_S = 0.2 → 0.75` + docstring |
| `client-sdk/typescript/CHANGELOG.md` | `[Unreleased]` entry |
| `client-sdk/python/CHANGELOG.md` | `[Unreleased]` entry |

Cross-SDK defaults are kept aligned per `client-sdk/python/CLAUDE.md`'s "wire compatibility" rule (when both SDKs pick the same default, drift is a bug).

## Out of scope (issue #31 also suggests)

The issue lists three fixes; this PR is suggestion **(1)** only:

1. ✅ **Bump the default** — this PR.
2. ⏳ **Expose `--stall` / `--timeout` on the example CLIs** — can be a separate PR per SDK; small scope, but UX-breaking if defaults change underneath.
3. ⏳ **Improve the empty-result message** in the examples — same.

Happy to do (2) and (3) in follow-up PRs once the bot review on this one is in.

## Verification

- **TS**: `bun run typecheck` clean. `bun run test:unit` — 201 / 201 passing.
- **Python**: `uv run ruff check --no-cache` clean on touched files. `uv run ruff format --check` clean. `uv run mypy --no-incremental` clean. `uv run pytest tests/test_discovery.py` — 4 / 4 passing.

## Note on TS `format:check`

The TS SDK's `Lint + typecheck` CI job has been failing on `main` for unrelated pre-existing whitespace drift across 6 files this PR doesn't touch (see GitHub Actions run `25077554126`). My CHANGELOG addition is itself prettier-clean — only the pre-existing drift remains. Cleaning that up is genuinely orthogonal to this fix; can ship as its own one-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)