### PR TITLE
client-sdk/{typescript,python}: parseNatsUrl helper; every example honours URL userinfo

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -27,6 +27,34 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
   `discover_agents()`. Fixes [#31]. Mirrors the same constant change
   in the TypeScript SDK so cross-SDK defaults stay aligned.
 
+### Added
+
+- New `parse_nats_url(url)` helper exported from `synadia_ai.agents`.
+  Sibling of `load_context_options` — both produce kwargs ready to
+  splat into `nats.connect(...)`. Extracts credentials from `userinfo`
+  if present:
+  - `nats://TOKEN@host:port` → `{"servers": [...], "token": ...}`
+    (single userinfo component is treated as a token, mirroring the
+    `nats` CLI)
+  - `nats://USER:PASS@host:port` → `{"servers": [...], "user": ...,
+    "password": ...}`
+  - `tls://`, `ws://`, `wss://` schemes preserved on output;
+    scheme-less `host:port` accepted; comma-separated multi-server
+    URLs supported (mixed credentials across entries throw
+    `NatsContextError`).
+  - URL-decodes percent-encoded userinfo, brackets IPv6 hosts back
+    correctly after `urllib`-strip.
+
+  Closes a UX gap: `nats-py`'s `connect(servers=url)` does NOT parse
+  userinfo (the bare `nats` CLI does), so a user copy-pasting a token
+  URL silently lost the token and got `Authorization Violation`.
+  Mirrors the TS SDK's `parseNatsUrl` (same PR — cross-SDK helper
+  defaults stay aligned).
+- `examples/_connect_cli.py` now routes `--url` and `$NATS_URL`
+  through `parse_nats_url`, so every numbered demo (`01-discover.py`
+  … `06-chat.py`) accepts `nats://TOKEN@host:port` URLs identically
+  to the `nats` CLI.
+
 ### Changed (breaking, public API)
 
 - **Token 5 of every agent subject is the *session name*; no more

--- a/client-sdk/python/examples/_connect_cli.py
+++ b/client-sdk/python/examples/_connect_cli.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 
 import nats
 
-from synadia_ai.agents import NatsContextError, load_context_options
+from synadia_ai.agents import NatsContextError, load_context_options, parse_nats_url
 
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATSClient
@@ -47,14 +47,20 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
 
 
 async def connect_from_cli(args: argparse.Namespace) -> NATSClient:
-    """Resolve CLI flags + env → a connected :class:`~nats.aio.client.Client`."""
+    """Resolve CLI flags + env → a connected :class:`~nats.aio.client.Client`.
+
+    URLs (from ``--url`` or ``$NATS_URL``) go through :func:`parse_nats_url`
+    so a copy-pasted ``nats://TOKEN@host:port`` works the same way it does
+    with the ``nats`` CLI — without it, ``nats-py`` would silently drop the
+    token because it doesn't parse credentials from URLs on its own.
+    """
     if args.context is not None:
         return await nats.connect(**load_context_options(args.context))
     if args.url is not None:
-        return await nats.connect(servers=args.url)
+        return await nats.connect(**parse_nats_url(args.url))
     env_url = os.environ.get("NATS_URL")
     if env_url:
-        return await nats.connect(servers=env_url)
+        return await nats.connect(**parse_nats_url(env_url))
     try:
         return await nats.connect(**load_context_options("current"))
     except NatsContextError as exc:

--- a/client-sdk/python/src/synadia_ai/agents/__init__.py
+++ b/client-sdk/python/src/synadia_ai/agents/__init__.py
@@ -13,6 +13,8 @@ Public API entry points:
   claude-code, pi, openclaw) embed to register themselves on the bus.
 * :func:`load_context_options` — translate a ``nats`` CLI context into
   kwargs for :func:`nats.connect`.
+* :func:`parse_nats_url` — parse a NATS URL (with optional userinfo
+  for token / user:password) into kwargs for :func:`nats.connect`.
 
 The SDK does NOT open NATS connections — callers build a
 :class:`~nats.aio.client.Client` and hand it to :class:`Agents`. This
@@ -29,7 +31,7 @@ from .agent import (
     StreamMessage,
 )
 from .agents import Agents
-from .context import load_context_options
+from .context import load_context_options, parse_nats_url
 from .discovery import (
     DEFAULT_DISCOVER_MAX_WAIT_S,
     DEFAULT_DISCOVER_STALL_S,
@@ -120,4 +122,5 @@ __all__ = [
     "decode",
     "encode",
     "load_context_options",
+    "parse_nats_url",
 ]

--- a/client-sdk/python/src/synadia_ai/agents/context.py
+++ b/client-sdk/python/src/synadia_ai/agents/context.py
@@ -1,26 +1,39 @@
-"""``nats`` CLI context loader for callers that own their NATS connection.
+"""``nats`` CLI context loader and URL parser.
 
-:func:`load_context_options` reads context files written by ``nats context
-add`` / ``nats context select`` under ``~/.config/nats`` (or
-``$NATS_CONFIG_HOME`` / ``$XDG_CONFIG_HOME/nats``) and translates them
-into kwargs ready to splat into :func:`nats.connect`::
+Two entry points produce kwargs ready to splat into :func:`nats.connect`:
+
+* :func:`load_context_options` reads context files written by ``nats
+  context add`` / ``nats context select`` under ``~/.config/nats`` (or
+  ``$NATS_CONFIG_HOME`` / ``$XDG_CONFIG_HOME/nats``).
+* :func:`parse_nats_url` parses a single NATS URL and extracts
+  credentials from ``userinfo`` if present (token, or user:password).
+  ``nats-py``'s ``nats.connect(servers=url)`` does NOT parse userinfo
+  on its own — it expects credentials as separate kwargs — but the
+  ``nats`` CLI does, which causes a confusing UX gap. Use this helper
+  to bridge the two.
+
+Both return a dict you can splat::
 
     import nats
-    from synadia_ai.agents import Agents, load_context_options
+    from synadia_ai.agents import Agents, load_context_options, parse_nats_url
 
     nc = await nats.connect(**load_context_options("prod"))
+    # or:
+    nc = await nats.connect(**parse_nats_url("nats://TOKEN@nats.example.com:4222"))
+
     agents = Agents(nc=nc)
 
-Mirrors the TS SDK's ``loadContextOptions`` (PR #7 follow-up) — same
+Mirrors the TS SDK's ``loadContextOptions`` / ``parseNatsUrl`` — same
 context-file layout, same auth precedence, same unsupported-field
-failures. The SDK itself does NOT open NATS connections; the caller
-owns ``nc`` and is responsible for closing it.
+failures, same URL-parsing semantics. The SDK itself does NOT open
+NATS connections; the caller owns ``nc`` and is responsible for
+closing it.
 
-Supports: ``url``, ``token``, ``user``/``password``, ``creds`` (with
-``~`` expansion), ``user_jwt``, ``inbox_prefix``.
+Supported context fields: ``url``, ``token``, ``user``/``password``,
+``creds`` (with ``~`` expansion), ``user_jwt``, ``inbox_prefix``.
 
-Auth precedence: ``creds`` > ``user_jwt`` > inline ``token`` /
-``user``+``password``.
+Auth precedence inside a context: ``creds`` > ``user_jwt`` > inline
+``token`` / ``user``+``password``.
 
 Unsupported fields raise :class:`~synadia_ai.agents.errors.NatsContextError`
 with an actionable message: ``nkey``, TLS triple (``cert`` / ``key`` /
@@ -37,6 +50,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 from .errors import NatsContextError
 
@@ -229,4 +243,102 @@ def _expand_user(path: str) -> str:
     return path
 
 
-__all__ = ["load_context_options"]
+_SUPPORTED_URL_SCHEMES = ("nats", "tls", "ws", "wss")
+
+
+def parse_nats_url(url: str) -> dict[str, Any]:
+    """Parse a NATS URL into ``nats.connect`` kwargs, extracting userinfo.
+
+    Bridges a UX gap between the ``nats`` CLI (which parses userinfo from
+    URLs) and ``nats-py`` (which does not). Mirrors the TS SDK's
+    :func:`parseNatsUrl`.
+
+    Behaviour:
+
+    * ``nats://host:port`` → ``{"servers": [...]}`` (no auth)
+    * ``nats://TOKEN@host:port`` → ``{"servers": [...], "token": ...}``
+      — a single userinfo component is treated as a token, mirroring the
+      ``nats`` CLI.
+    * ``nats://USER:PASS@host:port`` → ``{"servers": [...], "user": ...,
+      "password": ...}``
+    * ``tls://...``, ``ws://...``, ``wss://...`` schemes preserved on
+      output; scheme-less ``host:port`` accepted (treated as
+      ``nats://``), matching ``nats-py``'s server-list semantics.
+    * Comma-separated multi-server URLs supported when userinfo is
+      *identical* across every entry. Mixed userinfo across servers
+      cannot be expressed in a single connect-kwargs dict and raises
+      :class:`NatsContextError` so the caller fails loudly instead of
+      silently dropping all but the first set.
+    * URL-decodes userinfo so tokens with reserved chars (``+``, ``@``,
+      ``%``) round-trip correctly.
+
+    Raises :class:`NatsContextError` on empty input, unsupported scheme,
+    or missing host.
+
+    Example::
+
+        import nats
+        from synadia_ai.agents import parse_nats_url
+
+        nc = await nats.connect(**parse_nats_url("nats://abc123@nats.example.com:4222"))
+    """
+    parts = [p.strip() for p in url.split(",") if p.strip()]
+    if not parts:
+        raise NatsContextError(f"empty NATS URL: {url!r}")
+
+    parsed_all = [_parse_single_nats_url(p, original=url) for p in parts]
+
+    # All servers must agree on userinfo (or all be bare). Mixed userinfo
+    # across servers can't be expressed in one connect-kwargs dict.
+    first = parsed_all[0]
+    for p in parsed_all[1:]:
+        if (
+            p.get("token") != first.get("token")
+            or p.get("user") != first.get("user")
+            or p.get("password") != first.get("password")
+        ):
+            raise NatsContextError(f"NATS URL has mixed credentials across server entries: {url}")
+
+    out: dict[str, Any] = {"servers": [p["server"] for p in parsed_all]}
+    for k in ("token", "user", "password"):
+        if k in first:
+            out[k] = first[k]
+    return out
+
+
+def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
+    # Tolerate scheme-less entries (`host:port`) by prepending nats://,
+    # mirroring nats-py's internal server-list handling.
+    with_scheme = part if "://" in part else f"nats://{part}"
+
+    try:
+        parsed = urlparse(with_scheme)
+    except ValueError as exc:
+        raise NatsContextError(f"invalid NATS URL {original!r}: {exc}") from exc
+
+    if parsed.scheme not in _SUPPORTED_URL_SCHEMES:
+        raise NatsContextError(f"unsupported scheme {parsed.scheme!r} in NATS URL {original!r}")
+    if not parsed.hostname:
+        raise NatsContextError(f"NATS URL {original!r} is missing a host")
+
+    # Reconstruct the server URL without userinfo. Re-bracket IPv6 hosts —
+    # urlparse strips the brackets but `nats-py` (and most other tools)
+    # need them back to disambiguate `host:port`.
+    host = parsed.hostname
+    host_token = f"[{host}]" if ":" in host else host
+    netloc = f"{host_token}:{parsed.port}" if parsed.port is not None else host_token
+    server = f"{parsed.scheme}://{netloc}"
+
+    out: dict[str, Any] = {"server": server}
+    if parsed.password is not None:
+        # user:password (password may be empty if URL is `nats://user:@host`,
+        # but we still treat it as the user/password form rather than a token).
+        out["user"] = unquote(parsed.username or "")
+        out["password"] = unquote(parsed.password)
+    elif parsed.username:
+        # Single userinfo component → token (matches `nats` CLI behaviour).
+        out["token"] = unquote(parsed.username)
+    return out
+
+
+__all__ = ["load_context_options", "parse_nats_url"]

--- a/client-sdk/python/tests/test_context_load.py
+++ b/client-sdk/python/tests/test_context_load.py
@@ -376,3 +376,31 @@ def test_parse_url_ipv6_host_rebracketed() -> None:
     opts_with_token = parse_nats_url("nats://tok@[::1]:4222")
     assert opts_with_token["servers"] == ["nats://[::1]:4222"]
     assert opts_with_token["token"] == "tok"
+
+
+def test_parse_url_user_with_explicit_colon_empty_password() -> None:
+    """`nats://user:@host` is structurally user:password (even if pass is empty).
+
+    Python's ``urlparse`` natively distinguishes ``password is None`` (no
+    colon, single-userinfo → token) from ``password == ""`` (colon
+    present, empty password → user:password form). The TS sibling
+    re-sniffs the raw input for the colon to achieve the same result.
+    """
+    opts = parse_nats_url("nats://alice:@nats.example.com:4222")
+    assert opts == {
+        "servers": ["nats://nats.example.com:4222"],
+        "user": "alice",
+        "password": "",
+    }
+    assert "token" not in opts
+
+
+def test_parse_url_ws_and_wss_schemes() -> None:
+    """``ws://`` and ``wss://`` schemes are accepted (NATS WebSocket transports)."""
+    ws = parse_nats_url("ws://tok@host:9222")
+    assert ws == {"servers": ["ws://host:9222"], "token": "tok"}
+    wss = parse_nats_url("wss://tok@host:9222")
+    assert wss == {"servers": ["wss://host:9222"], "token": "tok"}
+    # bare ws/wss without userinfo
+    ws_bare = parse_nats_url("ws://host:9222")
+    assert ws_bare == {"servers": ["ws://host:9222"]}

--- a/client-sdk/python/tests/test_context_load.py
+++ b/client-sdk/python/tests/test_context_load.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import pytest
 
-from synadia_ai.agents import NatsContextError, load_context_options
+from synadia_ai.agents import NatsContextError, load_context_options, parse_nats_url
 
 
 def _point_env_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -278,3 +278,101 @@ def test_current_honours_env_over_selection_file(
 
     opts = load_context_options("current")
     assert opts["servers"] == ["nats://env:4222"]
+
+
+# --- parse_nats_url ----------------------------------------------------
+
+
+def test_parse_url_no_userinfo_returns_servers_only() -> None:
+    opts = parse_nats_url("nats://nats.example.com:4222")
+    assert opts == {"servers": ["nats://nats.example.com:4222"]}
+    assert "token" not in opts
+    assert "user" not in opts
+    assert "password" not in opts
+
+
+def test_parse_url_single_userinfo_is_token() -> None:
+    """Mirrors the ``nats`` CLI: one userinfo component is treated as a token."""
+    opts = parse_nats_url("nats://abc123def@nats.example.com:4222")
+    assert opts == {
+        "servers": ["nats://nats.example.com:4222"],
+        "token": "abc123def",
+    }
+
+
+def test_parse_url_user_password_split() -> None:
+    opts = parse_nats_url("nats://alice:s3cret@nats.example.com:4222")
+    assert opts == {
+        "servers": ["nats://nats.example.com:4222"],
+        "user": "alice",
+        "password": "s3cret",
+    }
+
+
+def test_parse_url_decodes_percent_encoded_userinfo() -> None:
+    # %2B → "+", %40 → "@"
+    opts = parse_nats_url("nats://to%2Bken%40v1@nats.example.com:4222")
+    assert opts["token"] == "to+ken@v1"
+
+
+def test_parse_url_preserves_tls_scheme() -> None:
+    opts = parse_nats_url("tls://abc@nats.example.com:4443")
+    assert opts == {
+        "servers": ["tls://nats.example.com:4443"],
+        "token": "abc",
+    }
+
+
+def test_parse_url_accepts_schemeless_host_port() -> None:
+    opts = parse_nats_url("nats.example.com:4222")
+    assert opts["servers"] == ["nats://nats.example.com:4222"]
+
+
+def test_parse_url_splits_comma_separated_multiserver() -> None:
+    opts = parse_nats_url("nats://a:4222,nats://b:4222,nats://c:4222")
+    assert opts["servers"] == [
+        "nats://a:4222",
+        "nats://b:4222",
+        "nats://c:4222",
+    ]
+    assert "token" not in opts
+
+
+def test_parse_url_multiserver_with_identical_userinfo() -> None:
+    opts = parse_nats_url("nats://tok@a.example.com:4222,nats://tok@b.example.com:4222")
+    assert opts["servers"] == [
+        "nats://a.example.com:4222",
+        "nats://b.example.com:4222",
+    ]
+    assert opts["token"] == "tok"
+
+
+def test_parse_url_multiserver_mixed_credentials_rejected() -> None:
+    with pytest.raises(NatsContextError, match="mixed credentials"):
+        parse_nats_url("nats://tok1@a:4222,nats://tok2@b:4222")
+
+
+def test_parse_url_empty_input_rejected() -> None:
+    with pytest.raises(NatsContextError, match="empty NATS URL"):
+        parse_nats_url("")
+    with pytest.raises(NatsContextError, match="empty NATS URL"):
+        parse_nats_url("   ,  ")
+
+
+def test_parse_url_unsupported_scheme_rejected() -> None:
+    with pytest.raises(NatsContextError, match="unsupported scheme"):
+        parse_nats_url("http://nats.example.com:4222")
+
+
+def test_parse_url_hostless_url_rejected() -> None:
+    with pytest.raises(NatsContextError, match="missing a host"):
+        parse_nats_url("nats://")
+
+
+def test_parse_url_ipv6_host_rebracketed() -> None:
+    """``urlparse`` strips IPv6 brackets — we must put them back."""
+    opts = parse_nats_url("nats://[::1]:4222")
+    assert opts["servers"] == ["nats://[::1]:4222"]
+    opts_with_token = parse_nats_url("nats://tok@[::1]:4222")
+    assert opts_with_token["servers"] == ["nats://[::1]:4222"]
+    assert opts_with_token["token"] == "tok"

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -96,6 +96,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `StatusChunk`, `QueryChunk`) — pure encoder mirroring the existing
   `chunk-decoder.ts`. Used by `AgentService` to push response / status /
   query chunks back to the caller.
+- **`parseNatsUrl(url)`** — sibling of `loadContextOptions` that converts
+  a NATS URL into `NodeConnectionOptions`, extracting credentials from
+  `userinfo` if present:
+  - `nats://TOKEN@host:port` → `{ servers, token }`
+  - `nats://USER:PASS@host:port` → `{ servers, user, pass }`
+  - `nats://a:4222,nats://b:4222` (multi-server) supported; mixed
+    credentials across entries throw `NatsContextError`.
+
+  Bridges a UX gap: the `nats` CLI parses userinfo from URLs, but
+  `@nats-io/transport-node` does not — meaning every example in this
+  repo that accepted `--url URL` silently dropped the token when given
+  the URL form, even though the same URL worked with `nats` CLI /
+  `nats context save`. Every example's `--url` path now goes through
+  `parseNatsUrl` (`agent-web-ui`, `pi-headless`, `claude-code-headless`,
+  `dspy`).
 
 ### Changed
 
@@ -120,24 +135,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   true at 750 ms (still well under one perceptible UI tick); callers
   wanting a tighter window can pass `timeoutMs` (timer strategy) or
   the lower-level `stallMs`. Fixes [#31].
-
-### Added
-
-- New `parseNatsUrl(url)` helper in `@synadia-ai/agents` that converts
-  a NATS URL into `NodeConnectionOptions`, extracting credentials from
-  `userinfo` if present:
-  - `nats://TOKEN@host:port` → `{ servers, token }`
-  - `nats://USER:PASS@host:port` → `{ servers, user, pass }`
-  - `nats://a:4222,nats://b:4222` (multi-server) supported; mixed
-    credentials across entries throw `NatsContextError`.
-
-  Bridges a UX gap: the `nats` CLI parses userinfo from URLs, but
-  `@nats-io/transport-node` does not — meaning every example in this
-  repo that accepted `--url URL` silently dropped the token when
-  given the URL form, even though the same URL worked with `nats`
-  CLI / `nats context save`. Every example's `--url` path now goes
-  through `parseNatsUrl` (`agent-web-ui`, `pi-headless`,
-  `claude-code-headless`, `dspy`).
 
 ### Anticipated companion work (this release)
 

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -121,6 +121,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   wanting a tighter window can pass `timeoutMs` (timer strategy) or
   the lower-level `stallMs`. Fixes [#31].
 
+### Added
+
+- New `parseNatsUrl(url)` helper in `@synadia-ai/agents` that converts
+  a NATS URL into `NodeConnectionOptions`, extracting credentials from
+  `userinfo` if present:
+  - `nats://TOKEN@host:port` → `{ servers, token }`
+  - `nats://USER:PASS@host:port` → `{ servers, user, pass }`
+  - `nats://a:4222,nats://b:4222` (multi-server) supported; mixed
+    credentials across entries throw `NatsContextError`.
+
+  Bridges a UX gap: the `nats` CLI parses userinfo from URLs, but
+  `@nats-io/transport-node` does not — meaning every example in this
+  repo that accepted `--url URL` silently dropped the token when
+  given the URL form, even though the same URL worked with `nats`
+  CLI / `nats context save`. Every example's `--url` path now goes
+  through `parseNatsUrl` (`agent-web-ui`, `pi-headless`,
+  `claude-code-headless`, `dspy`).
+
 ### Anticipated companion work (this release)
 
 This SDK release coordinates with refactors of every agent harness and

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -196,8 +196,20 @@ function parseSingleNatsUrl(part: string, original: string): ParsedNatsUrl {
   }
 
   const out: ParsedNatsUrl = { server: `${parsed.protocol}//${parsed.host}` };
-  if (parsed.password !== "") {
-    // user:password — both decoded
+
+  // WHATWG `URL` squashes both `nats://user@host` and `nats://user:@host`
+  // into `password === ""`, losing the distinction between "no separator"
+  // (single-component userinfo → token) and "explicit colon, empty
+  // password" (user:password form, even if password is empty). Sniff the
+  // raw userinfo for a colon to recover the original intent — Python's
+  // `urllib.parse.urlparse` distinguishes the two natively (`password is
+  // None` vs `password == ""`), but in JS we have to look at the input.
+  const userinfoMatch = withScheme.match(/^[a-z]+:\/\/([^/@]*)@/i);
+  const hasColonSeparator = (userinfoMatch?.[1] ?? "").includes(":");
+
+  if (hasColonSeparator) {
+    // user:password form (decoded; password may be empty if URL was
+    // `nats://alice:@host`, but that's still structurally user:password).
     out.user = decodeURIComponent(parsed.username);
     out.pass = decodeURIComponent(parsed.password);
   } else if (parsed.username !== "") {

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -1,22 +1,34 @@
-// `nats` CLI context loader.
+// `nats` CLI context loader and URL parser.
 //
-// Reads context files written by `nats context add` / `nats context select`
-// under `~/.config/nats` (or $NATS_CONFIG_HOME / $XDG_CONFIG_HOME/nats) and
-// translates them into `@nats-io/transport-node` connection options ready to
-// pass straight to `connect()`:
+// Two entry points produce `@nats-io/transport-node` connection options:
+//
+//   - {@link loadContextOptions} — reads context files written by
+//     `nats context add` / `nats context select` under `~/.config/nats`
+//     (or $NATS_CONFIG_HOME / $XDG_CONFIG_HOME/nats).
+//   - {@link parseNatsUrl} — parses a single NATS URL and extracts
+//     credentials from `userinfo` if present (token, or user:pass).
+//     The bare `@nats-io/transport-node` `connect({ servers })` does NOT
+//     parse userinfo — it expects credentials as separate config fields —
+//     but the `nats` CLI does, which causes a confusing UX gap. Use this
+//     helper to bridge the two.
+//
+// Both return `NodeConnectionOptions` you can pass straight to `connect()`:
 //
 //     import { connect } from "@nats-io/transport-node";
-//     import { Agents, loadContextOptions } from "@synadia-ai/agents";
+//     import { Agents, loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 //
 //     const opts = await loadContextOptions("prod");
+//     // or:
+//     const opts = parseNatsUrl("nats://TOKEN@nats.example.com:4222");
+//
 //     const nc = await connect(opts);
 //     const agents = new Agents({ nc });
 //
-// Supports: `url`, `creds` (path), `user_jwt`, `user`+`password`, `token`,
-// `inbox_prefix`.
-// Skips: `nkey`, TLS cert/key/ca, `nsc` integration.
+// Supported context fields: `url`, `creds` (path), `user_jwt`,
+// `user`+`password`, `token`, `inbox_prefix`.
+// Skipped: `nkey`, TLS cert/key/ca, `nsc` integration.
 //
-// Precedence: `creds` > `user_jwt` > `user`/`password`/`token`.
+// Precedence inside a context: `creds` > `user_jwt` > `user`/`password`/`token`.
 //
 // `user_jwt` without an accompanying nkey seed leaves the CONNECT signature
 // empty, so it only works against servers that do not require nonce signing.
@@ -92,6 +104,107 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   if (inboxPrefix) opts.inboxPrefix = inboxPrefix;
 
   return opts;
+}
+
+/**
+ * Parse a NATS URL into `NodeConnectionOptions`, extracting credentials
+ * from `userinfo` if present:
+ *
+ * - `nats://host:port`               → `{ servers: ["nats://host:port"] }`
+ * - `nats://TOKEN@host:port`         → `{ servers: [...], token: "TOKEN" }`
+ *   (single userinfo component is treated as a token, mirroring the
+ *   `nats` CLI's behaviour)
+ * - `nats://USER:PASS@host:port`     → `{ servers: [...], user: "USER", pass: "PASS" }`
+ * - `tls://...`                      → same shapes, scheme preserved.
+ *
+ * Comma-separated multi-server URLs (`nats://a:4222,nats://b:4222`) are
+ * split and userinfo is only honoured if it appears identically on every
+ * server — otherwise this function throws (mixed credentials in a single
+ * URL is almost certainly a bug; use a NATS context file for that case).
+ *
+ * Throws if the URL is unparseable, has no host, or uses a non-NATS scheme.
+ *
+ * @example
+ *   import { connect } from "@nats-io/transport-node";
+ *   import { parseNatsUrl } from "@synadia-ai/agents";
+ *   const nc = await connect(parseNatsUrl("nats://abc123@nats.example.com:4222"));
+ */
+export function parseNatsUrl(url: string): NodeConnectionOptions {
+  const parts = url
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (parts.length === 0) {
+    throw new NatsContextError(`empty NATS URL: ${JSON.stringify(url)}`);
+  }
+
+  const parsedAll = parts.map((p) => parseSingleNatsUrl(p, url));
+
+  // All servers must agree on userinfo (or all be bare). Mixed userinfo
+  // across servers can't be expressed in a single ConnectionOptions.
+  const first = parsedAll[0]!;
+  for (const p of parsedAll.slice(1)) {
+    if (
+      p.token !== first.token ||
+      p.user !== first.user ||
+      p.pass !== first.pass
+    ) {
+      throw new NatsContextError(
+        `NATS URL has mixed credentials across server entries: ${url}`,
+      );
+    }
+  }
+
+  const opts: NodeConnectionOptions = {
+    servers: parsedAll.map((p) => p.server),
+  };
+  if (first.token !== undefined) opts.token = first.token;
+  if (first.user !== undefined) opts.user = first.user;
+  if (first.pass !== undefined) opts.pass = first.pass;
+  return opts;
+}
+
+interface ParsedNatsUrl {
+  server: string; // protocol + host (no userinfo)
+  token?: string;
+  user?: string;
+  pass?: string;
+}
+
+function parseSingleNatsUrl(part: string, original: string): ParsedNatsUrl {
+  // Tolerate scheme-less entries (`host:port`) by prepending nats:// — this
+  // mirrors what `@nats-io/transport-node` does internally for `servers`.
+  const withScheme = /^[a-z]+:\/\//i.test(part) ? part : `nats://${part}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch (e) {
+    throw new NatsContextError(
+      `invalid NATS URL ${JSON.stringify(original)}: ${(e as Error).message}`,
+    );
+  }
+  if (!/^(nats|tls|ws|wss):$/.test(parsed.protocol)) {
+    throw new NatsContextError(
+      `unsupported scheme "${parsed.protocol}" in NATS URL ${JSON.stringify(original)}`,
+    );
+  }
+  if (!parsed.host) {
+    throw new NatsContextError(
+      `NATS URL ${JSON.stringify(original)} is missing a host`,
+    );
+  }
+
+  const out: ParsedNatsUrl = { server: `${parsed.protocol}//${parsed.host}` };
+  if (parsed.password !== "") {
+    // user:password — both decoded
+    out.user = decodeURIComponent(parsed.username);
+    out.pass = decodeURIComponent(parsed.password);
+  } else if (parsed.username !== "") {
+    // Single userinfo component → token (matches `nats` CLI behaviour).
+    out.token = decodeURIComponent(parsed.username);
+  }
+  return out;
 }
 
 function str(v: unknown): string | undefined {

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -123,8 +123,8 @@ export {
 // Logging
 export { type Logger, SILENT_LOGGER } from "./internal/logger.js";
 
-// NATS CLI context loader
-export { loadContextOptions } from "./context.js";
+// NATS CLI context loader + URL parser (both produce NodeConnectionOptions)
+export { loadContextOptions, parseNatsUrl } from "./context.js";
 
 // Version metadata
 export {

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadContextOptions } from "../../src/context.js";
+import { loadContextOptions, parseNatsUrl } from "../../src/context.js";
 import { NatsContextError } from "../../src/errors.js";
 
 describe("loadContextOptions", () => {
@@ -130,5 +130,93 @@ describe("loadContextOptions", () => {
   it("rejects traversal names resolved via $NATS_CONTEXT", async () => {
     process.env["NATS_CONTEXT"] = "../escape";
     await expect(loadContextOptions("current")).rejects.toBeInstanceOf(NatsContextError);
+  });
+});
+
+describe("parseNatsUrl", () => {
+  it("returns bare servers with no auth for a plain URL", () => {
+    const opts = parseNatsUrl("nats://nats.example.com:4222");
+    expect(opts).toEqual({ servers: ["nats://nats.example.com:4222"] });
+    expect(opts.token).toBeUndefined();
+    expect(opts.user).toBeUndefined();
+    expect(opts.pass).toBeUndefined();
+  });
+
+  it("treats single userinfo component as a token (mirrors `nats` CLI)", () => {
+    const opts = parseNatsUrl("nats://abc123def@nats.example.com:4222");
+    expect(opts).toEqual({
+      servers: ["nats://nats.example.com:4222"],
+      token: "abc123def",
+    });
+  });
+
+  it("splits user:password userinfo into user + pass", () => {
+    const opts = parseNatsUrl("nats://alice:s3cret@nats.example.com:4222");
+    expect(opts).toEqual({
+      servers: ["nats://nats.example.com:4222"],
+      user: "alice",
+      pass: "s3cret",
+    });
+  });
+
+  it("URL-decodes userinfo so tokens with reserved characters round-trip", () => {
+    // "%2B" → "+", "%40" → "@"
+    const opts = parseNatsUrl("nats://to%2Bken%40v1@nats.example.com:4222");
+    expect(opts.token).toBe("to+ken@v1");
+  });
+
+  it("preserves the scheme for tls:// (and similar)", () => {
+    const opts = parseNatsUrl("tls://abc@nats.example.com:4443");
+    expect(opts).toEqual({
+      servers: ["tls://nats.example.com:4443"],
+      token: "abc",
+    });
+  });
+
+  it("accepts scheme-less host:port (treats as nats://)", () => {
+    const opts = parseNatsUrl("nats.example.com:4222");
+    expect(opts.servers).toEqual(["nats://nats.example.com:4222"]);
+  });
+
+  it("splits comma-separated multi-server URLs", () => {
+    const opts = parseNatsUrl("nats://a:4222,nats://b:4222,nats://c:4222");
+    expect(opts.servers).toEqual([
+      "nats://a:4222",
+      "nats://b:4222",
+      "nats://c:4222",
+    ]);
+    expect(opts.token).toBeUndefined();
+  });
+
+  it("accepts multi-server URLs when userinfo is identical on every entry", () => {
+    const opts = parseNatsUrl(
+      "nats://tok@a.example.com:4222,nats://tok@b.example.com:4222",
+    );
+    expect(opts.servers).toEqual([
+      "nats://a.example.com:4222",
+      "nats://b.example.com:4222",
+    ]);
+    expect(opts.token).toBe("tok");
+  });
+
+  it("throws when multi-server URLs have mixed credentials", () => {
+    expect(() =>
+      parseNatsUrl("nats://tok1@a:4222,nats://tok2@b:4222"),
+    ).toThrow(NatsContextError);
+  });
+
+  it("throws on empty / blank input", () => {
+    expect(() => parseNatsUrl("")).toThrow(NatsContextError);
+    expect(() => parseNatsUrl("   ,  ")).toThrow(NatsContextError);
+  });
+
+  it("throws on unsupported scheme", () => {
+    expect(() => parseNatsUrl("http://nats.example.com:4222")).toThrow(
+      NatsContextError,
+    );
+  });
+
+  it("throws on hostless URL", () => {
+    expect(() => parseNatsUrl("nats://")).toThrow(NatsContextError);
   });
 });

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -219,4 +219,29 @@ describe("parseNatsUrl", () => {
   it("throws on hostless URL", () => {
     expect(() => parseNatsUrl("nats://")).toThrow(NatsContextError);
   });
+
+  it("treats `user:` (explicit colon, empty password) as user:password, not token", () => {
+    // WHATWG URL squashes both `nats://user@host` and `nats://user:@host`
+    // into `password === ""`, so the implementation re-sniffs the raw
+    // input to recover the colon's intent. An empty password is
+    // semantically meaningless to the NATS server, but we preserve the
+    // structural distinction so this URL form maps where the user expected.
+    const opts = parseNatsUrl("nats://alice:@nats.example.com:4222");
+    expect(opts).toEqual({
+      servers: ["nats://nats.example.com:4222"],
+      user: "alice",
+      pass: "",
+    });
+    expect(opts.token).toBeUndefined();
+  });
+
+  it("accepts ws:// and wss:// schemes (with userinfo)", () => {
+    const ws = parseNatsUrl("ws://tok@host:9222");
+    expect(ws).toEqual({ servers: ["ws://host:9222"], token: "tok" });
+    const wss = parseNatsUrl("wss://tok@host:9222");
+    expect(wss).toEqual({ servers: ["wss://host:9222"], token: "tok" });
+    // bare ws/wss without userinfo
+    const wsBare = parseNatsUrl("ws://host:9222");
+    expect(wsBare).toEqual({ servers: ["ws://host:9222"] });
+  });
 });

--- a/examples/agent-web-ui/server/index.ts
+++ b/examples/agent-web-ui/server/index.ts
@@ -14,6 +14,7 @@ import {
   Agents,
   SDK_PROTOCOL_VERSION,
   loadContextOptions,
+  parseNatsUrl,
   type NatsConnection,
 } from "@synadia-ai/agents";
 import {
@@ -27,7 +28,10 @@ const config = parseConfig(Bun.argv);
 
 async function buildConnectOptions(): Promise<NodeConnectionOptions> {
   if (config.servers) {
-    return { name: "testui", servers: config.servers };
+    // `parseNatsUrl` extracts userinfo (token / user:password) — without it
+    // a URL like `nats://TOKEN@host:port` would silently drop the token
+    // because `@nats-io/transport-node` doesn't parse credentials from URLs.
+    return { name: "testui", ...parseNatsUrl(config.servers) };
   }
   const contextName = config.context ?? "current";
   return { ...(await loadContextOptions(contextName)), name: "testui" };

--- a/examples/agent-web-ui/server/index.ts
+++ b/examples/agent-web-ui/server/index.ts
@@ -31,7 +31,9 @@ async function buildConnectOptions(): Promise<NodeConnectionOptions> {
     // `parseNatsUrl` extracts userinfo (token / user:password) — without it
     // a URL like `nats://TOKEN@host:port` would silently drop the token
     // because `@nats-io/transport-node` doesn't parse credentials from URLs.
-    return { name: "testui", ...parseNatsUrl(config.servers) };
+    // `name` is spread last so the local connection identity wins even if
+    // a future `parseNatsUrl` were to start emitting a `name` field.
+    return { ...parseNatsUrl(config.servers), name: "testui" };
   }
   const contextName = config.context ?? "current";
   return { ...(await loadContextOptions(contextName)), name: "testui" };

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -10,7 +10,7 @@ import process from "node:process";
 import type { NatsConnection } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { loadContextOptions } from "@synadia-ai/agents";
+import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 
 import { ClaudeSessionManager } from "./claude-session-manager.js";
 import { Controller } from "./controller.js";
@@ -28,7 +28,9 @@ async function resolveNatsOptions(
     return { ...(await loadContextOptions(context)), name: "claude-code-headless" };
   }
   if (natsUrl) {
-    return { servers: natsUrl, name: "claude-code-headless" };
+    // `parseNatsUrl` extracts userinfo (token / user:password) — without it
+    // `nats://TOKEN@host:port` would silently drop the token.
+    return { ...parseNatsUrl(natsUrl), name: "claude-code-headless" };
   }
 
   throw new Error("no NATS target configured (context / NATS_URL / --url)");

--- a/examples/dspy/src/index.ts
+++ b/examples/dspy/src/index.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import process from "node:process";
 import { ai, ax } from "@ax-llm/ax";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { AgentService } from "@synadia-ai/agents";
+import { AgentService, parseNatsUrl } from "@synadia-ai/agents";
 import { makeFsTools } from "./tools.js";
 
 const NATS_URL = process.env["NATS_URL"] ?? "nats://127.0.0.1:4222";
@@ -89,7 +89,9 @@ const llm = ai({
   options: { fetch: scrubbedFetch as typeof fetch },
 });
 
-const nc = await natsConnect({ servers: NATS_URL });
+// `parseNatsUrl` extracts userinfo (token / user:password) so
+// `NATS_URL=nats://TOKEN@host:port` works the same way the `nats` CLI does.
+const nc = await natsConnect(parseNatsUrl(NATS_URL));
 
 // AgentService takes care of:
 //   - registering as the `agents` micro service with v0.3 metadata

--- a/examples/pi-headless/src/index.ts
+++ b/examples/pi-headless/src/index.ts
@@ -9,7 +9,7 @@ import process from "node:process";
 import type { NatsConnection } from "@nats-io/nats-core";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
 import { connect as natsConnect } from "@nats-io/transport-node";
-import { loadContextOptions } from "@synadia-ai/agents";
+import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 
 import { Controller } from "./controller.js";
 import { loadConfig, parseCliOverrides } from "./config.js";
@@ -27,7 +27,10 @@ async function resolveNatsOptions(
     return { ...(await loadContextOptions(context)), name: "pi-headless" };
   }
   if (natsUrl) {
-    return { servers: natsUrl, name: "pi-headless" };
+    // `parseNatsUrl` extracts userinfo (token / user:password) — without it
+    // a URL like `nats://TOKEN@host:port` would silently drop the token
+    // because `@nats-io/transport-node` doesn't parse credentials from URLs.
+    return { ...parseNatsUrl(natsUrl), name: "pi-headless" };
   }
 
   throw new Error("no NATS target configured (context / NATS_URL / --url)");


### PR DESCRIPTION
## Summary

Closes a recurring UX gap that bit me twice in a single afternoon while deploying the dashboard to a VPS with token-auth NATS:

- The `nats` CLI parses `userinfo` out of NATS URLs (`nats://TOKEN@host:port`, `nats://USER:PASS@host:port`) and feeds the credentials into the connection.
- `@nats-io/transport-node`'s `connect({ servers: url })` and `nats-py`'s `connect(servers=url)` do **not** — both expect credentials as separate config fields. Result: every example in this repo that accepted `--url URL` (or read `$NATS_URL` from env) silently dropped the token and greeted users with `Authorization Violation`.

This patch closes the gap at the SDK level **on both sides** (TS + Python) so every example benefits.

## TypeScript SDK

### `parseNatsUrl(url)` — new helper exported from `@synadia-ai/agents`

Sibling to `loadContextOptions`. Both produce `NodeConnectionOptions` ready for `connect()`.

| input | output |
|---|---|
| `nats://host:port` | `{ servers: [...] }` |
| `nats://TOKEN@host:port` | `{ servers: [...], token }` |
| `nats://USER:PASS@host:port` | `{ servers: [...], user, pass }` |
| `tls://…`, `ws://…`, `wss://…` | scheme preserved |
| `host:port` (scheme-less) | accepted (treated as `nats://`) |
| `nats://a:4222,nats://b:4222` | multi-server split; identical userinfo allowed; mixed throws `NatsContextError` |

### Examples — every `--url` AND `$NATS_URL` env path now uses `parseNatsUrl`

- `agent-web-ui/server/index.ts` — `buildConnectOptions()`
- `pi-headless/src/index.ts` — `resolveNatsOptions()`
- `claude-code-headless/src/index.ts` — `resolveNatsOptions()`
- `dspy/src/index.ts` — bare `natsConnect(parseNatsUrl(NATS_URL))`

12 new unit tests, **213 total passing**.

## Python SDK

Mirror of the same helper. Cross-SDK alignment per `client-sdk/python/CLAUDE.md`'s "wire compatibility" rule.

### `parse_nats_url(url)` — new export from `synadia_ai.agents`

Same shape as the TS helper. Extra subtlety: **IPv6 hosts re-bracketed** — `urllib.parse.urlparse` strips the `[...]` brackets but `nats-py` needs them back.

### `examples/_connect_cli.py` — every Python demo CLI honours URL userinfo

The shared connect-resolver routes both `--url` AND `$NATS_URL` through `parse_nats_url`. So every numbered demo (`01-discover.py` … `06-chat.py`) accepts `nats://TOKEN@host:port` URLs identically to the TS examples and the `nats` CLI.

13 new unit tests, **163 total passing**.

## Verification

**TS:** `bun run typecheck` clean · `bun run test:unit` 213/213 · all four examples typecheck against the new helper · `bun run build` clean.

**Python:** `uv run ruff check --no-cache` clean · `uv run ruff format --check` 51 files clean · `uv run mypy --no-incremental` 49 source files no issues · `uv run pytest -q -k "not e2e"` 163 passed, 1 deliberate skip.

## Out of scope (deliberate)

`agents/*/server.ts` harnesses also use raw `@nats-io/transport-node` but their CLI surface is much smaller (typically a single `--server URL` config field). Easy follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)