### PR TITLE
client-sdk/python: default missing port in URL helpers (nats-py list-path bug)

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -10,6 +10,23 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ### Changed
 
+- `load_context_options(...)` and `parse_nats_url(...)` now default a
+  missing port to `4222` for `nats://` / `tls://` server entries
+  (`ws://` / `wss://` left alone, mirroring nats-py's own carve-out at
+  `nats/aio/client.py:1359`). Works around an asymmetric nats-py
+  URL-parsing bug: in `nats/aio/client.py::_setup_server_pool`, the
+  single-string path applies port defaulting via `_parse_server_uri`,
+  but the list path (`servers=[...]` — what both helpers feed)
+  `urlparse`s each entry and leaves `Srv(uri).uri.port` as `None`, so
+  the asyncio TCP connect lands on port 0 and the kernel rejects with
+  `EADDRNOTAVAIL` (see `nats/aio/client.py:1373-1376`). The `nats` CLI
+  papers over the missing port internally, so context files written by
+  `nats context add` routinely carry entries like
+  `tls://connect.ngs.global` (no port); previously these silently
+  failed at connect time with a confusing kernel error. Python-only
+  fix; the TypeScript SDK uses a different transport and is not
+  affected. Filing the upstream bug against nats-py is out of scope
+  here — TODO follow-up.
 - Reply-inbox prefix for prompt streams, mid-stream queries, and
   internal `$SRV.INFO` discovery is now fixed at `_INBOX.agents` (was
   the connection's default `_INBOX`). The prefix is held constant

--- a/client-sdk/python/src/synadia_ai/agents/context.py
+++ b/client-sdk/python/src/synadia_ai/agents/context.py
@@ -42,6 +42,20 @@ with an actionable message: ``nkey``, TLS triple (``cert`` / ``key`` /
 Ignored (present in JSON but irrelevant to the SDK): ``jetstream_*``,
 ``socks_proxy``, ``color_scheme``, ``windows_*``, ``user_seed`` (only
 meaningful with ``nkey``), ``tls_first``.
+
+Both helpers normalise each server URL by defaulting a missing port to
+``4222`` for ``nats://`` / ``tls://`` schemes (``ws://`` / ``wss://``
+left alone, mirroring ``nats-py``'s own carve-out). This works around
+an asymmetric ``nats-py`` URL-parsing bug: in
+``nats/aio/client.py::_setup_server_pool``, the single-string path
+defaults missing ports via ``_parse_server_uri``, but the list path
+(``servers=[...]``) just calls ``urlparse`` per entry and leaves
+``Srv(uri).uri.port`` as ``None``, so the asyncio TCP connect lands on
+port 0 and the kernel rejects with ``EADDRNOTAVAIL``. The ``nats``
+CLI papers over the missing port internally, so context files written
+by ``nats context add`` routinely contain entries like
+``tls://connect.ngs.global``; without this defaulting, those would
+silently fail at connect time with a confusing kernel error.
 """
 
 from __future__ import annotations
@@ -226,7 +240,37 @@ def _resolve_current_context_name() -> str:
 
 def _split_urls(url: str) -> list[str]:
     """Split a context's ``url`` field into individual server URLs."""
-    return [part.strip() for part in url.split(",") if part.strip()]
+    return [_ensure_default_port(part.strip()) for part in url.split(",") if part.strip()]
+
+
+def _ensure_default_port(server: str) -> str:
+    """Append ``:4222`` to a server URL that's missing a port (nats/tls only).
+
+    Works around the ``nats-py`` list-path bug documented in the module
+    docstring. Returns the input unchanged when:
+
+    * the URL already declares a port,
+    * the scheme is ``ws://`` / ``wss://`` (matches nats-py's carve-out
+      at ``client.py:1359`` — WebSocket transports use HTTP-style scheme
+      defaults that nats-py does not enforce), or
+    * the scheme is unknown (let validation surface elsewhere).
+
+    Userinfo and IPv6 brackets are preserved by appending the suffix to
+    the original string rather than reconstructing from ``urlparse``
+    parts.
+    """
+    if not server:
+        return server
+    with_scheme = server if "://" in server else f"nats://{server}"
+    try:
+        parsed = urlparse(with_scheme)
+    except ValueError:
+        return server
+    if parsed.port is not None:
+        return server
+    if parsed.scheme not in ("nats", "tls"):
+        return server
+    return f"{server}:{_DEFAULT_NATS_PORT}"
 
 
 def _expand_user(path: str) -> str:
@@ -244,6 +288,8 @@ def _expand_user(path: str) -> str:
 
 
 _SUPPORTED_URL_SCHEMES = ("nats", "tls", "ws", "wss")
+
+_DEFAULT_NATS_PORT = 4222
 
 
 def parse_nats_url(url: str) -> dict[str, Any]:
@@ -326,7 +372,12 @@ def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
     # need them back to disambiguate `host:port`.
     host = parsed.hostname
     host_token = f"[{host}]" if ":" in host else host
-    netloc = f"{host_token}:{parsed.port}" if parsed.port is not None else host_token
+    if parsed.port is not None:
+        netloc = f"{host_token}:{parsed.port}"
+    elif parsed.scheme in ("nats", "tls"):
+        netloc = f"{host_token}:{_DEFAULT_NATS_PORT}"
+    else:
+        netloc = host_token
     server = f"{parsed.scheme}://{netloc}"
 
     out: dict[str, Any] = {"server": server}

--- a/client-sdk/python/tests/test_context_load.py
+++ b/client-sdk/python/tests/test_context_load.py
@@ -122,6 +122,53 @@ def test_split_urls_comma_separated(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert opts["servers"] == ["nats://a:4222", "nats://b:4222", "nats://c:4222"]
 
 
+def test_split_urls_defaults_port_for_bare_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _point_env_at(tmp_path, monkeypatch)
+    _write_context(base, "bare", {"url": "nats://nats.example.com"})
+    opts = load_context_options("bare")
+    assert opts["servers"] == ["nats://nats.example.com:4222"]
+
+
+def test_split_urls_defaults_port_for_ngs_style_tls_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: `nats context add` writes `tls://connect.ngs.global` (no port).
+
+    Without port-defaulting, nats-py's list path leaves ``Srv.uri.port``
+    as ``None`` and the asyncio TCP connect lands on port 0 →
+    ``EADDRNOTAVAIL``.
+    """
+    base = _point_env_at(tmp_path, monkeypatch)
+    _write_context(base, "ngs", {"url": "tls://connect.ngs.global"})
+    opts = load_context_options("ngs")
+    assert opts["servers"] == ["tls://connect.ngs.global:4222"]
+
+
+def test_split_urls_mixed_port_and_bare(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit ports survive untouched; bare hosts get :4222 appended."""
+    base = _point_env_at(tmp_path, monkeypatch)
+    _write_context(base, "mixed", {"url": "nats://a:5222,nats://b,tls://c,tls://d:7777"})
+    opts = load_context_options("mixed")
+    assert opts["servers"] == [
+        "nats://a:5222",
+        "nats://b:4222",
+        "tls://c:4222",
+        "tls://d:7777",
+    ]
+
+
+def test_split_urls_passes_ws_and_wss_through_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ws://`` / ``wss://`` mirror nats-py's carve-out at client.py:1359."""
+    base = _point_env_at(tmp_path, monkeypatch)
+    _write_context(base, "ws", {"url": "ws://host,wss://host"})
+    opts = load_context_options("ws")
+    assert opts["servers"] == ["ws://host", "wss://host"]
+
+
 def test_field_mapping_full_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``creds`` supersedes user/pass/token; inbox_prefix survives."""
     base = _point_env_at(tmp_path, monkeypatch)
@@ -404,3 +451,34 @@ def test_parse_url_ws_and_wss_schemes() -> None:
     # bare ws/wss without userinfo
     ws_bare = parse_nats_url("ws://host:9222")
     assert ws_bare == {"servers": ["ws://host:9222"]}
+
+
+def test_parse_url_defaults_port_for_bare_nats_host() -> None:
+    opts = parse_nats_url("nats://host")
+    assert opts == {"servers": ["nats://host:4222"]}
+
+
+def test_parse_url_defaults_port_for_bare_tls_host_with_token() -> None:
+    """Port defaulted, userinfo stripped onto kwargs, scheme preserved."""
+    opts = parse_nats_url("tls://tok@host")
+    assert opts == {"servers": ["tls://host:4222"], "token": "tok"}
+
+
+def test_parse_url_defaults_port_for_bare_ipv6_host() -> None:
+    """IPv6 brackets are preserved alongside the default port."""
+    opts = parse_nats_url("nats://[::1]")
+    assert opts == {"servers": ["nats://[::1]:4222"]}
+
+
+def test_parse_url_defaults_port_and_scheme_for_bare_host() -> None:
+    """Schemeless + portless: both defaults applied."""
+    opts = parse_nats_url("host")
+    assert opts == {"servers": ["nats://host:4222"]}
+
+
+def test_parse_url_does_not_default_port_for_ws_scheme() -> None:
+    """``ws://`` / ``wss://`` carve-out applies to parse_nats_url too."""
+    opts = parse_nats_url("ws://host")
+    assert opts == {"servers": ["ws://host"]}
+    opts_wss = parse_nats_url("wss://host")
+    assert opts_wss == {"servers": ["wss://host"]}


### PR DESCRIPTION
## Summary

- Fixes a silent connect-time failure when a `nats` CLI context (or any caller) supplies a port-less server URL like `tls://connect.ngs.global`. The `nats` Go CLI papers over the missing port internally, so context files written by `nats context add` routinely omit it; the Python SDK then handed the unmodified list to `nats.connect(servers=[...])` and the asyncio TCP connect landed on port 0, raising `EADDRNOTAVAIL`.
- Root cause is asymmetric URL parsing inside nats-py: `nats/aio/client.py::_setup_server_pool` defaults missing ports on the single-string path via `_parse_server_uri`, but the list path (lines 1373–1376) just calls `urlparse` and leaves `Srv(uri).uri.port` as `None`. Both `load_context_options()` and `parse_nats_url()` feed nats-py through the list path, so every SDK caller was exposed.
- Fix at our boundary: a new internal `_ensure_default_port()` helper normalises each server entry, appending `:4222` to `nats://` / `tls://` URLs that lack a port. `ws://` / `wss://` pass through unchanged, mirroring nats-py's own carve-out at `client.py:1359`. Userinfo and IPv6 brackets are preserved by appending to the original string rather than reconstructing from `urlparse` parts.
- Python-only — the TypeScript SDK uses a different transport and isn't affected. Filing the upstream nats-py bug is deliberately out of scope (TODO noted in the CHANGELOG entry).

## Test plan

- [x] `uv run ruff check --no-cache .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy --no-incremental src tests examples`
- [x] `uv run pytest` — 196 passed, 1 pre-existing TS-interop skip
- [x] 9 new unit tests in `tests/test_context_load.py` covering: ngs-style `tls://` regression, mixed comma list, `ws://` / `wss://` carve-out, IPv6, schemeless, bare-host
- [x] REPL smoke against the original reproducer (`tls://connect.ngs.global` context) returns `tls://connect.ngs.global:4222`

🤖 Generated with [Claude Code](https://claude.com/claude-code)