### PR TITLE
max_payload: derive from nc.info, clamp on advertise, cap on publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>
        └─── streamed chunks ───────┘
 ```
 
-- **`client-sdk/*`** - produce envelopes, validate locally against agent metadata (`max_payload`, `attachments_ok`), parse streamed chunks.
+- **`client-sdk/*`** - produce envelopes, validate locally against agent metadata (`max_payload`, `attachments_ok`) and the caller's own `nc.info.max_payload` (the smaller of the two binds — the caller's broker rejects oversized publishes before they reach the agent), parse streamed chunks.
 - **`agents/*`** - register the `agents` micro service, drive the underlying AI harness, stream chunks back.
 - **`examples/*`** - demonstrate SDK usage end-to-end against real agents.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -8,10 +8,12 @@ For an example of *building* a fresh agent from scratch using the TypeScript SDK
 
 | Path                | Type token | Underlying harness                          | Prompt subject (v0.3 verb-first)                              | `max_payload` | `attachments_ok` |
 | ------------------- | ---------- | ------------------------------------------- | ------------------------------------------------------------- | ------------- | ---------------- |
-| `pi/`               | `pi`       | [PI Agent](https://github.com/badlogic/pi-mono) | `agents.prompt.pi.<owner>.<session>`                      | 1 MB          | true             |
-| `openclaw/`         | `oc`       | [OpenClaw](https://openclaw.ai)             | `agents.prompt.oc.<owner>.<agentName>`                        | 1 MB          | true             |
-| `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | 1 MB          | true             |
-| `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | 1 MB (configurable) | true        |
+| `pi/`               | `pi`       | [PI Agent](https://github.com/badlogic/pi-mono) | `agents.prompt.pi.<owner>.<session>`                      | 1 MB / system-defined | true |
+| `openclaw/`         | `oc`       | [OpenClaw](https://openclaw.ai)             | `agents.prompt.oc.<owner>.<agentName>`                        | 1 MB / system-defined | true |
+| `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | 1 MB / system-defined | true |
+| `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | 1 MB / system-defined (config can request a smaller cap) | true |
+
+`max_payload` is read from the NATS connection's `INFO` block at startup and advertised verbatim, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and the agents track it.
 
 Every agent also publishes heartbeats on `agents.hb.<type-token>.<owner>.<session>` every 30 s and answers `agents.status.<type-token>.<owner>.<session>` requests with the same payload (§8.7 (v0.3)).
 

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -110,8 +110,11 @@ This plugin implements the **NATS Agent Protocol v0.3** end-to-end:
   token).
 - Service metadata includes `agent`, `owner`, `session`, and
   `protocol_version: "0.3"` (§3.2).
-- `prompt` endpoint declares `max_payload: "1MB"`,
-  `attachments_ok: "true"` (§2.1), and queue group `"agents"` (§3.3).
+- `prompt` endpoint declares the server-negotiated `max_payload` (read
+  from `nc.info.max_payload` at startup and formatted into the §2.1
+  `\d+(B|KB|MB|GB)` grammar — `1MB` against a default `nats-server`,
+  larger if the operator bumped `--max_payload`), `attachments_ok:
+  "true"` (§2.1), and queue group `"agents"` (§3.3).
 - Accepts both plain-text shorthand and JSON envelopes with optional
   base64-encoded attachments (§5.1, §5.2, §5.3). Inbound attachments
   are staged to a per-request temp directory and exposed to Claude via

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -759,7 +759,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         }
 
         process.stderr.write(
-        const maxPayload = MAX_PAYLOAD_BYTES
+          `nats channel: replying to ${pending.replySubject} (request ${requestId}, done=${done}, bytes=${text.length})\n`,
         )
 
         const maxPayload = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -759,7 +759,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         }
 
         process.stderr.write(
-          `nats channel: replying to ${pending.replySubject} (request ${requestId}, done=${done}, bytes=${text.length})\n`,
+        const maxPayload = MAX_PAYLOAD_BYTES
         )
 
         const maxPayload = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -47,9 +47,21 @@ const AGENT_SUBJECT_TOKEN = 'cc'        // 3rd subject token (abbreviation per A
 const SERVICE_NAME = 'agents'           // §3.1 — the bare token, subject-safe as-is
 const PROMPT_QUEUE_GROUP = 'agents'     // §3.3 — queue group on the prompt endpoint
 const STATUS_QUEUE_GROUP = 'agents'     // §8.7 (v0.3) — same as prompt
-const MAX_PAYLOAD_STRING = '1MB'        // advertised in endpoint metadata
-const MAX_PAYLOAD_BYTES = 1024 * 1024   // enforcement value (base-1024, matches SDK)
+// Fallbacks used only when the server `INFO` block is unavailable. The real
+// values come from `nc.info.max_payload` after connect — that's the limit the
+// server will actually accept for this user/account, so it's also what we
+// advertise in endpoint metadata and enforce on inbound requests.
+const DEFAULT_MAX_PAYLOAD_STR = '1MB'
+const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024
 const ATTACHMENTS_OK = true
+
+/** Format a byte count back into the §2.1 `\d+(B|KB|MB|GB)` grammar, base-1024. */
+function formatMaxPayloadString(bytes: number): string {
+  if (bytes >= 1024 ** 3 && bytes % 1024 ** 3 === 0) return `${bytes / 1024 ** 3}GB`
+  if (bytes >= 1024 ** 2 && bytes % 1024 ** 2 === 0) return `${bytes / 1024 ** 2}MB`
+  if (bytes >= 1024 && bytes % 1024 === 0) return `${bytes / 1024}KB`
+  return `${bytes}B`
+}
 const HEARTBEAT_INTERVAL_S = 30         // §8.2 recommended default
 const ACK_INTERVAL_MS = 30_000          // keep-alive cadence; caller inactivity timeout is 60s
 const PERMISSION_TIMEOUT_MS = 120_000   // query reply timeout for permission prompts
@@ -305,11 +317,11 @@ type ParseResult =
 const WHITESPACE = new Set([0x09, 0x0A, 0x0D, 0x20])
 const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
 
-function parseRequest(data: Uint8Array): ParseResult {
+function parseRequest(data: Uint8Array, maxPayloadBytes: number): ParseResult {
   if (data.byteLength === 0) {
     return { kind: 'error', code: 400, description: 'empty payload' }
   }
-  if (data.byteLength > MAX_PAYLOAD_BYTES) {
+  if (data.byteLength > maxPayloadBytes) {
     return { kind: 'error', code: 400, description: 'request exceeds max_payload' }
   }
 
@@ -499,7 +511,13 @@ const ctxLabel = ctxName
     : 'default: demo.nats.io'
 process.stderr.write(`nats channel: connecting to ${natsCtx.url ?? 'default'} (${ctxLabel})\n`)
 const nc = await connect(connectOpts)
-process.stderr.write(`nats channel: connected\n`)
+// Server-negotiated max_payload (§2.1). Reflects this user/account's real
+// limit, so we use it for both endpoint metadata and §5.4 enforcement.
+const MAX_PAYLOAD_BYTES = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES
+const MAX_PAYLOAD_STR = nc.info?.max_payload
+  ? formatMaxPayloadString(MAX_PAYLOAD_BYTES)
+  : DEFAULT_MAX_PAYLOAD_STR
+process.stderr.write(`nats channel: connected (max_payload=${MAX_PAYLOAD_STR})\n`)
 
 // ── Resolve session name and register micro service ────────────────────
 
@@ -534,7 +552,7 @@ service.addEndpoint('prompt', {
   queue: PROMPT_QUEUE_GROUP,
   handler: (err, msg) => handleNatsMessage(err, msg),
   metadata: {
-    max_payload: MAX_PAYLOAD_STRING,
+    max_payload: MAX_PAYLOAD_STR,
     attachments_ok: ATTACHMENTS_OK ? 'true' : 'false',
   },
 })
@@ -744,7 +762,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           `nats channel: replying to ${pending.replySubject} (request ${requestId}, done=${done}, bytes=${text.length})\n`,
         )
 
-        const maxPayload = nc.info?.max_payload ?? MAX_PAYLOAD_BYTES
+        const maxPayload = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES
 
         if (text.length > 0) {
           const envelope = JSON.stringify({ type: 'response', data: text })
@@ -803,7 +821,7 @@ function handleNatsMessage(err: Error | null, msg: ServiceMsg): void {
     return
   }
 
-  const parsed = parseRequest(msg.data)
+  const parsed = parseRequest(msg.data, MAX_PAYLOAD_BYTES)
   if (parsed.kind === 'error') {
     process.stderr.write(`nats channel: rejecting request (${parsed.code} ${parsed.description})\n`)
     msg.respondError(parsed.code, parsed.description)

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -762,7 +762,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           `nats channel: replying to ${pending.replySubject} (request ${requestId}, done=${done}, bytes=${text.length})\n`,
         )
 
-        const maxPayload = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES
+        const maxPayload = MAX_PAYLOAD_BYTES
 
         if (text.length > 0) {
           const envelope = JSON.stringify({ type: 'response', data: text })

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -86,7 +86,8 @@ Start the gateway and confirm registration:
 
 ```bash
 hermes gateway run
-# expect: "[Nats] Connected — subscribed at agents.prompt.hermes.yourname.demo (heartbeat=30s, max_payload=1MB, attachments_ok=True)"
+# expect: "[Nats] Connected — subscribed at agents.prompt.hermes.yourname.demo (heartbeat=30s, max_payload=<server>, attachments_ok=True)"
+# (max_payload defaults to nc.info.max_payload — 1MB on a default nats-server.)
 ```
 
 ## Configure
@@ -127,7 +128,7 @@ platforms:
       attachments_ok: true
       # Optional tuning (defaults shown):
       # agent: hermes                # 3rd subject token; rarely changed
-      # max_payload: "1MB"           # pattern \d+(B|KB|MB|GB)
+      # max_payload: "1MB"           # pattern \d+(B|KB|MB|GB); see "Config fields"
       # heartbeat_interval_s: 30
 ```
 
@@ -147,7 +148,7 @@ All fields live under `platforms.nats.extra` in `~/.hermes/config.yaml`.
 | `session_name` | yes | — | 5th subject token — fixed per service (multi-session = multi-profile) |
 | `agent` | no | `hermes` | 3rd subject token; rarely changed |
 | `attachments_ok` | no | `true` | Accept inline base64 attachments |
-| `max_payload` | no | `"1MB"` | Per-request limit; must match `\d+(B\|KB\|MB\|GB)` |
+| `max_payload` | no | server-negotiated | Per-request advertised limit; must match `\d+(B\|KB\|MB\|GB)`. Defaults to `nc.info.max_payload` (1 MB on a default `nats-server`). A configured value is honored up to the server limit; if it's larger, the SDK clamps the advertised value down to the server's limit and logs a warning — anything bigger would be rejected by the broker before reaching your handler. Set this only when you want to advertise a *smaller* cap to shed expensive prompts client-side. |
 | `heartbeat_interval_s` | no | `30` | Liveness beacon interval |
 
 ### Environment variables (optional)
@@ -273,7 +274,7 @@ When `hermes gateway run` starts with `platforms.nats.enabled = true`:
 
 1. Connects to NATS using a configured context (or `demo.nats.io` by default via `$NATS_URL`).
 2. Registers a NATS micro service named `agents` with v0.3 spec metadata (`agent`, `owner`, `protocol_version`).
-3. Adds a `prompt` endpoint at `agents.prompt.hermes.<owner>.<session_name>` advertising `max_payload: 1MB` and `attachments_ok: true`, and a `status` endpoint at `agents.status.hermes.<owner>.<session_name>` for on-demand liveness.
+3. Adds a `prompt` endpoint at `agents.prompt.hermes.<owner>.<session_name>` advertising the server-negotiated `max_payload` (read from `nc.info.max_payload` and formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar — `1MB` against a default `nats-server`; a YAML `max_payload` setting overrides this *down* but is clamped if larger than the server allows) and `attachments_ok: true`, and a `status` endpoint at `agents.status.hermes.<owner>.<session_name>` for on-demand liveness.
 4. Publishes heartbeats on `agents.hb.hermes.<owner>.<session_name>` every 30 s.
 5. On each inbound prompt: decodes any attached files to the gateway's attachment staging area, routes images through Hermes's `vision_analyze` tool so the agent actually sees them, emits a `status: ack` chunk, runs the full Hermes agent loop (tools, memory, skills, approvals) to completion, and streams model output back as typed `{type:"response","data":…}` chunks, terminating with the spec-mandated empty-body no-headers terminator.
 6. Malformed envelopes, oversized payloads, invalid base64, and unsafe filenames are rejected at the wire with `Nats-Service-Error-Code: 400`. Internal failures return `500`.

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -12,7 +12,7 @@ When OpenClaw starts the channel:
 
 1. Connects to NATS using the configured URL and optional credentials.
 2. Registers a NATS micro service named `agents` with spec metadata (`agent`, `owner`, `session`, `protocol_version`).
-3. Adds a `prompt` endpoint at `agents.prompt.oc.<owner>.<agentName>` (verb-first §2 v0.3) advertising `max_payload: 1MB` and `attachments_ok: true`.
+3. Adds a `prompt` endpoint at `agents.prompt.oc.<owner>.<agentName>` (verb-first §2 v0.3) advertising the server-negotiated `max_payload` (read from `nc.info.max_payload` at connect, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar — `1MB` against a default `nats-server`, more if the operator bumped `--max_payload`) and `attachments_ok: true`.
 4. Adds a `status` endpoint at `agents.status.oc.<owner>.<agentName>` (§8.7 (v0.3)) that replies with the same payload shape as a heartbeat.
 5. Publishes heartbeats on `agents.hb.oc.<owner>.<agentName>` (verb is the abbreviation `hb`, §8.1 v0.3) every 30 s.
 5. On each inbound prompt: decodes any attached files to `~/.openclaw/attachments/<agentName>/<uuid>/<filename>`, prepends their absolute paths to the prompt text, emits a `status: ack` chunk, dispatches the augmented prompt into OpenClaw's direct-DM pipeline, and streams each delivered block back as a typed `{type:"response",data}` chunk, terminating with the spec-mandated empty-body no-headers terminator.
@@ -191,7 +191,7 @@ Caller-side constraints (rejected with `400` if violated):
 
 - `content` must be strict RFC 4648 §4 base64 - standard alphabet, padded, no URL-safe, no whitespace.
 - `filename` must be a plain basename. Path separators (`/`, `\`), `..`, absolute paths, and NUL bytes are rejected rather than silently flattened.
-- Full encoded envelope must fit within `max_payload` (1 MB).
+- Full encoded envelope must fit within the advertised `max_payload` — the server-negotiated limit read at connect time. `1 MB` against a default `nats-server`; matches whatever `nc.info.max_payload` reports.
 
 Spec §5.5 reserves a future `attachments` endpoint at `agents.attachments.oc.<owner>.<agentName>` (v0.3 verb-first) for chunked large-file upload; that lands in a future protocol revision and will coexist with inline attachments.
 

--- a/agents/openclaw/src/gateway.ts
+++ b/agents/openclaw/src/gateway.ts
@@ -11,8 +11,8 @@ import {
   ATTACHMENTS_OK,
   DEFAULT_SESSION,
   HEARTBEAT_INTERVAL_S,
-  MAX_PAYLOAD_BYTES,
-  MAX_PAYLOAD_STR,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+  DEFAULT_MAX_PAYLOAD_STR,
   PROMPT_QUEUE_GROUP,
   PROTOCOL_VERSION,
   SERVICE_NAME,
@@ -21,6 +21,7 @@ import {
   buildHeartbeatPayload,
   connectToNats,
   drainConnection,
+  formatMaxPayloadString,
   heartbeatSubject,
   parseEnvelope,
   promptSubject,
@@ -107,6 +108,15 @@ export async function startNatsGateway(
   setActiveConnection(nc, agentName, owner);
   ctx.setStatus({ state: "running" });
 
+  // Server-negotiated max_payload (§2.1). Reflects this user/account's real
+  // limit, so we use it for endpoint metadata advertisement and §5.4
+  // local enforcement instead of a hard-coded 1MB.
+  const maxPayloadBytes = nc.info?.max_payload ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  const maxPayloadStr = nc.info?.max_payload
+    ? formatMaxPayloadString(maxPayloadBytes)
+    : DEFAULT_MAX_PAYLOAD_STR;
+  ctx.log?.info?.(`nats: server max_payload=${maxPayloadStr}`);
+
   // 2. Register the shared `agents` service (spec §3).
   const svc = new Svcm(nc);
   const service = await svc.add({
@@ -131,9 +141,9 @@ export async function startNatsGateway(
   service.addEndpoint("prompt", {
     subject,
     queue: PROMPT_QUEUE_GROUP,
-    handler: buildPromptHandler(ctx, nc, account, cfg, channelRuntime),
+    handler: buildPromptHandler(ctx, nc, account, cfg, channelRuntime, maxPayloadBytes, maxPayloadStr),
     metadata: {
-      max_payload: MAX_PAYLOAD_STR,
+      max_payload: maxPayloadStr,
       attachments_ok: ATTACHMENTS_OK ? "true" : "false",
     },
   });
@@ -215,13 +225,15 @@ function buildPromptHandler(
   account: ResolvedNatsAccount,
   cfg: Parameters<typeof dispatchInboundDirectDmWithRuntime>[0]["cfg"],
   channelRuntime: ChannelGatewayContext<ResolvedNatsAccount>["channelRuntime"],
+  maxPayloadBytes: number,
+  maxPayloadStr: string,
 ): ServiceHandler {
   return (err, msg) => {
     if (err || !msg.reply) return;
 
     // §5.4: enforce max_payload locally.
-    if (msg.data.byteLength > MAX_PAYLOAD_BYTES) {
-      respondWithError(nc, msg, 400, `payload exceeds max_payload (${MAX_PAYLOAD_STR})`);
+    if (msg.data.byteLength > maxPayloadBytes) {
+      respondWithError(nc, msg, 400, `payload exceeds max_payload (${maxPayloadStr})`);
       return;
     }
 

--- a/agents/openclaw/src/nats/protocol.ts
+++ b/agents/openclaw/src/nats/protocol.ts
@@ -33,9 +33,21 @@ export const SUBJECT_AGENT_TOKEN = "oc";
  *  (spec Appendix C). We set it so callers always see a value in $SRV.INFO. */
 export const DEFAULT_SESSION = "default";
 
-export const MAX_PAYLOAD_STR = "1MB";
-export const MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, NATS convention
+// Fallbacks used only when the server `INFO` block is unavailable. The real
+// values come from `nc.info.max_payload` after connect — that's the negotiated
+// limit for this user/account, so it's also what we advertise on the prompt
+// endpoint and enforce on inbound requests.
+export const DEFAULT_MAX_PAYLOAD_STR = "1MB";
+export const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, NATS convention
 export const ATTACHMENTS_OK = true;
+
+/** Format a byte count back into the §2.1 `\d+(B|KB|MB|GB)` grammar (base-1024). */
+export function formatMaxPayloadString(bytes: number): string {
+  if (bytes >= 1024 ** 3 && bytes % 1024 ** 3 === 0) return `${bytes / 1024 ** 3}GB`;
+  if (bytes >= 1024 ** 2 && bytes % 1024 ** 2 === 0) return `${bytes / 1024 ** 2}MB`;
+  if (bytes >= 1024 && bytes % 1024 === 0) return `${bytes / 1024}KB`;
+  return `${bytes}B`;
+}
 
 /** Spec §8.2 recommended default cadence. */
 export const HEARTBEAT_INTERVAL_S = 30;

--- a/agents/openclaw/test/nats-server.conf
+++ b/agents/openclaw/test/nats-server.conf
@@ -1,0 +1,11 @@
+// Test config consumed by `test/smoke.mjs` when it spawns its own local
+// nats-server. `port: -1` asks the server to pick an ephemeral port — the
+// smoke harness reads it back via `--ports_file_dir`, so the test never
+// touches a developer's real server on 4222.
+//
+// `max_payload: 8MB` is deliberately non-default so the dynamic
+// `nc.info.max_payload` path (advertise on the prompt endpoint, enforce on
+// §5.4) is actually exercised — a 1MB default would silently match the
+// legacy hard-coded value.
+port: -1
+max_payload: 8MB

--- a/agents/openclaw/test/smoke.mjs
+++ b/agents/openclaw/test/smoke.mjs
@@ -13,13 +13,19 @@
 //
 //   bun test/smoke.mjs
 //
-// Prereq: nats-server on 127.0.0.1:4222.
+// Server: this test always spawns its own private nats-server (via
+// `test/nats-server.conf`, which pins `port: -1` so the kernel picks an
+// ephemeral port and `max_payload: 8MB` so the dynamic max_payload path is
+// exercised). The chosen port is read back from `--ports_file_dir` and the
+// server is killed on exit. Prereq: `nats-server` on PATH.
 
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { connect } from "@nats-io/transport-node";
 import { createInbox } from "@nats-io/nats-core";
 import { Svcm } from "@nats-io/services";
@@ -29,12 +35,13 @@ import {
 	ATTACHMENTS_OK,
 	DEFAULT_SESSION,
 	HEARTBEAT_INTERVAL_S,
-	MAX_PAYLOAD_STR,
+	DEFAULT_MAX_PAYLOAD_STR,
 	PROMPT_QUEUE_GROUP,
 	PROTOCOL_VERSION,
 	SERVICE_NAME,
 	SERVICE_VERSION,
 	buildHeartbeatPayload,
+	formatMaxPayloadString,
 	heartbeatSubject,
 	parseEnvelope,
 	promptSubject,
@@ -67,8 +74,50 @@ function step(name, fn) {
 	};
 }
 
+// ── Spawn a private nats-server on an ephemeral port ──────────────────────
+// Avoids touching whatever the developer has running on 4222 — every smoke
+// run is fully isolated.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORTS_DIR = mkdtempSync(join(tmpdir(), "nats-oc-smoke-ports-"));
+const NATS_CONF = join(__dirname, "nats-server.conf");
+const spawnedServer = spawn(
+	"nats-server",
+	["-c", NATS_CONF, "--ports_file_dir", PORTS_DIR],
+	{ stdio: "ignore" },
+);
+spawnedServer.on("error", (err) => {
+	console.error(`could not spawn nats-server: ${err.message}`);
+	console.error("install nats-server (https://nats.io) before re-running this smoke");
+	process.exit(2);
+});
+process.on("exit", () => {
+	if (spawnedServer && !spawnedServer.killed) spawnedServer.kill();
+	try {
+		rmSync(PORTS_DIR, { recursive: true, force: true });
+	} catch {}
+});
+
+// `nats-server --ports_file_dir <dir>` writes `<exe>_<pid>.ports` once it
+// finishes binding — poll for it.
+async function readBoundUrl() {
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		try {
+			const entries = readdirSync(PORTS_DIR).filter((f) => f.endsWith(".ports"));
+			if (entries.length > 0) {
+				const ports = JSON.parse(readFileSync(join(PORTS_DIR, entries[0]), "utf8"));
+				if (Array.isArray(ports.nats) && ports.nats.length > 0) return ports.nats[0];
+			}
+		} catch {}
+		await delay(50);
+	}
+	throw new Error("nats-server never wrote a ports file");
+}
+const SERVER_URL = await readBoundUrl();
+console.log(`  (spawned nats-server at ${SERVER_URL})`);
+
 // ── Observer connection (subscribes BEFORE service registers) ──────────────
-const obs = await connect({ servers: "nats://127.0.0.1:4222" });
+const obs = await connect({ servers: SERVER_URL });
 // v0.3 heartbeat wildcard: `agents.hb.<agent>.<owner>.<name>`.
 const hbSub = obs.subscribe("agents.hb.*.*.*");
 const heartbeats = [];
@@ -81,7 +130,11 @@ const heartbeats = [];
 })();
 
 // ── Gateway connection + minimal service ───────────────────────────────────
-const gw = await connect({ servers: "nats://127.0.0.1:4222" });
+const gw = await connect({ servers: SERVER_URL });
+// Match the gateway: derive the advertised max_payload from `nc.info`.
+const maxPayloadStr = gw.info?.max_payload
+	? formatMaxPayloadString(gw.info.max_payload)
+	: DEFAULT_MAX_PAYLOAD_STR;
 const svc = await new Svcm(gw).add({
 	name: SERVICE_NAME,
 	version: SERVICE_VERSION,
@@ -103,7 +156,7 @@ svc.addEndpoint("prompt", {
 	subject: SUBJECT,
 	queue: PROMPT_QUEUE_GROUP,
 	metadata: {
-		max_payload: MAX_PAYLOAD_STR,
+		max_payload: maxPayloadStr,
 		attachments_ok: ATTACHMENTS_OK ? "true" : "false",
 	},
 	handler: (err, msg) => {
@@ -215,7 +268,10 @@ await step("$SRV.INFO.agents returns spec-shaped metadata + prompt endpoint", as
 	assert.ok(ep, "prompt endpoint missing");
 	assert.equal(ep.subject, SUBJECT);
 	assert.equal(ep.queue_group, "agents", "prompt endpoint must register queue_group=agents (spec §3.3)");
-	assert.equal(ep.metadata?.max_payload, "1MB");
+	// max_payload is server-driven (`nc.info.max_payload`), so just verify it
+	// matches the §2.1 grammar and the value we registered with.
+	assert.match(ep.metadata?.max_payload ?? "", /^\d+(B|KB|MB|GB)$/);
+	assert.equal(ep.metadata?.max_payload, maxPayloadStr);
 	assert.equal(ep.metadata?.attachments_ok, "true");
 })();
 

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -12,7 +12,7 @@ On session start the extension:
 
 1. Connects to NATS using a configured context (or `demo.nats.io` by default).
 2. Registers a NATS micro service named `agents` with spec metadata (`agent`, `owner`, `session`, `protocol_version`).
-3. Adds a `prompt` endpoint at `agents.prompt.pi.<owner>.<session>` (verb-first §2 v0.3) advertising `max_payload: 1MB` and `attachments_ok: true`.
+3. Adds a `prompt` endpoint at `agents.prompt.pi.<owner>.<session>` (verb-first §2 v0.3) advertising the server-negotiated `max_payload` (read from `nc.info.max_payload` at connect, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar — `1MB` against a default `nats-server`, more if the operator bumped `--max_payload`) and `attachments_ok: true`.
 4. Adds a `status` endpoint at `agents.status.pi.<owner>.<session>` (§8.7 (v0.3)) that replies with the same payload shape as a heartbeat.
 5. Begins publishing heartbeats on `agents.hb.pi.<owner>.<session>` (verb is the abbreviation `hb`, §8.1 v0.3) every 30 s.
 5. On each inbound prompt: decodes any attached files to `~/.pi/agent/attachments/<session>/<uuid>/<filename>`, prepends their absolute paths to the prompt text, emits a `status: ack` chunk, injects the augmented prompt into PI via `pi.sendUserMessage()`, streams `text_delta` events back as typed `{type:"response",data}` chunks, and closes with the spec-mandated empty-body no-headers terminator.
@@ -171,7 +171,7 @@ PI's model sees the list in the user message and can open the files with its fil
 Caller-side constraints (rejected at the wire with `400` if violated):
 - `content` must be strict RFC 4648 §4 base64 - standard alphabet, padded, no URL-safe, no whitespace.
 - `filename` must be a plain basename. Path separators (`/`, `\`), `..`, absolute paths, and NUL bytes are rejected rather than silently flattened.
-- Full encoded envelope must fit within `max_payload` (1 MB).
+- Full encoded envelope must fit within the advertised `max_payload` — the server-negotiated limit read at connect time. `1 MB` against a default `nats-server`; matches whatever `nc.info.max_payload` reports.
 
 Spec §5.5 reserves a future `attachments` endpoint at `agents.attachments.pi.<owner>.<session>` (v0.3 verb-first) for chunked large-file upload; that lands in a future protocol revision and will coexist with inline attachments.
 

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -64,9 +64,21 @@ const PROTOCOL_VERSION = "0.3";
 const AGENT_ID = "pi";
 
 // Spec §2.1: endpoint capability metadata advertised on the `prompt` endpoint.
-const MAX_PAYLOAD_STR = "1MB";
-const MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, matching NATS server convention
+// The actual values used at runtime come from `nc.info.max_payload` after
+// connect — that's the negotiated limit for this user/account, so it's also
+// what we advertise and enforce on inbound requests. These constants are
+// fallbacks for the (rare) case where `INFO` is unavailable.
+const DEFAULT_MAX_PAYLOAD_STR = "1MB";
+const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, matching NATS server convention
 const ATTACHMENTS_OK = true;
+
+/** Format a byte count back into the §2.1 `\d+(B|KB|MB|GB)` grammar (base-1024). */
+function formatMaxPayloadString(bytes: number): string {
+	if (bytes >= 1024 ** 3 && bytes % 1024 ** 3 === 0) return `${bytes / 1024 ** 3}GB`;
+	if (bytes >= 1024 ** 2 && bytes % 1024 ** 2 === 0) return `${bytes / 1024 ** 2}MB`;
+	if (bytes >= 1024 && bytes % 1024 === 0) return `${bytes / 1024}KB`;
+	return `${bytes}B`;
+}
 
 // Spec §8.2: default 30s cadence.
 const HEARTBEAT_INTERVAL_S = 30;
@@ -486,6 +498,10 @@ export default function (pi: ExtensionAPI) {
 	let piCtx: ExtensionContext | undefined;
 	let contextLabel: string | undefined;
 	let serverUrl: string | undefined;
+	// Filled in after connect from `nc.info?.max_payload`; falls back to the
+	// 1MB defaults if the server INFO block is unavailable.
+	let maxPayloadBytes = DEFAULT_MAX_PAYLOAD_BYTES;
+	let maxPayloadStr = DEFAULT_MAX_PAYLOAD_STR;
 
 	let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 	let ackTimer: ReturnType<typeof setInterval> | undefined;
@@ -597,8 +613,8 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		// §5.4 local enforcement.
-		if (msg.data.byteLength > MAX_PAYLOAD_BYTES) {
-			respondWithError(msg, 400, `payload exceeds max_payload (${MAX_PAYLOAD_STR})`);
+		if (msg.data.byteLength > maxPayloadBytes) {
+			respondWithError(msg, 400, `payload exceeds max_payload (${maxPayloadStr})`);
 			return;
 		}
 
@@ -872,6 +888,10 @@ export default function (pi: ExtensionAPI) {
 			const opts = contextToConnectOpts(natsCtx);
 			opts.name = `pi-${owner}`;
 			nc = await connect(opts);
+			if (nc.info?.max_payload) {
+				maxPayloadBytes = nc.info.max_payload;
+				maxPayloadStr = formatMaxPayloadString(maxPayloadBytes);
+			}
 		} catch (e) {
 			ctx.ui.notify(
 				`NATS connection failed (${serverUrl}): ${(e as Error).message}`,
@@ -919,7 +939,7 @@ export default function (pi: ExtensionAPI) {
 				queue: PROMPT_QUEUE_GROUP,
 				handler: handleNatsMessage,
 				metadata: {
-					max_payload: MAX_PAYLOAD_STR,
+					max_payload: maxPayloadStr,
 					attachments_ok: ATTACHMENTS_OK ? "true" : "false",
 				},
 			});

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -68,12 +68,12 @@ const AGENT_ID = "pi";
 // connect — that's the negotiated limit for this user/account, so it's also
 // what we advertise and enforce on inbound requests. These constants are
 // fallbacks for the (rare) case where `INFO` is unavailable.
-const DEFAULT_MAX_PAYLOAD_STR = "1MB";
-const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, matching NATS server convention
+export const DEFAULT_MAX_PAYLOAD_STR = "1MB";
+export const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024; // base-1024, matching NATS server convention
 const ATTACHMENTS_OK = true;
 
 /** Format a byte count back into the §2.1 `\d+(B|KB|MB|GB)` grammar (base-1024). */
-function formatMaxPayloadString(bytes: number): string {
+export function formatMaxPayloadString(bytes: number): string {
 	if (bytes >= 1024 ** 3 && bytes % 1024 ** 3 === 0) return `${bytes / 1024 ** 3}GB`;
 	if (bytes >= 1024 ** 2 && bytes % 1024 ** 2 === 0) return `${bytes / 1024 ** 2}MB`;
 	if (bytes >= 1024 && bytes % 1024 === 0) return `${bytes / 1024}KB`;

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -539,7 +539,7 @@ export default function (pi: ExtensionAPI) {
 	 */
 	function publishResponseText(replySubject: string, text: string): void {
 		if (!nc || text.length === 0) return;
-		const serverMax = nc.info?.max_payload ?? 1024 * 1024;
+		const serverMax = maxPayloadBytes;
 		// Reserve for the `{"type":"response","data":""}` wrapper + JSON escapes.
 		const reserve = 256;
 		const textBudget = Math.max(1, serverMax - reserve);

--- a/agents/pi/test/nats-server.conf
+++ b/agents/pi/test/nats-server.conf
@@ -1,0 +1,11 @@
+// Test config consumed by `test/smoke.mjs` when it spawns its own local
+// nats-server. `port: -1` asks the server to pick an ephemeral port — the
+// smoke harness reads it back via `--ports_file_dir`, so the test never
+// touches a developer's real server on 4222.
+//
+// `max_payload: 8MB` is deliberately non-default so the dynamic
+// `nc.info.max_payload` path (advertise on the prompt endpoint, enforce on
+// §5.4) is actually exercised — a 1MB default would silently match the
+// legacy hard-coded value.
+port: -1
+max_payload: 8MB

--- a/agents/pi/test/smoke.mjs
+++ b/agents/pi/test/smoke.mjs
@@ -207,7 +207,13 @@ await step("$SRV.INFO returns spec-shaped service info", async () => {
 	assert.equal(ep.queue_group, "agents", "prompt endpoint must register queue_group=agents (spec §3.3)");
 	// max_payload is server-driven (`nc.info.max_payload`), so just verify it
 	// matches the §2.1 `\d+(B|KB|MB|GB)` grammar.
+	// max_payload is server-driven (`nc.info.max_payload`), so verify it
+	// matches the §2.1 grammar AND the value our server is advertising.
+	const expectedMaxPayload = obs.info?.max_payload
+		? formatMaxPayloadString(obs.info.max_payload)
+		: DEFAULT_MAX_PAYLOAD_STR;
 	assert.match(ep.metadata?.max_payload ?? "", /^\d+(B|KB|MB|GB)$/);
+	assert.equal(ep.metadata?.max_payload, expectedMaxPayload);
 	assert.equal(ep.metadata?.attachments_ok, "true");
 })();
 

--- a/agents/pi/test/smoke.mjs
+++ b/agents/pi/test/smoke.mjs
@@ -110,7 +110,11 @@ process.env.NATS_CONTEXT = SMOKE_CONTEXT_NAME;
 process.env.NATS_SESSION_NAME = `smoke-${process.pid}`;
 process.env.USER = process.env.USER || "smoke";
 
-const channelFactory = (await import("../extensions/nats-channel.ts")).default;
+const {
+	default: channelFactory,
+	formatMaxPayloadString,
+	DEFAULT_MAX_PAYLOAD_STR,
+} = await import("../extensions/nats-channel.ts");
 
 let ok = 0;
 let fail = 0;
@@ -205,8 +209,6 @@ await step("$SRV.INFO returns spec-shaped service info", async () => {
 	assert.ok(ep, "prompt endpoint missing");
 	assert.equal(ep.subject, expectedSubject);
 	assert.equal(ep.queue_group, "agents", "prompt endpoint must register queue_group=agents (spec §3.3)");
-	// max_payload is server-driven (`nc.info.max_payload`), so just verify it
-	// matches the §2.1 `\d+(B|KB|MB|GB)` grammar.
 	// max_payload is server-driven (`nc.info.max_payload`), so verify it
 	// matches the §2.1 grammar AND the value our server is advertising.
 	const expectedMaxPayload = obs.info?.max_payload

--- a/agents/pi/test/smoke.mjs
+++ b/agents/pi/test/smoke.mjs
@@ -16,24 +16,101 @@
 //
 // Run with:
 //   bun test/smoke.mjs
-// Prereq: nats-server on 127.0.0.1:4222.
+// Server: this test always spawns its own private nats-server (via
+// `test/nats-server.conf`, which pins `port: -1` so the kernel picks an
+// ephemeral port and `max_payload: 8MB` so the dynamic max_payload path is
+// exercised). The chosen port is read back from `--ports_file_dir` and the
+// server is killed on exit. Prereq: `nats-server` on PATH.
 //
 // Exit code is non-zero on any failed assertion.
 
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { spawn } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { connect } from "@nats-io/transport-node";
 import { createInbox } from "@nats-io/nats-core";
 import { Svcm } from "@nats-io/services";
 
-import channelFactory from "../extensions/nats-channel.ts";
+// ── Spawn a private nats-server on an ephemeral port ──────────────────────
+// Avoids touching whatever the developer has running on 4222 — every smoke
+// run is fully isolated. We must do this BEFORE importing the channel
+// factory below: the factory reads `NATS_URL` at activation time, and we
+// want it pointing at our private server rather than at the user's
+// `localhost` context.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORTS_DIR = mkdtempSync(join(tmpdir(), "nats-pi-smoke-ports-"));
+const NATS_CONF = join(__dirname, "nats-server.conf");
+const spawnedServer = spawn(
+	"nats-server",
+	["-c", NATS_CONF, "--ports_file_dir", PORTS_DIR],
+	{ stdio: "ignore" },
+);
+spawnedServer.on("error", (err) => {
+	console.error(`could not spawn nats-server: ${err.message}`);
+	console.error("install nats-server (https://nats.io) before re-running this smoke");
+	process.exit(2);
+});
+process.on("exit", () => {
+	if (spawnedServer && !spawnedServer.killed) spawnedServer.kill();
+	try {
+		rmSync(PORTS_DIR, { recursive: true, force: true });
+	} catch {}
+});
 
-process.env.NATS_CONTEXT = "localhost";
+async function readBoundUrl() {
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		try {
+			const entries = readdirSync(PORTS_DIR).filter((f) => f.endsWith(".ports"));
+			if (entries.length > 0) {
+				const ports = JSON.parse(readFileSync(join(PORTS_DIR, entries[0]), "utf8"));
+				if (Array.isArray(ports.nats) && ports.nats.length > 0) return ports.nats[0];
+			}
+		} catch {}
+		await delay(50);
+	}
+	throw new Error("nats-server never wrote a ports file");
+}
+const SERVER_URL = await readBoundUrl();
+console.log(`  (spawned nats-server at ${SERVER_URL})`);
+
+// The harness's resolution chain is `NATS_CONTEXT > config.context >
+// NATS_URL > default`. The PI agent's persisted config (e.g. a developer's
+// `~/.pi/agent/nats-channel.json` pointing at NGS) beats `NATS_URL`, so
+// `NATS_URL` alone isn't enough to redirect the harness here. Write a
+// throwaway NATS context file with the spawned server's URL and point
+// `NATS_CONTEXT` at it — that wins unconditionally.
+const NATS_CONTEXT_DIR = join(homedir(), ".config", "nats", "context");
+mkdirSync(NATS_CONTEXT_DIR, { recursive: true });
+const SMOKE_CONTEXT_NAME = `pi-smoke-${process.pid}`;
+const SMOKE_CONTEXT_PATH = join(NATS_CONTEXT_DIR, `${SMOKE_CONTEXT_NAME}.json`);
+writeFileSync(
+	SMOKE_CONTEXT_PATH,
+	JSON.stringify({ url: SERVER_URL, description: "pi smoke ephemeral" }),
+);
+process.on("exit", () => {
+	try {
+		rmSync(SMOKE_CONTEXT_PATH, { force: true });
+	} catch {}
+});
+
+process.env.NATS_CONTEXT = SMOKE_CONTEXT_NAME;
 process.env.NATS_SESSION_NAME = `smoke-${process.pid}`;
 process.env.USER = process.env.USER || "smoke";
+
+const channelFactory = (await import("../extensions/nats-channel.ts")).default;
 
 let ok = 0;
 let fail = 0;
@@ -78,7 +155,7 @@ function emit(event, ...args) {
 }
 
 // ── Observer NATS connection (separate from the one the extension opens) ──
-const obs = await connect({ servers: "nats://127.0.0.1:4222" });
+const obs = await connect({ servers: SERVER_URL });
 
 // Subscribe to heartbeats BEFORE the extension registers — §8.5.
 // v0.3 wildcard: `agents.hb.<agent>.<owner>.<name>`.
@@ -128,7 +205,9 @@ await step("$SRV.INFO returns spec-shaped service info", async () => {
 	assert.ok(ep, "prompt endpoint missing");
 	assert.equal(ep.subject, expectedSubject);
 	assert.equal(ep.queue_group, "agents", "prompt endpoint must register queue_group=agents (spec §3.3)");
-	assert.equal(ep.metadata?.max_payload, "1MB");
+	// max_payload is server-driven (`nc.info.max_payload`), so just verify it
+	// matches the §2.1 `\d+(B|KB|MB|GB)` grammar.
+	assert.match(ep.metadata?.max_payload ?? "", /^\d+(B|KB|MB|GB)$/);
 	assert.equal(ep.metadata?.attachments_ok, "true");
 })();
 

--- a/client-sdk/README.md
+++ b/client-sdk/README.md
@@ -71,7 +71,7 @@ Same concepts in each language; names adapt to each language's idioms.
 | Track liveness   | Watch an agent's heartbeat subject for up/down state without polling.                       |
 | Ping an agent    | On-demand ping of a specific agent instance.                                                |
 
-SDKs also validate envelopes locally - oversized payloads, unsupported attachments, invalid base64 - against the target agent's advertised `max_payload` and `attachments_ok`, so you catch those errors before a round-trip.
+SDKs also validate envelopes locally - oversized payloads, unsupported attachments, invalid base64 - against the target agent's advertised `max_payload` and `attachments_ok`, so you catch those errors before a round-trip. The size check uses the smaller of the agent's advertised `max_payload` and the caller's own `nc.info.max_payload`, so a caller against a smaller-cap broker (multi-cluster / per-account configs) fails fast instead of waiting for the broker's `MAX_PAYLOAD_VIOLATION`.
 
 <details>
 <summary>Adding a new language SDK</summary>

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -10,6 +10,31 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ### Changed
 
+- Caller-side §5.4 validation now considers **both** the agent's
+  advertised `max_payload` *and* the caller's own
+  `nc.max_payload` (the broker holding the caller's connection).
+  The effective cap is the smaller of the two — in multi-cluster /
+  per-account deployments the caller's broker may reject an
+  oversized publish with `MAX_PAYLOAD_VIOLATION` before it ever
+  reaches the agent. `assert_within_max_payload(payload_size,
+  max_payload_bytes)` gains an optional third
+  `connection_max_payload` parameter (defaults to `None` =
+  not-declared); `Agent.prompt` passes `nc.max_payload` so callers
+  fail fast when their own connection is the binding constraint.
+  Mirrors the same change on the TS side.
+- `AgentService(max_payload=...)` is now clamped down to the connected
+  server's negotiated `max_payload` (`nc.max_payload`, populated from
+  the NATS server's `INFO` block) at `start()`. If the override is
+  larger than the server allows, the SDK logs a warning and advertises
+  the server's value formatted via the new `_bytes.format_human_bytes`
+  helper. Smaller overrides are still honored (use case: shed
+  expensive prompts before they reach the handler). When the server
+  didn't report a value (unconnected client / INFO without
+  `max_payload`), the override stands as configured. Mirrors the same
+  clamp added to the TS `AgentService` and `ReferenceAgent`. Rationale:
+  advertising larger than the broker accepts only sets up callers for
+  `MAX_PAYLOAD_VIOLATION` rejections at publish time, with no
+  local-validation path catching it first.
 - Reply-inbox prefix for prompt streams, mid-stream queries, and
   internal `$SRV.INFO` discovery is now fixed at `_INBOX.agents` (was
   the connection's default `_INBOX`). The prefix is held constant

--- a/client-sdk/python/README.md
+++ b/client-sdk/python/README.md
@@ -147,7 +147,7 @@ agents = Agents(nc=nc)
 
 `load_context_options(...)` reads
 `~/.config/nats/context/<name>.json` — URL, creds file, token,
-user/password, inbox prefix are all honoured. See
+user/password, inbox prefix are all honored. See
 [`CLAUDE.md`](CLAUDE.md#connecting-to-nats) for the full field-by-field
 table (including which NATS-context fields are not yet supported and
 fail fast rather than silently).

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -41,7 +41,7 @@ spec to catch up.
 | `Agent.prompt(text, attachments=[...])`      | Adds `attachments: [{filename, content: <base64>}]` per RFC 4648 §4 (standard alphabet, padded). | §5.1, §5.2 |
 | Plain-text request shorthand                 | NOT emitted by this SDK; always JSON. Decoders accept it per §5.3.                    | §5.3       |
 | Pre-publish `attachments_ok` check           | `AttachmentsNotSupportedError` before any wire I/O.                                   | §5.4       |
-| Pre-publish `max_payload` check              | `PayloadTooLargeError(limit, actual)` before any wire I/O.                            | §5.4       |
+| Pre-publish `max_payload` check              | `PayloadTooLargeError(limit, actual)` before any wire I/O. Effective limit is `min(endpoint.max_payload_bytes, nc.max_payload)` — caller's broker cap binds when smaller. | §5.4       |
 | Empty prompt rejected pre-publish            | `PromptEmptyError` before any wire I/O.                                               | §5.1, §5.3 |
 | Endpoint subject resolution                  | Always `endpoints[].subject` from discovery; never constructed from identity.         | §4.3, §12  |
 | Unknown envelope fields                      | `Envelope` uses `extra="allow"`; decode → encode round-trips lossless per §5.6. A stray inbound `session` from a non-compliant peer rides this bag — under v0.3 the request subject IS the session, so `Envelope.session` is no longer a first-class field. | §5.6 |

--- a/client-sdk/python/src/synadia_ai/agents/_bytes.py
+++ b/client-sdk/python/src/synadia_ai/agents/_bytes.py
@@ -39,6 +39,31 @@ def parse_human_bytes(value: str) -> int:
     return int(number) * multiplier
 
 
+# Largest unit first so a server-reported ``8388608`` formats back to ``"8MB"``,
+# not ``"8192KB"``.
+_FORMAT_UNITS: tuple[tuple[str, int], ...] = (
+    ("GB", 1024**3),
+    ("MB", 1024**2),
+    ("KB", 1024),
+)
+
+
+def format_human_bytes(byte_count: int) -> str:
+    """Format an integer byte count back into the §2.1 ``\\d+(B|KB|MB|GB)`` grammar.
+
+    Picks the largest unit that divides ``byte_count`` evenly so a
+    server-reported ``8 * 1024 * 1024`` round-trips cleanly to ``"8MB"``,
+    not ``"8192KB"``. Used by :class:`AgentService` to format a clamped
+    server-derived limit back into the spec's metadata grammar.
+    """
+    if byte_count < 0:
+        raise InvalidSizeError(str(byte_count), "byte count must be non-negative")
+    for unit, multiplier in _FORMAT_UNITS:
+        if byte_count >= multiplier and byte_count % multiplier == 0:
+            return f"{byte_count // multiplier}{unit}"
+    return f"{byte_count}B"
+
+
 def utf8_byte_length(text: str) -> int:
     """UTF-8 byte length of a Python string — pre-publish size check helper."""
     return len(text.encode("utf-8"))

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -241,7 +241,13 @@ class Agent:
         assert_prompt_non_empty(envelope.prompt)
         ep = self._info.prompt_endpoint
         assert_attachments_allowed(bool(envelope.attachments), ep.attachments_ok)
-        assert_within_max_payload(len(encoded), ep.max_payload_bytes)
+        # The caller's own broker may enforce a smaller `max_payload` than
+        # the agent advertises (multi-cluster / per-account configs); pass
+        # `nc.max_payload` so the validator picks the smaller of the two.
+        # Treat 0 / missing as "not declared" — the agent's value (or
+        # nothing) governs.
+        conn_limit = getattr(self._nc, "max_payload", 0) or None
+        assert_within_max_payload(len(encoded), ep.max_payload_bytes, conn_limit)
 
         effective_timeout = timeout if timeout is not None else self._default_inactivity_timeout
         return self._stream_prompt(envelope, encoded, effective_timeout)

--- a/client-sdk/python/src/synadia_ai/agents/service.py
+++ b/client-sdk/python/src/synadia_ai/agents/service.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 from nats.micro import ServiceConfig, add_service
 from nats.micro.service import EndpointConfig
 
-from ._bytes import parse_human_bytes
+from ._bytes import format_human_bytes, parse_human_bytes
 from ._inbox import new_inbox
 from ._logging import get_logger
 from .discovery import (
@@ -76,9 +76,16 @@ def _resolve_sdk_version() -> str:
 
 _SDK_VERSION = _resolve_sdk_version()
 
-# §2.1: prompt endpoint metadata defaults. Spec's own example uses 1MB;
-# attachments_ok defaults to True so envelopes with `attachments` just work
-# out of the box. Agents MAY override via `AgentService(max_payload=..., ...)`.
+# §2.1: prompt endpoint metadata defaults.
+#
+# ``DEFAULT_MAX_PAYLOAD`` is used only when ``nc.max_payload`` is missing or
+# zero (an unconnected client, or a server that did not include the field in
+# its INFO block) — the broker's negotiated value is the real cap, so when
+# it's available we always advertise that. The TS harnesses share the same
+# constant under the same name (``agents/{claude-code,openclaw,pi}``).
+#
+# ``attachments_ok`` defaults to True so envelopes with ``attachments`` just
+# work out of the box.
 DEFAULT_MAX_PAYLOAD = "1MB"
 DEFAULT_ATTACHMENTS_OK = True
 
@@ -197,6 +204,15 @@ class AgentService:
     handlers. Defaults to 30 s, matching the TS reference harnesses.
     Pass ``None`` to disable — for example when the handler emits its
     own status chunks at a finer cadence.
+
+    ``max_payload`` is honored up to the connected server's negotiated
+    limit (``nc.max_payload``). If you pass a value *larger* than the
+    server allows, :meth:`start` clamps the advertised metadata down to
+    the server's limit and logs a warning — the broker would reject
+    anything larger before it ever reached your handler, so
+    over-advertising would only break callers. Smaller overrides are
+    honored (use case: shed expensive prompts before they reach the
+    handler).
     """
 
     def __init__(
@@ -235,11 +251,48 @@ class AgentService:
         """Register the prompt handler. Must be called before :meth:`start`."""
         self._prompt_handler = handler
 
+    def _effective_max_payload(self) -> str:
+        """Return the value to advertise on the prompt endpoint.
+
+        Constructor-supplied ``max_payload`` is honored **unless it
+        exceeds** the connected server's negotiated limit
+        (``nc.max_payload``). When the override is larger, the broker
+        would reject any request that fits the override but not the
+        server cap, so we clamp down to the server value, log a warning,
+        and advertise the clamped value.
+
+        ``nc.max_payload == 0`` (or the attribute missing — older
+        ``nats-py`` builds) is treated as "no INFO available" and the
+        override stands as configured.
+        """
+        override_bytes = parse_human_bytes(self._max_payload)
+        server_bytes = getattr(self._nc, "max_payload", 0) or 0
+        if server_bytes <= 0:
+            return self._max_payload
+        if override_bytes <= server_bytes:
+            return self._max_payload
+        clamped = format_human_bytes(server_bytes)
+        log.warning(
+            "max_payload=%s (%d bytes) exceeds server limit %s (%d bytes); "
+            "clamping advertised value to %s — anything larger would be "
+            "rejected by the broker before reaching the handler",
+            self._max_payload,
+            override_bytes,
+            clamped,
+            server_bytes,
+            clamped,
+        )
+        return clamped
+
     async def start(self) -> None:
         if self._prompt_handler is None:
             raise RuntimeError("register a prompt handler via on_prompt() before start()")
         if self._service is not None:
             raise RuntimeError("agent already started")
+
+        # Resolve and clamp ``max_payload`` against the server's negotiated
+        # limit (§2.1). See ``_effective_max_payload`` for the rule.
+        max_payload_str = self._effective_max_payload()
 
         metadata: dict[str, str] = {
             "agent": self.subject.agent,
@@ -266,7 +319,7 @@ class AgentService:
                 # §2.1: endpoint metadata is a `Record<string, string>` on the
                 # wire — booleans are encoded as "true" / "false".
                 metadata={
-                    "max_payload": self._max_payload,
+                    "max_payload": max_payload_str,
                     "attachments_ok": "true" if self._attachments_ok else "false",
                 },
             )

--- a/client-sdk/python/src/synadia_ai/agents/validation.py
+++ b/client-sdk/python/src/synadia_ai/agents/validation.py
@@ -46,12 +46,30 @@ def assert_attachments_allowed(
 def assert_within_max_payload(
     payload_size: int,
     max_payload_bytes: int | None,
+    connection_max_payload: int | None = None,
 ) -> None:
-    """Fail if the encoded payload is larger than the endpoint's declared limit.
+    """Fail if the encoded payload is larger than the effective limit.
 
-    ``max_payload_bytes = None`` means the endpoint didn't declare a limit
-    (or the declared value was unparseable); in that case we don't enforce
-    locally and let the server decide (§5.4 last paragraph).
+    Two caps bind a publish:
+
+    1. ``max_payload_bytes`` — the agent's advertised limit (from its
+       ``$SRV.INFO`` metadata, §2.1). What the *agent's* broker accepts.
+    2. ``connection_max_payload`` — the *caller's* own
+       ``nc.max_payload`` (from the local NATS server's INFO block).
+       What the broker holding the caller's connection will publish at
+       all. In multi-cluster / per-account deployments this can be
+       smaller than the agent's advertised cap, in which case the
+       caller's broker rejects the publish with
+       ``MAX_PAYLOAD_VIOLATION`` before it ever reaches the agent.
+
+    The effective cap is ``min`` of whichever are set. ``None`` for
+    either means "not declared / not known" — when both are ``None`` we
+    don't enforce locally and let the server decide (§5.4 last
+    paragraph).
     """
-    if max_payload_bytes is not None and payload_size > max_payload_bytes:
-        raise PayloadTooLargeError(limit=max_payload_bytes, actual=payload_size)
+    limits = [lim for lim in (max_payload_bytes, connection_max_payload) if lim is not None]
+    if not limits:
+        return
+    effective = min(limits)
+    if payload_size > effective:
+        raise PayloadTooLargeError(limit=effective, actual=payload_size)

--- a/client-sdk/python/tests/test_bytes.py
+++ b/client-sdk/python/tests/test_bytes.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 import pytest
 
-from synadia_ai.agents._bytes import InvalidSizeError, parse_human_bytes, utf8_byte_length
+from synadia_ai.agents._bytes import (
+    InvalidSizeError,
+    format_human_bytes,
+    parse_human_bytes,
+    utf8_byte_length,
+)
 
 
 class TestParseHumanBytes:
@@ -37,6 +42,38 @@ class TestParseHumanBytes:
     def test_rejects_malformed(self, value: str) -> None:
         with pytest.raises(InvalidSizeError):
             parse_human_bytes(value)
+
+
+class TestFormatHumanBytes:
+    @pytest.mark.parametrize(
+        ("byte_count", "expected"),
+        [
+            (0, "0B"),
+            (1, "1B"),
+            (512 * 1024, "512KB"),
+            (1024 * 1024, "1MB"),
+            (8 * 1024 * 1024, "8MB"),
+            (4 * 1024 * 1024 * 1024, "4GB"),
+        ],
+    )
+    def test_happy_path(self, byte_count: int, expected: str) -> None:
+        assert format_human_bytes(byte_count) == expected
+
+    def test_picks_largest_clean_unit(self) -> None:
+        # 8MB-worth of bytes round-trips to "8MB", not "8192KB".
+        assert format_human_bytes(8 * 1024 * 1024) == "8MB"
+
+    def test_falls_back_to_bytes_when_no_clean_unit(self) -> None:
+        # 1500 bytes isn't a whole number of KB/MB/GB.
+        assert format_human_bytes(1500) == "1500B"
+
+    @pytest.mark.parametrize("byte_count", [0, 1, 512, 1024, 1024 * 1024, 8 * 1024 * 1024])
+    def test_round_trip_with_parse(self, byte_count: int) -> None:
+        assert parse_human_bytes(format_human_bytes(byte_count)) == byte_count
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(InvalidSizeError):
+            format_human_bytes(-1)
 
 
 class TestUtf8ByteLength:

--- a/client-sdk/python/tests/test_service_max_payload.py
+++ b/client-sdk/python/tests/test_service_max_payload.py
@@ -1,0 +1,69 @@
+"""Unit tests for :meth:`AgentService._effective_max_payload`.
+
+The clamp logic doesn't need a live broker — it only consults the
+constructor's ``max_payload`` and the connection's ``max_payload``
+property. Hand it a ``MagicMock`` standing in for ``nats-py``'s
+``Client`` so the test exercises the matrix in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from synadia_ai.agents.service import AgentService
+
+
+def _make_service(
+    *, max_payload: str = "1MB", server_max_payload: int | None = None
+) -> AgentService:
+    nc = MagicMock()
+    nc.max_payload = server_max_payload
+    return AgentService(
+        agent="test",
+        owner="pytest",
+        session_name="clamp",
+        nc=nc,
+        max_payload=max_payload,
+    )
+
+
+class TestEffectiveMaxPayload:
+    def test_override_smaller_than_server_is_honored(self) -> None:
+        # Operator wants a tighter cap (e.g. shed expensive prompts before
+        # they reach the handler) — that's allowed, no clamp.
+        svc = _make_service(max_payload="256KB", server_max_payload=8 * 1024 * 1024)
+        assert svc._effective_max_payload() == "256KB"
+
+    def test_override_equal_to_server_is_honored(self) -> None:
+        svc = _make_service(max_payload="1MB", server_max_payload=1024 * 1024)
+        assert svc._effective_max_payload() == "1MB"
+
+    def test_override_larger_than_server_clamps_down(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        svc = _make_service(max_payload="16MB", server_max_payload=8 * 1024 * 1024)
+        with caplog.at_level(logging.WARNING, logger="synadia_ai.agents.service"):
+            advertised = svc._effective_max_payload()
+        assert advertised == "8MB"
+        assert any("clamping advertised value to 8MB" in rec.message for rec in caplog.records)
+
+    def test_no_server_info_means_override_stands(self) -> None:
+        # `nc.max_payload == 0` (or absent) → unconnected client / INFO
+        # without `max_payload`. Nothing to clamp against; honour the
+        # override as configured.
+        svc = _make_service(max_payload="16MB", server_max_payload=0)
+        assert svc._effective_max_payload() == "16MB"
+
+    def test_server_info_unset_attribute_means_override_stands(self) -> None:
+        nc = MagicMock(spec=[])  # no `max_payload` attribute at all
+        svc = AgentService(
+            agent="test",
+            owner="pytest",
+            session_name="clamp-no-attr",
+            nc=nc,
+            max_payload="16MB",
+        )
+        assert svc._effective_max_payload() == "16MB"

--- a/client-sdk/python/tests/test_validation.py
+++ b/client-sdk/python/tests/test_validation.py
@@ -72,6 +72,33 @@ class TestWithinMaxPayload:
         """No declared capability ⇒ skip local check (agent decides)."""
         assert_within_max_payload(10**9, None)
 
+    def test_connection_limit_alone_enforced(self) -> None:
+        """Endpoint silent, connection caps at 1KB ⇒ 2KB still rejected."""
+        with pytest.raises(PayloadTooLargeError) as excinfo:
+            assert_within_max_payload(2048, None, connection_max_payload=1024)
+        assert excinfo.value.limit == 1024
+        assert excinfo.value.actual == 2048
+
+    def test_smaller_of_endpoint_and_connection_wins(self) -> None:
+        """Agent advertises 8MB but caller's broker caps at 1MB ⇒ cap is 1MB."""
+        eight_mb = 8 * 1024 * 1024
+        one_mb = 1024 * 1024
+        # Within both
+        assert_within_max_payload(512, eight_mb, connection_max_payload=one_mb)
+        # Within agent, over connection
+        with pytest.raises(PayloadTooLargeError) as excinfo:
+            assert_within_max_payload(2 * one_mb, eight_mb, connection_max_payload=one_mb)
+        assert excinfo.value.limit == one_mb
+
+    def test_endpoint_smaller_than_connection_still_caps(self) -> None:
+        """Reverse direction: endpoint is the binding cap."""
+        with pytest.raises(PayloadTooLargeError) as excinfo:
+            assert_within_max_payload(2048, 1024, connection_max_payload=8 * 1024 * 1024)
+        assert excinfo.value.limit == 1024
+
+    def test_both_none_is_permissive(self) -> None:
+        assert_within_max_payload(10**9, None, connection_max_payload=None)
+
 
 def test_all_validation_errors_share_base() -> None:
     """Callers can `except ValidationError` to catch the whole family."""

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,21 +13,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Caller-side §5.4 validation now considers **both** the agent's
+  advertised `max_payload` _and_ the caller's own
+  `nc.info.max_payload` (the broker holding the caller's
+  connection). The effective cap is the smaller of the two — in
+  multi-cluster / per-account deployments the caller's broker may
+  reject an oversized publish with `MAX_PAYLOAD_VIOLATION` before it
+  ever reaches the agent. `assertWithinMaxPayload(size, endpoint)`
+  gains an optional third `connectionMaxPayload?: number` parameter;
+  `Agent.prompt` passes `this.#nc.info?.max_payload` so callers fail
+  fast when their own connection is the binding constraint. Mirrors
+  the same change on the Python side.
+- `AgentService(maxPayload)` and `ReferenceAgent(maxPayload)` are now
+  clamped down to the connected server's negotiated limit
+  (`nc.info.max_payload`, populated from the NATS `INFO` block) at
+  `start()`. If the override is larger than the server allows, the
+  SDK `console.warn`s and advertises the server's value (formatted via
+  the new `formatHumanBytes` helper exported from `./bytes.js`).
+  Smaller overrides are still honored (use case: shed expensive
+  prompts before they reach the handler). When the server didn't
+  report a value (e.g. an INFO block without `max_payload`), the
+  override stands as configured. Mirrors the same clamp added to the
+  Python `AgentService`. Rationale: advertising larger than the
+  broker accepts only sets up callers for `MAX_PAYLOAD_VIOLATION`
+  rejections at publish time — the broker enforces the real cap, so
+  the metadata should match.
+
 ### Changed (wire-breaking)
 
 - **Wire moves to verb-first subjects (protocol v0.3).** The agent
   subject hierarchy gains a verb token directly after the root so each
   endpoint owns its own positional slot:
 
-  | endpoint  | v0.2 wire                       | v0.3 wire (this release)        |
-  | --------- | ------------------------------- | ------------------------------- |
-  | prompt    | `agents.{a}.{o}.{n}`            | `agents.prompt.{a}.{o}.{n}`     |
-  | heartbeat | `agents.{a}.{o}.{n}.heartbeat`  | `agents.hb.{a}.{o}.{n}` (verb abbreviated; heartbeats dominate per-account subject volume) |
-  | status    | —                               | `agents.status.{a}.{o}.{n}` (new) |
+  | endpoint  | v0.2 wire                      | v0.3 wire (this release)                                                                   |
+  | --------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
+  | prompt    | `agents.{a}.{o}.{n}`           | `agents.prompt.{a}.{o}.{n}`                                                                |
+  | heartbeat | `agents.{a}.{o}.{n}.heartbeat` | `agents.hb.{a}.{o}.{n}` (verb abbreviated; heartbeats dominate per-account subject volume) |
+  | status    | —                              | `agents.status.{a}.{o}.{n}` (new)                                                          |
 
   No back-compat shim — 0.x permits breaking changes per protocol §11.2,
   and silent talk-past between v0.2 and v0.3 callers is worse than a
   hard refusal at discovery time.
+
 - **`metadata.protocol_version` `"0.2"` → `"0.3"`.** Old v0.2 callers
   advertise `"0.2"` and therefore won't match a v0.3 agent's subjects;
   metadata-driven discovery filters make the mismatch a hard refusal.
@@ -55,7 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   emitting chunks (`response.send(...)`) and mid-stream queries
   (`response.ask(prompt, {timeoutMs})`).
 - **`AgentSubject`** — verb-first subject builder. `AgentSubject.new(agent,
-  owner, name)` validates the three identifying tokens and exposes
+owner, name)` validates the three identifying tokens and exposes
   `.prompt` / `.heartbeat` / `.status` getters that build the v0.3
   subjects. Single source of truth across SDK, agent harnesses, and
   examples — the verb-first wire shape lives in exactly one place.

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -2,7 +2,7 @@
 
 **TypeScript SDK for the [NATS Agent Protocol](https://github.com/synadia-ai/nats-agent-sdk-docs).** Discover, prompt, and stream from AI agents over NATS.
 
-- **Catch errors before they hit the wire.** Oversized payloads and unsupported attachments are validated locally against the agent's advertised limits.
+- **Catch errors before they hit the wire.** Oversized payloads and unsupported attachments are validated locally against the agent's advertised limits — and against the caller's own `nc.info.max_payload`, so the smaller of the two binds (a caller behind a smaller-cap broker fails fast instead of waiting for `MAX_PAYLOAD_VIOLATION`).
 - **Stream responses with `for await`.** Prompts return typed chunks (`response`, `status`, `query`) you iterate asynchronously.
 - **Runs on Node ≥ 20 and Bun ≥ 1.2.**
 

--- a/client-sdk/typescript/docs/protocol-mapping.md
+++ b/client-sdk/typescript/docs/protocol-mapping.md
@@ -18,16 +18,16 @@ Every SDK call mapped to its NATS Agent Protocol section, for implementers of ot
 
 ## Request envelope (§5)
 
-| SDK                                  | Wire behaviour                                                                       | Spec ref   |
-| ------------------------------------ | ------------------------------------------------------------------------------------ | ---------- |
-| `remote.prompt(text)`                | Publishes JSON envelope `{"prompt":"..."}` to the prompt endpoint subject.           | §5.1       |
-| `remote.prompt(text, {attachments})` | Adds `attachments: [{filename, content: <base64>}]` per RFC 4648 §4.                 | §5.1, §5.2 |
-| Plain-text shorthand                 | **Not emitted.** SDK always sends JSON (spec allows but doesn't require plain text). | §5.1       |
-| Pre-publish `attachments_ok`         | Throws `AttachmentsNotSupportedError` locally - no wire traffic.                     | §5.4       |
-| Pre-publish `max_payload`            | Throws `PayloadTooLargeError` on serialized UTF-8 byte length.                       | §5.4       |
-| Empty prompt                         | Throws `PromptEmptyError` locally.                                                   | §5.1, §5.3 |
-| Endpoint subject resolution          | Always `endpoints[].subject` from the discovery record - never constructed.          | §4.3, §12  |
-| Unknown envelope fields              | Preserved by decoders; the SDK's reference agent passes them through.                | §5.6       |
+| SDK                                  | Wire behaviour                                                                                                                                                                    | Spec ref   |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `remote.prompt(text)`                | Publishes JSON envelope `{"prompt":"..."}` to the prompt endpoint subject.                                                                                                        | §5.1       |
+| `remote.prompt(text, {attachments})` | Adds `attachments: [{filename, content: <base64>}]` per RFC 4648 §4.                                                                                                              | §5.1, §5.2 |
+| Plain-text shorthand                 | **Not emitted.** SDK always sends JSON (spec allows but doesn't require plain text).                                                                                              | §5.1       |
+| Pre-publish `attachments_ok`         | Throws `AttachmentsNotSupportedError` locally - no wire traffic.                                                                                                                  | §5.4       |
+| Pre-publish `max_payload`            | Throws `PayloadTooLargeError` on serialized UTF-8 byte length. Effective limit is `min(endpoint.maxPayloadBytes, nc.info?.max_payload)` — caller's broker cap binds when smaller. | §5.4       |
+| Empty prompt                         | Throws `PromptEmptyError` locally.                                                                                                                                                | §5.1, §5.3 |
+| Endpoint subject resolution          | Always `endpoints[].subject` from the discovery record - never constructed.                                                                                                       | §4.3, §12  |
+| Unknown envelope fields              | Preserved by decoders; the SDK's reference agent passes them through.                                                                                                             | §5.6       |
 
 ## Response streaming (§6)
 

--- a/client-sdk/typescript/src/agent.ts
+++ b/client-sdk/typescript/src/agent.ts
@@ -90,10 +90,16 @@ export class Agent {
       assertAttachmentsAllowed(true, this.promptEndpoint);
     }
 
+    // The caller's own broker may enforce a smaller `max_payload` than
+    // the agent advertises (multi-cluster / per-account configs); pass
+    // `nc.info?.max_payload` so the validator picks the smaller of the
+    // two. Treat 0 / missing as "not declared".
+    const connLimit = this.#nc.info?.max_payload;
+
     // Fast path: text-only — max_payload check is sync.
     if (!hasAttachments) {
       const envelope: RequestEnvelope = { prompt: text };
-      assertWithinMaxPayload(encodedEnvelopeSize(envelope), this.promptEndpoint);
+      assertWithinMaxPayload(encodedEnvelopeSize(envelope), this.promptEndpoint, connLimit);
       return Promise.resolve(this.#buildStream(envelope, opts));
     }
 
@@ -101,7 +107,7 @@ export class Agent {
     return (async (): Promise<PromptStream> => {
       const attachments = await normalizeAttachments(attachmentInputs);
       const envelope: RequestEnvelope = { prompt: text, attachments };
-      assertWithinMaxPayload(encodedEnvelopeSize(envelope), this.promptEndpoint);
+      assertWithinMaxPayload(encodedEnvelopeSize(envelope), this.promptEndpoint, connLimit);
       return this.#buildStream(envelope, opts);
     })();
   }

--- a/client-sdk/typescript/src/bytes.ts
+++ b/client-sdk/typescript/src/bytes.ts
@@ -49,6 +49,34 @@ export function parseHumanBytes(input: string): number {
   return bytes;
 }
 
+// Largest unit first so a server-reported `8388608` formats back to `"8MB"`,
+// not `"8192KB"`.
+const FORMAT_UNITS: ReadonlyArray<readonly [string, number]> = [
+  ["GB", 1024 ** 3],
+  ["MB", 1024 ** 2],
+  ["KB", 1024],
+];
+
+/**
+ * Format an integer byte count back into the §2.1 `\d+(B|KB|MB|GB)` grammar.
+ *
+ * Picks the largest unit that divides `bytes` evenly so a server-reported
+ * `8 * 1024 * 1024` round-trips cleanly to `"8MB"`, not `"8192KB"`. Used by
+ * {@link AgentService} (`./service.ts`) to format a clamped server-derived
+ * limit back into the spec's metadata grammar.
+ */
+export function formatHumanBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0 || !Number.isInteger(bytes)) {
+    throw new InvalidSizeError(String(bytes), "byte count must be a non-negative integer");
+  }
+  for (const [unit, multiplier] of FORMAT_UNITS) {
+    if (bytes >= multiplier && bytes % multiplier === 0) {
+      return `${bytes / multiplier}${unit}`;
+    }
+  }
+  return `${bytes}B`;
+}
+
 const TEXT_ENCODER = new TextEncoder();
 
 /** UTF-8 byte length of a JavaScript string. */

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -118,7 +118,7 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
  * - `tls://...`                      → same shapes, scheme preserved.
  *
  * Comma-separated multi-server URLs (`nats://a:4222,nats://b:4222`) are
- * split and userinfo is only honoured if it appears identically on every
+ * split and userinfo is only honored if it appears identically on every
  * server — otherwise this function throws (mixed credentials in a single
  * URL is almost certainly a bug; use a NATS context file for that case).
  *
@@ -144,14 +144,8 @@ export function parseNatsUrl(url: string): NodeConnectionOptions {
   // across servers can't be expressed in a single ConnectionOptions.
   const first = parsedAll[0]!;
   for (const p of parsedAll.slice(1)) {
-    if (
-      p.token !== first.token ||
-      p.user !== first.user ||
-      p.pass !== first.pass
-    ) {
-      throw new NatsContextError(
-        `NATS URL has mixed credentials across server entries: ${url}`,
-      );
+    if (p.token !== first.token || p.user !== first.user || p.pass !== first.pass) {
+      throw new NatsContextError(`NATS URL has mixed credentials across server entries: ${url}`);
     }
   }
 
@@ -190,9 +184,7 @@ function parseSingleNatsUrl(part: string, original: string): ParsedNatsUrl {
     );
   }
   if (!parsed.host) {
-    throw new NatsContextError(
-      `NATS URL ${JSON.stringify(original)} is missing a host`,
-    );
+    throw new NatsContextError(`NATS URL ${JSON.stringify(original)} is missing a host`);
   }
 
   const out: ParsedNatsUrl = { server: `${parsed.protocol}//${parsed.host}` };

--- a/client-sdk/typescript/src/prompt/envelope.ts
+++ b/client-sdk/typescript/src/prompt/envelope.ts
@@ -193,9 +193,7 @@ function assertSafeFilename(name: string, idx: number): void {
     throw new ProtocolError(`attachment[${idx}] has empty filename`);
   }
   if (FILENAME_FORBIDDEN_RE.test(name)) {
-    throw new ProtocolError(
-      `attachment[${idx}] has unsafe filename (path separator or NUL)`,
-    );
+    throw new ProtocolError(`attachment[${idx}] has unsafe filename (path separator or NUL)`);
   }
   if (name === "." || name === ".." || name.startsWith("../") || name.startsWith("./")) {
     throw new ProtocolError(`attachment[${idx}] has unsafe filename ('.' or '..' component)`);

--- a/client-sdk/typescript/src/prompt/validate.ts
+++ b/client-sdk/typescript/src/prompt/validate.ts
@@ -16,10 +16,43 @@ export function assertAttachmentsAllowed(
   if (endpoint.attachmentsOk === false) throw new AttachmentsNotSupportedError();
 }
 
-export function assertWithinMaxPayload(encodedByteSize: number, endpoint: EndpointInfo): void {
-  const limit = endpoint.maxPayloadBytes;
-  if (limit === undefined) return; // endpoint didn't declare a limit
-  if (encodedByteSize > limit) {
-    throw new PayloadTooLargeError(limit, encodedByteSize);
+/**
+ * Two caps bind a publish:
+ *
+ * 1. `endpoint.maxPayloadBytes` — the agent's advertised limit (from its
+ *    `$SRV.INFO` metadata, §2.1). What the *agent's* broker accepts.
+ * 2. `connectionMaxPayload` — the *caller's* own `nc.info.max_payload`
+ *    (from the local NATS server's INFO block). What the broker holding
+ *    the caller's connection will publish at all. In multi-cluster /
+ *    per-account deployments this can be smaller than the agent's
+ *    advertised cap, in which case the caller's broker rejects the
+ *    publish with `MAX_PAYLOAD_VIOLATION` before it ever reaches the
+ *    agent.
+ *
+ * The effective cap is the smaller of whichever are set. `undefined`
+ * for either means "not declared / not known" — when both are
+ * `undefined` we don't enforce locally and let the server decide
+ * (§5.4 last paragraph).
+ */
+export function assertWithinMaxPayload(
+  encodedByteSize: number,
+  endpoint: EndpointInfo,
+  connectionMaxPayload?: number,
+): void {
+  const endpointLimit = endpoint.maxPayloadBytes;
+  const connLimit =
+    connectionMaxPayload !== undefined && connectionMaxPayload > 0
+      ? connectionMaxPayload
+      : undefined;
+
+  let effective: number | undefined;
+  if (endpointLimit !== undefined && connLimit !== undefined) {
+    effective = Math.min(endpointLimit, connLimit);
+  } else {
+    effective = endpointLimit ?? connLimit;
+  }
+  if (effective === undefined) return;
+  if (encodedByteSize > effective) {
+    throw new PayloadTooLargeError(effective, encodedByteSize);
   }
 }

--- a/client-sdk/typescript/src/service.ts
+++ b/client-sdk/typescript/src/service.ts
@@ -32,6 +32,7 @@
 import type { NatsConnection } from "@nats-io/nats-core";
 import { Svcm, type Service, type ServiceMsg } from "@nats-io/services";
 
+import { formatHumanBytes, parseHumanBytes } from "./bytes.js";
 import { ProtocolError } from "./errors.js";
 import { newInbox } from "./internal/inbox.js";
 import {
@@ -41,10 +42,7 @@ import {
   STATUS_QUEUE_GROUP,
 } from "./internal/service-name.js";
 import { PROMPT_ENDPOINT_NAME } from "./discovery/endpoint-info.js";
-import {
-  buildHeartbeatPayload,
-  encodeHeartbeatPayload,
-} from "./heartbeat/payload.js";
+import { buildHeartbeatPayload, encodeHeartbeatPayload } from "./heartbeat/payload.js";
 import {
   decodeEnvelope,
   encodeBase64,
@@ -104,7 +102,14 @@ export interface AgentServiceOptions {
   readonly description?: string;
   /** Harness semver (`service.version`). Defaults to `"0.0.1"`. */
   readonly version?: string;
-  /** §2.1 `max_payload`. Defaults to `"1MB"`. */
+  /**
+   * §2.1 `max_payload`. Defaults to `"1MB"`. Advertised verbatim **unless
+   * it exceeds** the connected server's negotiated limit
+   * (`nc.info.max_payload`); in that case `start()` clamps the
+   * advertised value down to the server's limit and `console.warn`s.
+   * Over-advertising would only break callers — the broker rejects
+   * oversized publishes before any handler sees them.
+   */
   readonly maxPayload?: string;
   /** §2.1 `attachments_ok`. Defaults to `true`. */
   readonly attachmentsOk?: boolean;
@@ -179,10 +184,7 @@ export class PromptResponse {
   ): Promise<RequestEnvelope> {
     const promptText = typeof prompt === "string" ? prompt : prompt.prompt;
     const baseAttachments = typeof prompt === "string" ? undefined : prompt.attachments;
-    const merged: RequestAttachment[] = [
-      ...(baseAttachments ?? []),
-      ...(opts.attachments ?? []),
-    ];
+    const merged: RequestAttachment[] = [...(baseAttachments ?? []), ...(opts.attachments ?? [])];
 
     const replySubject = newInbox();
     const sub = this.#nc.subscribe(replySubject, { max: 1 });
@@ -247,10 +249,14 @@ export class AgentService {
   constructor(options: AgentServiceOptions) {
     const heartbeatIntervalS = options.heartbeatIntervalS ?? DEFAULT_HEARTBEAT_INTERVAL_S;
     if (heartbeatIntervalS <= 0) {
-      throw new Error("AgentService: heartbeatIntervalS must be > 0 (heartbeat is mandatory in v0.3)");
+      throw new Error(
+        "AgentService: heartbeatIntervalS must be > 0 (heartbeat is mandatory in v0.3)",
+      );
     }
     const keepaliveIntervalS =
-      options.keepaliveIntervalS === undefined ? DEFAULT_KEEPALIVE_INTERVAL_S : options.keepaliveIntervalS;
+      options.keepaliveIntervalS === undefined
+        ? DEFAULT_KEEPALIVE_INTERVAL_S
+        : options.keepaliveIntervalS;
     if (keepaliveIntervalS !== null && keepaliveIntervalS <= 0) {
       throw new Error(
         "AgentService: keepaliveIntervalS must be > 0 or null (null disables keep-alive)",
@@ -281,6 +287,30 @@ export class AgentService {
     this.#handler = handler;
   }
 
+  /**
+   * Compute the value to advertise in the prompt endpoint's `max_payload`
+   * metadata, clamping a too-large constructor override down to the
+   * server-negotiated limit. See the §2.1 commentary in {@link start}.
+   */
+  #effectiveMaxPayload(): string {
+    const override = this.#options.maxPayload ?? DEFAULT_MAX_PAYLOAD;
+    const overrideBytes = parseHumanBytes(override);
+    const serverBytes = this.#options.nc.info?.max_payload ?? 0;
+    if (serverBytes <= 0 || overrideBytes <= serverBytes) {
+      return override;
+    }
+    const clamped = formatHumanBytes(serverBytes);
+    // `console.warn` keeps the warning visible without taking an SDK-wide
+    // logger dependency; matches the Python SDK's `log.warning` level.
+    console.warn(
+      `AgentService: maxPayload=${override} (${overrideBytes} bytes) exceeds ` +
+        `server limit ${clamped} (${serverBytes} bytes); clamping advertised ` +
+        `value to ${clamped} — anything larger would be rejected by the ` +
+        `broker before reaching the handler`,
+    );
+    return clamped;
+  }
+
   async start(): Promise<void> {
     if (this.#handler === null) {
       throw new Error("AgentService.start: register a prompt handler via onPrompt() first");
@@ -308,6 +338,16 @@ export class AgentService {
       metadata,
     });
 
+    // §2.1: the broker enforces the *server-negotiated* `max_payload`
+    // (`nc.info.max_payload` from the INFO block). Advertising a larger
+    // value would set callers up for `MAX_PAYLOAD_VIOLATION` rejections
+    // at the broker without any local validation catching it first, so
+    // cap a constructor-supplied override down to the server limit.
+    // Smaller caps are honored (use case: shed expensive prompts before
+    // they reach the handler). When the server didn't report a value
+    // (e.g. an INFO block without `max_payload`), the override stands.
+    const maxPayloadStr = this.#effectiveMaxPayload();
+
     this.#service.addEndpoint(PROMPT_ENDPOINT_NAME, {
       subject: this.#subject.prompt,
       queue: PROMPT_QUEUE_GROUP,
@@ -316,7 +356,7 @@ export class AgentService {
         void this.#dispatchPrompt(msg);
       },
       metadata: {
-        max_payload: this.#options.maxPayload ?? DEFAULT_MAX_PAYLOAD,
+        max_payload: maxPayloadStr,
         attachments_ok: (this.#options.attachmentsOk ?? DEFAULT_ATTACHMENTS_OK) ? "true" : "false",
       },
     });

--- a/client-sdk/typescript/src/subjects.ts
+++ b/client-sdk/typescript/src/subjects.ts
@@ -119,9 +119,7 @@ export class AgentSubject {
 export function isHeartbeatSubject(subject: string): boolean {
   const parts = subject.split(".");
   return (
-    parts.length === SUBJECT_TOKEN_COUNT &&
-    parts[0] === SUBJECT_ROOT &&
-    parts[1] === VERB_HEARTBEAT
+    parts.length === SUBJECT_TOKEN_COUNT && parts[0] === SUBJECT_ROOT && parts[1] === VERB_HEARTBEAT
   );
 }
 

--- a/client-sdk/typescript/src/testing/reference-agent.ts
+++ b/client-sdk/typescript/src/testing/reference-agent.ts
@@ -30,10 +30,8 @@ import {
   STATUS_QUEUE_GROUP,
 } from "../internal/service-name.js";
 import { PROMPT_ENDPOINT_NAME } from "../discovery/endpoint-info.js";
-import {
-  buildHeartbeatPayload,
-  encodeHeartbeatPayload,
-} from "../heartbeat/payload.js";
+import { buildHeartbeatPayload, encodeHeartbeatPayload } from "../heartbeat/payload.js";
+import { formatHumanBytes, parseHumanBytes } from "../bytes.js";
 import { AgentSubject } from "../subjects.js";
 import { SDK_PROTOCOL_VERSION } from "../version.js";
 
@@ -126,7 +124,10 @@ export class ReferenceAgent {
     });
 
     const attachmentsOk = this.#options.attachmentsOk ?? true;
-    const maxPayload = this.#options.maxPayload ?? DEFAULT_MAX_PAYLOAD;
+    // Same clamp behaviour as `AgentService` — see `src/service.ts`. The
+    // broker enforces `nc.info.max_payload`; advertising more would break
+    // callers without any local validation catching it first.
+    const maxPayload = this.#effectiveMaxPayload();
     const promptHandler = this.#options.promptHandler ?? defaultTerminatorHandler;
 
     this.#service.addEndpoint(PROMPT_ENDPOINT_NAME, {
@@ -186,6 +187,22 @@ export class ReferenceAgent {
       await this.#service.stop();
       this.#service = null;
     }
+  }
+
+  #effectiveMaxPayload(): string {
+    const override = this.#options.maxPayload ?? DEFAULT_MAX_PAYLOAD;
+    const overrideBytes = parseHumanBytes(override);
+    const serverBytes = this.#options.nc.info?.max_payload ?? 0;
+    if (serverBytes <= 0 || overrideBytes <= serverBytes) {
+      return override;
+    }
+    const clamped = formatHumanBytes(serverBytes);
+    console.warn(
+      `ReferenceAgent: maxPayload=${override} (${overrideBytes} bytes) exceeds ` +
+        `server limit ${clamped} (${serverBytes} bytes); clamping advertised ` +
+        `value to ${clamped}`,
+    );
+    return clamped;
   }
 
   #startHeartbeats(): void {

--- a/client-sdk/typescript/test/integration/agent-service.test.ts
+++ b/client-sdk/typescript/test/integration/agent-service.test.ts
@@ -1,12 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, inject, it } from "vitest";
 import { connect as natsConnect, type Msg } from "@nats-io/transport-node";
 import type { NatsConnection } from "@nats-io/nats-core";
-import {
-  AgentService,
-  Agents,
-  decodeBase64,
-  type StreamMessage,
-} from "../../src/index.js";
+import { AgentService, Agents, decodeBase64, type StreamMessage } from "../../src/index.js";
 import { decodeHeartbeatPayload } from "../../src/heartbeat/payload.js";
 
 const natsUrl = inject("natsUrl");
@@ -155,9 +150,7 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     const envelopeBytes = new TextEncoder().encode(
       JSON.stringify({
         prompt: "x",
-        attachments: [
-          { filename: "../../etc/passwd", content: "QUJD" /* "ABC" base64 */ },
-        ],
+        attachments: [{ filename: "../../etc/passwd", content: "QUJD" /* "ABC" base64 */ }],
       }),
     );
     const reply = `_INBOX.agents.svc-test-${Math.random().toString(36).slice(2, 8)}`;
@@ -221,6 +214,51 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     expect(liveness).not.toBeNull();
     expect(liveness!.isOnline).toBe(true);
     expect(liveness!.intervalS).toBe(1);
+  });
+
+  it("clamps maxPayload down to nc.info.max_payload when over-advertised", async () => {
+    // Test broker is started with the nats-server default 1MB. A constructor
+    // override of 16MB should clamp down to "1MB" with a console.warn rather
+    // than advertising more than the broker would accept (which would only
+    // set up callers for `MAX_PAYLOAD_VIOLATION` rejections at publish).
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      const first = args[0];
+      warnings.push(typeof first === "string" ? first : "");
+    };
+    try {
+      const service = startService({ maxPayload: "16MB" });
+      service.onPrompt(async () => {});
+      await service.start();
+
+      const found = await client.discover({
+        timeoutMs: 1000,
+        filter: { agent: "svc-test", name: service.subject.name },
+      });
+      expect(found).toHaveLength(1);
+      const ep = found[0]!.endpoints.find((e) => e.name === "prompt");
+      expect(ep).toBeDefined();
+      expect(ep!.metadata["max_payload"]).toBe("1MB");
+      expect(warnings.some((w) => w.includes("clamping"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("honours a maxPayload override smaller than the server limit", async () => {
+    const service = startService({ maxPayload: "256KB" });
+    service.onPrompt(async () => {});
+    await service.start();
+
+    const found = await client.discover({
+      timeoutMs: 1000,
+      filter: { agent: "svc-test", name: service.subject.name },
+    });
+    expect(found).toHaveLength(1);
+    const ep = found[0]!.endpoints.find((e) => e.name === "prompt");
+    expect(ep).toBeDefined();
+    expect(ep!.metadata["max_payload"]).toBe("256KB");
   });
 
   it("rejects construction with invalid heartbeat / keepalive intervals", () => {

--- a/client-sdk/typescript/test/unit/agent-info.test.ts
+++ b/client-sdk/typescript/test/unit/agent-info.test.ts
@@ -77,9 +77,7 @@ describe("buildAgentInfo", () => {
     const a = buildAgentInfo(
       validInfo({
         metadata: { agent: "openclaw", owner: "rene", protocol_version: "0.3" },
-        endpoints: [
-          { name: "prompt", subject: "agents.prompt.oc.rene.default", metadata: {} },
-        ],
+        endpoints: [{ name: "prompt", subject: "agents.prompt.oc.rene.default", metadata: {} }],
       }),
     );
     expect(a).not.toBeNull();

--- a/client-sdk/typescript/test/unit/bytes.test.ts
+++ b/client-sdk/typescript/test/unit/bytes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { InvalidSizeError, parseHumanBytes, utf8ByteLength } from "../../src/bytes.js";
+import {
+  formatHumanBytes,
+  InvalidSizeError,
+  parseHumanBytes,
+  utf8ByteLength,
+} from "../../src/bytes.js";
 
 describe("parseHumanBytes", () => {
   it.each([
@@ -40,6 +45,39 @@ describe("parseHumanBytes", () => {
 
   it("rejects values that would overflow safe integer range", () => {
     expect(() => parseHumanBytes(`${Number.MAX_SAFE_INTEGER}GB`)).toThrow(InvalidSizeError);
+  });
+});
+
+describe("formatHumanBytes", () => {
+  it.each([
+    [0, "0B"],
+    [1, "1B"],
+    [512 * 1024, "512KB"],
+    [1024 * 1024, "1MB"],
+    [8 * 1024 * 1024, "8MB"],
+    [4 * 1024 * 1024 * 1024, "4GB"],
+  ])("%d → %s", (input, expected) => {
+    expect(formatHumanBytes(input)).toBe(expected);
+  });
+
+  it("picks the largest clean unit", () => {
+    // 8MB-worth of bytes formats to "8MB", not "8192KB".
+    expect(formatHumanBytes(8 * 1024 * 1024)).toBe("8MB");
+  });
+
+  it("falls back to bytes when no clean unit divides evenly", () => {
+    expect(formatHumanBytes(1500)).toBe("1500B");
+  });
+
+  it.each([0, 1, 512, 1024, 1024 * 1024, 8 * 1024 * 1024])(
+    "round-trips with parseHumanBytes: %d",
+    (n) => {
+      expect(parseHumanBytes(formatHumanBytes(n))).toBe(n);
+    },
+  );
+
+  it.each([-1, 1.5, NaN, Infinity])("rejects %s", (n) => {
+    expect(() => formatHumanBytes(n)).toThrow(InvalidSizeError);
   });
 });
 

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -180,29 +180,18 @@ describe("parseNatsUrl", () => {
 
   it("splits comma-separated multi-server URLs", () => {
     const opts = parseNatsUrl("nats://a:4222,nats://b:4222,nats://c:4222");
-    expect(opts.servers).toEqual([
-      "nats://a:4222",
-      "nats://b:4222",
-      "nats://c:4222",
-    ]);
+    expect(opts.servers).toEqual(["nats://a:4222", "nats://b:4222", "nats://c:4222"]);
     expect(opts.token).toBeUndefined();
   });
 
   it("accepts multi-server URLs when userinfo is identical on every entry", () => {
-    const opts = parseNatsUrl(
-      "nats://tok@a.example.com:4222,nats://tok@b.example.com:4222",
-    );
-    expect(opts.servers).toEqual([
-      "nats://a.example.com:4222",
-      "nats://b.example.com:4222",
-    ]);
+    const opts = parseNatsUrl("nats://tok@a.example.com:4222,nats://tok@b.example.com:4222");
+    expect(opts.servers).toEqual(["nats://a.example.com:4222", "nats://b.example.com:4222"]);
     expect(opts.token).toBe("tok");
   });
 
   it("throws when multi-server URLs have mixed credentials", () => {
-    expect(() =>
-      parseNatsUrl("nats://tok1@a:4222,nats://tok2@b:4222"),
-    ).toThrow(NatsContextError);
+    expect(() => parseNatsUrl("nats://tok1@a:4222,nats://tok2@b:4222")).toThrow(NatsContextError);
   });
 
   it("throws on empty / blank input", () => {
@@ -211,9 +200,7 @@ describe("parseNatsUrl", () => {
   });
 
   it("throws on unsupported scheme", () => {
-    expect(() => parseNatsUrl("http://nats.example.com:4222")).toThrow(
-      NatsContextError,
-    );
+    expect(() => parseNatsUrl("http://nats.example.com:4222")).toThrow(NatsContextError);
   });
 
   it("throws on hostless URL", () => {

--- a/client-sdk/typescript/test/unit/validate.test.ts
+++ b/client-sdk/typescript/test/unit/validate.test.ts
@@ -53,4 +53,45 @@ describe("assertWithinMaxPayload", () => {
     const noLimit = buildEndpointInfo({ name: "prompt", subject: "agents.ref.alice.echo" });
     expect(() => assertWithinMaxPayload(100_000_000, noLimit)).not.toThrow();
   });
+
+  describe("connection limit", () => {
+    const noLimit = buildEndpointInfo({ name: "prompt", subject: "agents.ref.alice.echo" });
+    const eightMb = buildEndpointInfo({
+      name: "prompt",
+      subject: "agents.ref.alice.echo",
+      metadata: { max_payload: "8MB" },
+    });
+    const oneMb = 1024 * 1024;
+
+    it("uses connection limit alone when endpoint silent", () => {
+      expect(() => assertWithinMaxPayload(2 * oneMb, noLimit, oneMb)).toThrow(PayloadTooLargeError);
+    });
+
+    it("picks the smaller of endpoint and connection (connection is binding)", () => {
+      // Agent advertises 8MB but caller's broker caps at 1MB.
+      expect(() => assertWithinMaxPayload(2 * oneMb, eightMb, oneMb)).toThrow(PayloadTooLargeError);
+      try {
+        assertWithinMaxPayload(2 * oneMb, eightMb, oneMb);
+      } catch (err) {
+        expect((err as PayloadTooLargeError).limit).toBe(oneMb);
+      }
+    });
+
+    it("picks the smaller of endpoint and connection (endpoint is binding)", () => {
+      // Reverse: agent advertises 1KB, caller's broker would allow 8MB.
+      expect(() => assertWithinMaxPayload(2048, endpoint, 8 * 1024 * 1024)).toThrow(
+        PayloadTooLargeError,
+      );
+      try {
+        assertWithinMaxPayload(2048, endpoint, 8 * 1024 * 1024);
+      } catch (err) {
+        expect((err as PayloadTooLargeError).limit).toBe(1024);
+      }
+    });
+
+    it("connection 0 / undefined behaves as 'not declared'", () => {
+      expect(() => assertWithinMaxPayload(100_000_000, noLimit, 0)).not.toThrow();
+      expect(() => assertWithinMaxPayload(100_000_000, noLimit, undefined)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Replace hard-coded 1MB max_payload across all agent harnesses and both SDKs with the broker-negotiated limit (nc.info.max_payload) read at connect time. Three layers, one rule: advertise what the broker will accept; never advertise more than the broker allows; never publish more than the smaller of the agent's advertised cap and the caller's own broker cap.

  Agent harnesses (TS):
    - agents/{claude-code,openclaw,pi}: read nc.info.max_payload at startup, format back to the §2.1 \d+(B|KB|MB|GB) grammar via a new formatMaxPayloadString helper, advertise that value on the prompt endpoint metadata, and use it for §5.4 inbound enforcement and response-chunk splitting. DEFAULT_MAX_PAYLOAD_{STR,BYTES} = "1MB" / 1MiB are the fallbacks used only when nc.info.max_payload is absent.
    - Naming consistent across the three harnesses (was a mix of MAX_PAYLOAD_STR_FALLBACK / MAX_PAYLOAD_STRING_FALLBACK).
    - Smoke tests now spawn their own private nats-server on an ephemeral port (port: -1 + --ports_file_dir, configured via test/nats-server.conf with max_payload: 8MB) so the dynamic path is exercised every run instead of accidentally matching 1MB. Never touches a developer's server on 4222. PI smoke writes a throwaway NATS context so the harness's NATS_CONTEXT > config > NATS_URL chain lands on the test server even when ~/.pi/agent/nats-channel.json points elsewhere.

  Server-side SDKs (AgentService):
    - Python (synadia_ai.agents.service) and TS (@synadia-ai/agents, plus the testing ReferenceAgent) now clamp a constructor-supplied max_payload override down to nc.{info.,}max_payload at start() and log a warning. Smaller overrides are honored (use case: shed expensive prompts before the handler). DEFAULT_MAX_PAYLOAD = "1MB" is the fallback when the server didn't report a value.
    - Adds {format_human_bytes,formatHumanBytes} as the inverse of the existing parsers (largest-clean-unit; "8MB" round-trips, not "8192KB").

  Caller-side SDKs (Agent.prompt):
    - assert_within_max_payload / assertWithinMaxPayload gain an optional connection_max_payload / connectionMaxPayload param. Effective cap is min(endpoint.max_payload_bytes, nc.{info?.,}max_payload) when both are known; the smaller of which is set otherwise; no check when neither is. A caller behind a smaller-cap broker (multi-cluster / per-account) now fails fast with PayloadTooLargeError instead of waiting for the broker's MAX_PAYLOAD_VIOLATION rejection.

  Tests:
    - Python: 211 passed (was 202) — bytes round-trip, AgentService clamp matrix (5 cases), validation connection-limit matrix (4 cases).
    - TS: 287 passed (was 283) — same matrices in unit tests, plus a real-broker integration test that constructs AgentService with maxPayload="16MB" against the test server's 1MB and asserts the advertised metadata is "1MB" + console.warn captured.
    - Smoke tests (openclaw, pi) verified end-to-end against an 8MB ephemeral server.

  Docs:
    - README.md, client-sdk/README.md, client-sdk/typescript/README.md, agents/README.md, agents/{claude-code,openclaw,pi,hermes}/README.md, client-sdk/{python,typescript}/docs/protocol-mapping.md updated to describe the server-derived value, the clamp behavior, and the min(endpoint, nc) caller-side rule.
    - CHANGELOG entries in both SDKs under [Unreleased].