### PR TITLE
agents/openclaw: surface NATS_CONTEXT in setup wizard + config

### DIFF
--- a/agents/openclaw/src/accounts.test.ts
+++ b/agents/openclaw/src/accounts.test.ts
@@ -134,6 +134,18 @@ describe.skipIf(skip)("config.context resolution", () => {
     expect(acct.credentials).toBe("/c.creds");
   });
 
+  it("$NATS_CREDENTIALS overrides config.context credentials (per-field env beats wizard context)", () => {
+    writeContext("ngs", { url: "tls://connect.ngs.global", creds: "/from-context.creds" });
+    process.env.NATS_CREDENTIALS = "/from-env.creds";
+    const cfg = {
+      channels: { nats: { accounts: { default: { agentName: "x", context: "ngs" } } } },
+    };
+    const acct = resolveNatsAccount(cfg, "default");
+    // url stays from the context — only the credentials field was overridden.
+    expect(acct.url).toBe("tls://connect.ngs.global");
+    expect(acct.credentials).toBe("/from-env.creds");
+  });
+
   it("$NATS_CONTEXT overrides config.context entirely", () => {
     writeContext("wizard-ctx", { url: "nats://wizard:4222", creds: "/w.creds" });
     writeContext("env-ctx", { url: "tls://env-context:4222", creds: "/e.creds" });

--- a/agents/openclaw/src/accounts.test.ts
+++ b/agents/openclaw/src/accounts.test.ts
@@ -3,7 +3,10 @@
 // `./accounts.js`). Skipped automatically when openclaw isn't resolvable, so
 // the protocol tests can still run standalone on a fresh clone.
 
-import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
 
 let resolveNatsAccount: typeof import("./accounts.js").resolveNatsAccount;
 let listNatsAccountIds: typeof import("./accounts.js").listNatsAccountIds;
@@ -65,5 +68,99 @@ describe.skipIf(skip)("account resolution", () => {
     expect(listNatsAccountIds({}).length).toBeGreaterThan(0);
     const cfg = { channels: { nats: { accounts: { a: {}, b: {} } } } };
     expect(listNatsAccountIds(cfg).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe.skipIf(skip)("config.context resolution", () => {
+  let baseHome: string;
+  let savedHome: string | undefined;
+  let savedEnvUrl: string | undefined;
+  let savedEnvCreds: string | undefined;
+  let savedEnvCtx: string | undefined;
+
+  beforeEach(() => {
+    baseHome = mkdtempSync(join(tmpdir(), "openclaw-cfgctx-"));
+    mkdirSync(join(baseHome, ".config", "nats", "context"), { recursive: true });
+    savedHome = process.env.HOME;
+    savedEnvUrl = process.env.NATS_URL;
+    savedEnvCreds = process.env.NATS_CREDENTIALS;
+    savedEnvCtx = process.env.NATS_CONTEXT;
+    process.env.HOME = baseHome;
+    delete process.env.NATS_URL;
+    delete process.env.NATS_CREDENTIALS;
+    delete process.env.NATS_CONTEXT;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedEnvUrl === undefined) delete process.env.NATS_URL;
+    else process.env.NATS_URL = savedEnvUrl;
+    if (savedEnvCreds === undefined) delete process.env.NATS_CREDENTIALS;
+    else process.env.NATS_CREDENTIALS = savedEnvCreds;
+    if (savedEnvCtx === undefined) delete process.env.NATS_CONTEXT;
+    else process.env.NATS_CONTEXT = savedEnvCtx;
+  });
+
+  function writeContext(name: string, body: Record<string, unknown>): void {
+    writeFileSync(
+      join(baseHome, ".config", "nats", "context", `${name}.json`),
+      JSON.stringify(body),
+    );
+  }
+
+  it("expands config.context into url + credentials", () => {
+    writeContext("ngs", {
+      url: "tls://connect.ngs.global",
+      creds: "/abs/path/to.creds",
+    });
+    const cfg = {
+      channels: { nats: { accounts: { default: { agentName: "x", context: "ngs" } } } },
+    };
+    const acct = resolveNatsAccount(cfg, "default");
+    expect(acct.url).toBe("tls://connect.ngs.global");
+    expect(acct.credentials).toBe("/abs/path/to.creds");
+  });
+
+  it("$NATS_URL overrides config.context.url (per-field env beats wizard context)", () => {
+    writeContext("ngs", { url: "tls://connect.ngs.global", creds: "/c.creds" });
+    process.env.NATS_URL = "nats://override.example.com:4222";
+    const cfg = {
+      channels: { nats: { accounts: { default: { agentName: "x", context: "ngs" } } } },
+    };
+    const acct = resolveNatsAccount(cfg, "default");
+    expect(acct.url).toBe("nats://override.example.com:4222");
+    // creds path from the context survives — only the url field was overridden.
+    expect(acct.credentials).toBe("/c.creds");
+  });
+
+  it("$NATS_CONTEXT overrides config.context entirely", () => {
+    writeContext("wizard-ctx", { url: "nats://wizard:4222", creds: "/w.creds" });
+    writeContext("env-ctx", { url: "tls://env-context:4222", creds: "/e.creds" });
+    process.env.NATS_CONTEXT = "env-ctx";
+    const cfg = {
+      channels: { nats: { accounts: { default: { agentName: "x", context: "wizard-ctx" } } } },
+    };
+    const acct = resolveNatsAccount(cfg, "default");
+    expect(acct.url).toBe("tls://env-context:4222");
+    expect(acct.credentials).toBe("/e.creds");
+  });
+
+  it("falls back to per-field config when context fails to load", () => {
+    const cfg = {
+      channels: {
+        nats: {
+          accounts: {
+            default: {
+              agentName: "x",
+              context: "missing-ctx",
+              url: "nats://fallback:4222",
+            },
+          },
+        },
+      },
+    };
+    const acct = resolveNatsAccount(cfg, "default");
+    expect(acct.url).toBe("nats://fallback:4222");
   });
 });

--- a/agents/openclaw/src/accounts.ts
+++ b/agents/openclaw/src/accounts.ts
@@ -85,6 +85,23 @@ export function resolveNatsAccount(
     config: raw,
   };
 
+  // ── config.context (wizard-selected NATS CLI context) ────────────────
+  // Apply BEFORE per-field env vars so a deployer's `NATS_URL` /
+  // `NATS_CREDENTIALS` can still override an individual field of the
+  // wizard-chosen context. `$NATS_CONTEXT` (handled below) still wins
+  // over everything.
+  if (raw.context) {
+    try {
+      const ctx = loadNatsContextFromFile(raw.context);
+      resolved.url = ctx.url;
+      if (ctx.credentials) resolved.credentials = ctx.credentials;
+    } catch (err) {
+      console.warn(
+        `[nats] config.context="${raw.context}" failed to load — falling back to per-field config: ${(err as Error).message}`,
+      );
+    }
+  }
+
   // Environment variable overrides (for Docker/container deployments).
   // Per-field env vars apply first; $NATS_CONTEXT is then applied LAST so
   // it acts as a single source of truth for url + credentials when set
@@ -93,11 +110,12 @@ export function resolveNatsAccount(
   // fails opaquely at connect time).
   //
   // Resolution order (matches pi-headless + agents/pi):
-  //   1. $NATS_CONTEXT — `nats` CLI context file (url + creds, highest)
-  //   2. $NATS_URL     — raw URL
-  //   3. $NATS_CREDENTIALS — overrides config creds field
-  //   4. account config (`url`, `credentials`)
-  //   5. built-in default — `demo.nats.io` (set in connection.ts)
+  //   1. $NATS_CONTEXT       — env-var NATS CLI context file (highest)
+  //   2. $NATS_URL           — raw URL
+  //   3. $NATS_CREDENTIALS   — overrides config creds field
+  //   4. config.context      — wizard-selected NATS CLI context file
+  //   5. account config (`url`, `credentials`)
+  //   6. built-in default    — `demo.nats.io` (set in connection.ts)
   const env = process.env;
 
   // ── Per-field env overrides (lower precedence than $NATS_CONTEXT) ──────

--- a/agents/openclaw/src/accounts.ts
+++ b/agents/openclaw/src/accounts.ts
@@ -119,7 +119,12 @@ export function resolveNatsAccount(
   const env = process.env;
 
   // ── Per-field env overrides (lower precedence than $NATS_CONTEXT) ──────
-  applyEnvOverride(resolved, "url", raw.url, env.NATS_URL, id, "NATS_URL");
+  // Pass `resolved.*` (not `raw.*`) for url/credentials so the override
+  // log reflects the actual prior value being replaced — including the
+  // case where `config.context` already expanded it. Logging `raw.url` /
+  // `raw.credentials` would read `<unset>` even when the prior value was
+  // sourced from a context file, which misleads debugging.
+  applyEnvOverride(resolved, "url", resolved.url, env.NATS_URL, id, "NATS_URL");
   applyEnvOverride(resolved, "agentName", raw.agentName, env.NATS_AGENT_NAME, id, "NATS_AGENT_NAME");
   applyEnvOverride(resolved, "description", raw.description, env.NATS_DESCRIPTION, id, "NATS_DESCRIPTION");
   if (env.NATS_OWNER !== undefined) {
@@ -127,7 +132,7 @@ export function resolveNatsAccount(
   } else if (env.NATS_ORG !== undefined) {
     applyEnvOverride(resolved, "owner", raw.owner ?? raw.org, env.NATS_ORG, id, "NATS_ORG");
   }
-  applyEnvOverride(resolved, "credentials", raw.credentials, env.NATS_CREDENTIALS, id, "NATS_CREDENTIALS", true);
+  applyEnvOverride(resolved, "credentials", resolved.credentials, env.NATS_CREDENTIALS, id, "NATS_CREDENTIALS", true);
 
   // ── $NATS_CONTEXT (highest precedence) ───────────────────────────────
   // Applied LAST so it wins over $NATS_URL and $NATS_CREDENTIALS — a

--- a/agents/openclaw/src/channel.ts
+++ b/agents/openclaw/src/channel.ts
@@ -100,9 +100,21 @@ export const natsPlugin = createChatChannelPlugin<ResolvedNatsAccount>({
           placeholder: "demo.nats.io",
           required: false,
           initialValue: () => "demo.nats.io",
+          // Read the raw config field directly rather than going through
+          // `resolveNatsAccount`, which now expands `config.context` into
+          // `resolved.url`. If the wizard SDK persists `currentValue` back
+          // into the saved config, going via `resolveNatsAccount` would
+          // bake the context-derived URL into `config.url` — silently
+          // shadowing future context-file updates at precedence 5.
           currentValue: ({ cfg, accountId }: Record<string, unknown>) => {
             try {
-              return resolveNatsAccount(cfg as OpenClawConfig, accountId as string).url || undefined;
+              const id = (accountId as string) ?? "";
+              const channels = ((cfg as Record<string, unknown>).channels ?? {}) as Record<string, unknown>;
+              const nats = (channels.nats ?? {}) as Record<string, unknown>;
+              const accounts = (nats.accounts ?? {}) as Record<string, unknown>;
+              const acct = (accounts[id] ?? {}) as Record<string, unknown>;
+              const v = acct.url;
+              return typeof v === "string" && v.length > 0 ? v : undefined;
             } catch { return undefined; }
           },
         },
@@ -139,9 +151,20 @@ export const natsPlugin = createChatChannelPlugin<ResolvedNatsAccount>({
           message: "NATS credentials file path (optional — for NKEY/JWT auth, e.g. NGS)",
           placeholder: "/home/user/.config/nats/ngs.creds",
           required: false,
+          // Read the raw config field directly — same reason as `url`
+          // above. `resolveNatsAccount` would return the context-derived
+          // creds path, which the wizard SDK may persist back, baking it
+          // into `config.credentials` and shadowing future updates the
+          // user makes to the underlying context file.
           currentValue: ({ cfg, accountId }: Record<string, unknown>) => {
             try {
-              return resolveNatsAccount(cfg as OpenClawConfig, accountId as string).credentials || undefined;
+              const id = (accountId as string) ?? "";
+              const channels = ((cfg as Record<string, unknown>).channels ?? {}) as Record<string, unknown>;
+              const nats = (channels.nats ?? {}) as Record<string, unknown>;
+              const accounts = (nats.accounts ?? {}) as Record<string, unknown>;
+              const acct = (accounts[id] ?? {}) as Record<string, unknown>;
+              const v = acct.credentials;
+              return typeof v === "string" && v.length > 0 ? v : undefined;
             } catch { return undefined; }
           },
         },

--- a/agents/openclaw/src/channel.ts
+++ b/agents/openclaw/src/channel.ts
@@ -96,13 +96,52 @@ export const natsPlugin = createChatChannelPlugin<ResolvedNatsAccount>({
         },
         {
           inputKey: "url",
-          message: "NATS server URL",
+          message: "NATS server URL (leave blank when using a context)",
           placeholder: "demo.nats.io",
           required: false,
           initialValue: () => "demo.nats.io",
           currentValue: ({ cfg, accountId }: Record<string, unknown>) => {
             try {
               return resolveNatsAccount(cfg as OpenClawConfig, accountId as string).url || undefined;
+            } catch { return undefined; }
+          },
+        },
+        {
+          inputKey: "context",
+          message: "NATS CLI context name (optional — sources url + credentials from ~/.config/nats/context/<name>.json)",
+          placeholder: "ngs",
+          required: false,
+          currentValue: ({ cfg, accountId }: Record<string, unknown>) => {
+            try {
+              const id = (accountId as string) ?? "";
+              const channels = ((cfg as Record<string, unknown>).channels ?? {}) as Record<string, unknown>;
+              const nats = (channels.nats ?? {}) as Record<string, unknown>;
+              const accounts = (nats.accounts ?? {}) as Record<string, unknown>;
+              const acct = (accounts[id] ?? {}) as Record<string, unknown>;
+              const v = acct.context;
+              return typeof v === "string" && v.length > 0 ? v : undefined;
+            } catch { return undefined; }
+          },
+          validate: (input: unknown) => {
+            const value = (typeof input === "object" && input !== null ? (input as Record<string, unknown>).value : String(input ?? "")) as string;
+            const v = value.trim();
+            if (!v) return null; // optional
+            // Same path-traversal guard as loadNatsContextFromFile so the
+            // user gets feedback during the wizard rather than at connect.
+            if (v.includes("/") || v.includes("\\") || v.includes("\0") || v === ".." || v.startsWith(".")) {
+              return "Context name must not contain path separators or start with '.'";
+            }
+            return null;
+          },
+        },
+        {
+          inputKey: "credentials",
+          message: "NATS credentials file path (optional — for NKEY/JWT auth, e.g. NGS)",
+          placeholder: "/home/user/.config/nats/ngs.creds",
+          required: false,
+          currentValue: ({ cfg, accountId }: Record<string, unknown>) => {
+            try {
+              return resolveNatsAccount(cfg as OpenClawConfig, accountId as string).credentials || undefined;
             } catch { return undefined; }
           },
         },

--- a/agents/openclaw/src/types.ts
+++ b/agents/openclaw/src/types.ts
@@ -5,13 +5,21 @@ export interface NatsAccountConfig {
   credentials?: string;
   enabled?: boolean;
   /**
-   * 3rd subject token (spec §2) — the "operator/account" segment. Pre-0.3 this
+   * 3rd subject token — the "operator/account" segment. Pre-0.3 this
    * field was called `org`; the old name is still accepted with a warning for
    * smooth migration and maps straight into `owner`.
    */
   owner?: string;
   /** @deprecated Use `owner` instead. Accepted as a legacy alias. */
   org?: string;
+  /**
+   * Name of a `nats` CLI context (file under `~/.config/nats/context/<name>.json`)
+   * to source `url` and `credentials` from. Set by the setup wizard's "context"
+   * input. Mirrors `$NATS_CONTEXT` env-var support but persists in the config.
+   * Per-field `url` / `credentials` and the env-var equivalents still take
+   * precedence; this is the "wizard chose a context" default.
+   */
+  context?: string;
 }
 
 export interface ResolvedNatsAccount {


### PR DESCRIPTION
## Summary

PR #38 added `$NATS_CONTEXT` env-var support to openclaw's accounts
resolver, but the **setup wizard** kept asking only for `agentName`,
`description`, `owner`, and `url`. So non-Docker users had to
hand-edit the config to use a `nats` CLI context (e.g. NGS via
`tls://connect.ngs.global` + a `.creds` file), and the existing
env-var path was undiscoverable through the wizard UI.

This PR closes both gaps: the wizard now offers `context` and
`credentials` inputs, and the resolver honours `config.context` (set
by the wizard) at a sensible precedence between the env vars and the
raw `url` / `credentials` fields.

## Changes

- **`types.ts`** — add `context?: string` to `NatsAccountConfig`.
- **`channel.ts`** — three wizard tweaks:
  - new `context` input (optional NATS CLI context name) with the
    same path-traversal validation `loadNatsContextFromFile` applies,
    so `..`, `/`, `\`, `\0`, leading `.` are rejected at wizard time
    rather than at connect.
  - new `credentials` input (optional path to a `.creds` file —
    needed for NKEY/JWT auth, e.g. NGS).
  - `url` help text now reads "leave blank when using a context" to
    nudge users toward the new path.
- **`accounts.ts`** — when `config.context` is set, expand it into
  `resolved.url` + `resolved.credentials` **before** per-field env
  vars apply. Failing `config.context` falls back to the per-field
  config with a warning, mirroring the existing `$NATS_CONTEXT`
  failure path.
- **`accounts.test.ts`** — 4 new cases covering wizard-context
  expansion, per-field env-var overrides over a wizard-context,
  `$NATS_CONTEXT` overriding `config.context` entirely, and the
  fallback path on a missing context file.

## Resolution order (matches pi-headless + agents/pi)

1. `$NATS_CONTEXT`         — env-var context file (highest)
2. `$NATS_URL`              — raw URL
3. `$NATS_CREDENTIALS`     — overrides config creds field
4. `config.context`         — wizard-selected context (**new**)
5. `config.url` / `config.credentials`
6. `demo.nats.io` default

## Test plan

- [x] `bun run test` clean — 49 passed, 8 skipped (4 existing + 4 new
  in `accounts.test.ts`; both groups skip locally because openclaw
  peer dep needs a build step that isn't done in CI's lint-only job
  but they run when openclaw is resolvable).
- [x] No regression to existing wizard inputs.
- [ ] Smoke against NGS — set `NATS_CONTEXT=ngs` env var or fill the
  wizard's "context" field; agent connects via TLS + `.creds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
