### PR TITLE
agent-web-ui: fix heartbeat-wildcard subject for v0.3

### DIFF
--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -11,6 +11,7 @@ import {
   buildAgentInfo,
   decodeBase64,
   AttachmentsNotSupportedError,
+  HEARTBEAT_SUBJECT,
   PayloadTooLargeError,
   SERVICE_NAME,
   ServiceError,
@@ -539,17 +540,17 @@ export class Bridge {
   // ─── Auto-discovery via heartbeat wildcard ────────────────────────────────
 
   /**
-   * Subscribe to `agents.*.*.*.heartbeat` (protocol-fixed subject, §2) so new
-   * agents are picked up as soon as they publish their first heartbeat —
-   * which `ReferenceAgent` does synchronously in `start()` (see
+   * Subscribe to the protocol-fixed heartbeat wildcard so new agents are
+   * picked up as soon as they publish their first heartbeat — which
+   * `ReferenceAgent` does synchronously in `start()` (see
    * `reference-agent.ts:173`), yielding sub-second latency for fresh
    * instances. Unknown instance_ids trigger a direct `$SRV.INFO.agents.<id>`
-   * lookup (§4.2) so we add them to the map with full metadata.
+   * lookup so we add them to the map with full metadata.
    */
   private startHeartbeatWatch(): void {
     if (this.heartbeatWildcardSub) return;
     try {
-      this.heartbeatWildcardSub = this.nc.subscribe("agents.*.*.*.heartbeat", {
+      this.heartbeatWildcardSub = this.nc.subscribe(HEARTBEAT_SUBJECT, {
         callback: (err, msg) => {
           if (err || this.closed) return;
           let parsed: unknown;


### PR DESCRIPTION
## Summary

- `bridge.startHeartbeatWatch()` was subscribing to the v0.2 trailing-form heartbeat wildcard (`agents.*.*.*.heartbeat`); under v0.3 the subject is `agents.hb.*.*.*`, so the wildcard matched zero traffic.
- The bug was masked: per-instance subscriptions go through `Agents.onHeartbeat(id, ...)` (uses the SDK's correct v0.3 subject), and `Agents.discover()` populates the bridge map on its own cadence — so already-known agents kept showing heartbeats. The dead path was the fast lane: brand-new agents arriving between discovery cycles wouldn't be auto-picked-up via their first heartbeat.
- Swap the literal for the SDK's `HEARTBEAT_SUBJECT` constant so the subject can never drift again.

This is the first PR of a broader sweep to remove duplication between the TS SDK and the agents/examples (per the recently-flipped CLAUDE.md rule that agents *should* reuse the SDK).

## Test plan

- [x] `bun run typecheck` in `examples/agent-web-ui/` passes
- [ ] Manual: run the web-ui server, start a fresh `ReferenceAgent` (or pi-headless / openclaw / claude-code) **after** the UI is connected, and verify the new instance appears in the UI within ~1s of its first heartbeat (i.e. before the next discovery cycle)
- [ ] Manual: existing connected agents continue to show heartbeat ticks (regression check on the per-instance path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)