### PR TITLE
agents/openclaw: wire credsAuthenticator from config.credentials

### DIFF
--- a/agents/openclaw/src/nats/connection.ts
+++ b/agents/openclaw/src/nats/connection.ts
@@ -1,5 +1,6 @@
 import { connect } from "@nats-io/transport-node";
-import type { NatsConnection } from "@nats-io/nats-core";
+import { credsAuthenticator, type NatsConnection } from "@nats-io/nats-core";
+import { readFileSync } from "node:fs";
 import type { ConnectionConfig } from "./types.js";
 import { parseNatsUrl } from "./url.js";
 
@@ -16,10 +17,21 @@ export async function connectToNats(
   // a URL like `nats://TOKEN@host:port` would silently drop the token,
   // because `@nats-io/transport-node`'s `connect({ servers: url })` does
   // not parse credentials from URLs.
-  const nc = await connect({
+  const opts: Parameters<typeof connect>[0] = {
     ...parseNatsUrl(url),
     name: config.name,
-  });
+  };
+  // Wire NKEY/JWT auth from a `.creds` file when configured. Required for
+  // NGS (Synadia Cloud) and any account-mode NATS server. Without this,
+  // `tls://connect.ngs.global` connects but immediately fails CONNECT
+  // with "Authorization Violation" because no credentials are presented.
+  // `readFileSync` is intentional: the connection is async but the creds
+  // file is small and read once at startup, and `credsAuthenticator`
+  // wants the bytes synchronously to derive the seed/JWT pair.
+  if (config.credentials) {
+    opts.authenticator = credsAuthenticator(readFileSync(config.credentials));
+  }
+  const nc = await connect(opts);
 
   // Log connection status events
   (async () => {


### PR DESCRIPTION
## Summary

`ConnectionConfig.credentials` was declared in the type and threaded
through `gateway.ts → connectToNats({...credentials: account.credentials})`,
but `connectToNats` itself never read it. Token-in-URL worked (via
`parseNatsUrl`), but `.creds` files for NKEY/JWT auth (which NGS /
Synadia Cloud / any account-mode server requires) were silently
dropped — the connection succeeded TLS but failed at CONNECT with
**Authorization Violation**.

Symptom users hit (concrete log from a `claw1` container pointed at NGS):

```
[nats] gateway starting — agents.prompt.oc.m64.Claw1 @ tls://connect.ngs.global
[nats] [default] channel exited: Authorization Violation
[nats] [default] auto-restart attempt 1/10 in 5s
```

The path that surfaced this was `config.context = "ngs"` (from PR #39's
wizard) → `loadNatsContextFromFile` → `resolved.credentials = "/abs/path.creds"`
→ ignored by `connectToNats`. Same outcome via `$NATS_CREDENTIALS=...` or a
hand-edited `accounts.<id>.credentials` config field.

## Fix

Mirror the pattern already in `agents/pi/extensions/nats-channel.ts` and
`agents/claude-code/server.ts`: when `config.credentials` is set, read
the file and attach a `credsAuthenticator(bytes)` to the connect
options.

```ts
if (config.credentials) {
  opts.authenticator = credsAuthenticator(readFileSync(config.credentials));
}
```

Same import shape (`@nats-io/nats-core`), same `readFileSync` choice
(small file, read once at startup, authenticator wants bytes
synchronously).

## Test plan

- [x] `bun run test` clean (49 passed, 9 skipped — same skip pattern).
- [ ] Smoke against NGS — set `config.context: "ngs"` (or
  `$NATS_CONTEXT=ngs`) inside a container with the matching `.creds`
  mounted; the agent should connect cleanly via TLS instead of
  thrashing on Authorization Violation.

## Related

- PR #38 (env-var support for `$NATS_CONTEXT`) — merged.
- PR #39 (wizard inputs for `context` + `credentials`) — merged.
- This PR — the missing third leg that makes the credentials path
  actually authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
