### PR TITLE
docs(hermes): default install assumes PyPI; collapse pre-PyPI workaround

### DIFF
--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -13,20 +13,6 @@ Hermes is a self-improving coding agent with a CLI, a TUI, and a messaging gatew
 
 Sibling implementations sharing the same wire protocol: [`pi`](../pi) (PI), [`openclaw`](../openclaw) (OpenClaw), [`claude-code`](../claude-code) (Claude Code).
 
-## How it works
-
-When `hermes gateway run` starts with `platforms.nats.enabled = true`:
-
-1. Connects to NATS using a configured context (or `demo.nats.io` by default via `$NATS_URL`).
-2. Registers a NATS micro service named `agents` with v0.3 spec metadata (`agent`, `owner`, `protocol_version`).
-3. Adds a `prompt` endpoint at `agents.prompt.hermes.<owner>.<session_name>` advertising `max_payload: 1MB` and `attachments_ok: true`, and a `status` endpoint at `agents.status.hermes.<owner>.<session_name>` for on-demand liveness.
-4. Publishes heartbeats on `agents.hb.hermes.<owner>.<session_name>` every 30 s.
-5. On each inbound prompt: decodes any attached files to the gateway's attachment staging area, routes images through Hermes's `vision_analyze` tool so the agent actually sees them, emits a `status: ack` chunk, runs the full Hermes agent loop (tools, memory, skills, approvals) to completion, and streams model output back as typed `{type:"response","data":…}` chunks, terminating with the spec-mandated empty-body no-headers terminator.
-6. Malformed envelopes, oversized payloads, invalid base64, and unsafe filenames are rejected at the wire with `Nats-Service-Error-Code: 400`. Internal failures return `500`.
-7. Mid-stream approval prompts (dangerous tool calls) are surfaced as spec §7 `query` chunks when a caller drives a prompt; see `examples/04-query-reply.py` in the SDK.
-
-**Single-session-per-service (v0.3 §-PR #26).** One Hermes gateway = one `AgentService` = one `session_name` (the 5th subject token). For multiple isolated sessions on one host, run multiple **Hermes profiles** — each profile registers its own service with its own `session_name`. This matches the way pi/openclaw/claude-code already work; the v0.2 `envelope.session` demux is gone.
-
 ## Install
 
 Two parts: (1) clone the fork and bootstrap Hermes, (2) configure the gateway.
@@ -281,6 +267,20 @@ To talk to a *different* conversation, point `DiscoverFilter(session_name=...)` 
 | `examples/06-chat.py` | Multi-turn chat against one selected agent |
 
 All honor `--context`, `--url`, `$NATS_URL`, or `nats context select` (in that order). Examples that take a target agent honor `--session NAME` to filter by `session_name`.
+
+## How it works
+
+When `hermes gateway run` starts with `platforms.nats.enabled = true`:
+
+1. Connects to NATS using a configured context (or `demo.nats.io` by default via `$NATS_URL`).
+2. Registers a NATS micro service named `agents` with v0.3 spec metadata (`agent`, `owner`, `protocol_version`).
+3. Adds a `prompt` endpoint at `agents.prompt.hermes.<owner>.<session_name>` advertising `max_payload: 1MB` and `attachments_ok: true`, and a `status` endpoint at `agents.status.hermes.<owner>.<session_name>` for on-demand liveness.
+4. Publishes heartbeats on `agents.hb.hermes.<owner>.<session_name>` every 30 s.
+5. On each inbound prompt: decodes any attached files to the gateway's attachment staging area, routes images through Hermes's `vision_analyze` tool so the agent actually sees them, emits a `status: ack` chunk, runs the full Hermes agent loop (tools, memory, skills, approvals) to completion, and streams model output back as typed `{type:"response","data":…}` chunks, terminating with the spec-mandated empty-body no-headers terminator.
+6. Malformed envelopes, oversized payloads, invalid base64, and unsafe filenames are rejected at the wire with `Nats-Service-Error-Code: 400`. Internal failures return `500`.
+7. Mid-stream approval prompts (dangerous tool calls) are surfaced as spec §7 `query` chunks when a caller drives a prompt; see `examples/04-query-reply.py` in the SDK.
+
+**Single-session-per-service (v0.3 §-PR #26).** One Hermes gateway = one `AgentService` = one `session_name` (the 5th subject token). For multiple isolated sessions on one host, run multiple **Hermes profiles** — each profile registers its own service with its own `session_name`. This matches the way pi/openclaw/claude-code already work; the v0.2 `envelope.session` demux is gone.
 
 ## Subject hierarchy (v0.3 verb-first)
 

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -29,61 +29,58 @@ When `hermes gateway run` starts with `platforms.nats.enabled = true`:
 
 ## Install
 
-The install has three parts: (1) clone the fork and bootstrap Hermes, (2) install the Python SDK editable from this monorepo (not yet on PyPI), (3) configure the gateway. Sibling agents ship as npm plugins; Hermes is a full application, so the first two steps look different.
-
-### Directory layout
-
-You're reading this README inside a clone of `synadia-agents`. The commands below clone `hermes-agent` as a **sibling** of that clone, so the SDK (which lives inside this monorepo) is reachable via the relative path `../synadia-agents/client-sdk/python` from the hermes-agent root:
-
-```
-parent/
-├── synadia-agents/                    ← you're reading this inside here
-│   ├── agents/hermes/README.md
-│   └── client-sdk/python/             ← the synadia-ai-agents SDK
-└── hermes-agent/                      ← you'll clone the fork here
-    └── venv/                          ← created by ./setup-hermes.sh
-```
-
-If you prefer a different layout, substitute an absolute path (e.g. `/home/you/projects/synadia-agents/client-sdk/python`) for every occurrence of `../synadia-agents` in the commands below. Nothing else needs to change.
+Two parts: (1) clone the fork and bootstrap Hermes, (2) configure the gateway.
 
 ### 1. Clone and bootstrap Hermes
 
-Run this from the **root of your `synadia-agents` clone** (`cd` there first if you opened this file deeper in the tree — e.g. from `agents/hermes/` do `cd ../..`):
-
 ```bash
-# Clone hermes-agent as a sibling of synadia-agents.
-cd ..
+# Clone hermes-agent anywhere you like.
 git clone -b nats-gateway https://github.com/renerocksai/hermes-agent.git
 cd hermes-agent
 
-# setup-hermes.sh installs uv, creates venv, installs hermes-agent[all,dev],
+# setup-hermes.sh installs uv, creates venv, installs hermes-agent[all,dev]
+# (which pulls synadia-ai-agents from PyPI via the [nats] extra),
 # symlinks ~/.local/bin/hermes, and prompts for an LLM provider key.
 ./setup-hermes.sh
 ```
 
 After this you can run `hermes --help` from anywhere. User state lives in `~/.hermes/`.
 
-> You'll see a yellow warning during `setup-hermes.sh`:
-> `⚠ Lockfile install failed (may be outdated), falling back to pip install...`
-> That's **expected** until `synadia-ai-agents` publishes to PyPI — the `[nats]` extra pins an unpublished package, which breaks the primary `uv sync --all-extras --locked` path, so the script falls back to `uv pip install -e ".[all]"` (which excludes `[nats]` by design). Step 2 below installs the SDK manually.
+<details>
+<summary><b>Pre-PyPI install</b> — required until <code>synadia-ai-agents</code> ships to PyPI. Delete this block once PyPI is live.</summary>
 
-### 2. Install the `synadia-ai-agents` Python SDK
+Until `synadia-ai-agents` v0.4 publishes to PyPI, `setup-hermes.sh` prints a yellow warning and falls back to `uv pip install -e ".[all]"`, which omits the `[nats]` extra (because it pins an unpublished package). You then need to install the SDK editable from a local checkout of the `synadia-agents` monorepo.
 
-The SDK is in this monorepo at [`../../client-sdk/python`](../../client-sdk/python). It's **not yet on PyPI** (publishing will follow the upstream Hermes PR merge), so install it editable from the sibling `synadia-agents` checkout — this is how you point hermes at the SDK:
+**Directory layout.** Clone `hermes-agent` as a **sibling** of your `synadia-agents` clone so the SDK is reachable via the relative path `../synadia-agents/client-sdk/python`:
+
+```
+parent/
+├── synadia-agents/                    ← you're reading this inside here
+│   ├── agents/hermes/README.md
+│   └── client-sdk/python/             ← the synadia-ai-agents SDK
+└── hermes-agent/                      ← clone the fork here
+    └── venv/                          ← created by ./setup-hermes.sh
+```
+
+If you prefer a different layout, substitute an absolute path (e.g. `/home/you/projects/synadia-agents/client-sdk/python`) for `../synadia-agents` in the command below.
+
+**The yellow warning** during `setup-hermes.sh` (`⚠ Lockfile install failed (may be outdated), falling back to pip install...`) is **expected** until PyPI publishes — the `[nats]` extra pins an unpublished package, which breaks the primary `uv sync --all-extras --locked` path.
+
+**Install the SDK editable** from the sibling `synadia-agents` checkout:
 
 ```bash
-# From the hermes-agent clone (the sibling of synadia-agents), venv active:
+# From the hermes-agent clone, venv active:
 source venv/bin/activate
 uv pip install --python venv/bin/python -e ../synadia-agents/client-sdk/python
 ```
-
-(If you didn't clone synadia-agents as a sibling, replace `../synadia-agents/client-sdk/python` with the absolute path to this monorepo's `client-sdk/python` directory.)
 
 Verify: `venv/bin/python -c "import synadia_ai.agents; print(synadia_ai.agents.__file__)"` should print a path inside this monorepo.
 
 Without this, Hermes logs `NATS: synadia-ai-agents not installed` at startup and skips registering the NATS adapter.
 
-### 3. Configure the gateway
+</details>
+
+### 2. Configure the gateway
 
 Edit `~/.hermes/config.yaml` and add the `platforms.nats` block. The `owner` and `session_name` fields determine your subject — `agents.prompt.hermes.<owner>.<session_name>`.
 
@@ -349,7 +346,7 @@ Current deferrals (candidates for future phases, not bugs):
 
 ## Troubleshooting
 
-- **`NATS: synadia-ai-agents not installed` at gateway startup.** Install step 2 was skipped. Re-run `uv pip install --python venv/bin/python -e ../synadia-agents/client-sdk/python` from the hermes-agent clone with the venv active. **`./setup-hermes.sh` does NOT install the SDK** — it isn't on PyPI yet — so re-run the editable install after every bootstrap.
+- **`NATS: synadia-ai-agents not installed` at gateway startup.** The `[nats]` extra wasn't installed. Run `uv pip install --python venv/bin/python -e ".[nats]"` from the hermes-agent clone with the venv active. (If `setup-hermes.sh` should have done this for you, it's a packaging bug — file an issue. Pre-PyPI, see the collapsible install block in the README.)
 - **Gateway not discovered / `nats micro list` returns nothing.** Gateway didn't register. Check `platforms.nats.enabled: true`, that the NATS URL/context resolves, and look for `[Nats] Connected — subscribed at …` in the gateway log. If another Hermes instance already holds the same `(agent, owner, session_name)` on this host, the log shows `NATS agent identity hermes:<owner>:<session_name> already in use (PID …)`.
 - **Stale platform lock blocks restart.** Lives at `~/.local/state/hermes/gateway-locks/nats-<hash>.lock`. Verify the recorded PID is dead (`ps -p <PID>`), then `rm` the file.
 - **`nats req` returns only one chunk.** That's expected — `nats request` shows the first reply. For the full streamed body use `examples/02-prompt-text.py` (or any caller iterating the SDK's async iterator).


### PR DESCRIPTION
## Summary

- Restructures `agents/hermes/README.md` so the **post-PyPI install path is the documented default**: `git clone` + `./setup-hermes.sh` (the `[nats]` extra pulls `synadia-ai-agents` from PyPI). Once PyPI is live, that's the whole story.
- Moves the sibling-checkout / editable-install workaround into a collapsed `<details>` block clearly labelled **"Pre-PyPI install — delete this block once PyPI is live."** The directory-layout diagram, yellow-warning explanation, and `uv pip install -e ../synadia-agents/client-sdk/python` step all live there.
- Updates the matching troubleshooting bullet: post-PyPI it points at `uv pip install -e ".[nats]"`, with a pointer to the collapsible block for the pre-PyPI case.

The README still reflects the current reality (PyPI is not yet live), but the structure now matches where we're heading instead of treating the workaround as the canonical path. Removing the block once `synadia-ai-agents` ships to PyPI is a one-shot delete.

## Test plan

- [x] `git diff` review — only `agents/hermes/README.md` changes
- [ ] Render preview on GitHub — verify the `<details>` block collapses cleanly and the directory-layout code fence renders inside it
- [ ] Verify links inside the collapsed block (`../../client-sdk/python`) still resolve from the rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)