### PR TITLE
ci: stop nats-server extraction polluting client-sdk/python dir

### DIFF
--- a/.github/workflows/client-sdk-python.yml
+++ b/.github/workflows/client-sdk-python.yml
@@ -34,7 +34,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install nats-server
-        # This step has no working-directory because it only touches /usr/local/bin.
+        # Override the default working-directory so the tarball extracts into
+        # the runner's auto-cleaned temp area instead of leaving the unpacked
+        # `nats-server-v*-linux-amd64/` parent directory in `client-sdk/python/`
+        # after the binary is `mv`'d out. (The default at job level is
+        # `client-sdk/python`; without this override, every CI run dropped a
+        # stray dir there.)
+        working-directory: ${{ runner.temp }}
         run: |
           curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER_VERSION}/nats-server-v${NATS_SERVER_VERSION}-linux-amd64.tar.gz" | tar xz
           sudo mv "nats-server-v${NATS_SERVER_VERSION}-linux-amd64/nats-server" /usr/local/bin/

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -34,6 +34,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install nats-server
+        # Extract into the runner's auto-cleaned temp area so we don't leave the
+        # unpacked `nats-server-v*-linux-amd64/` parent directory in
+        # `client-sdk/python/` after the binary is `mv`'d out (the default
+        # working-directory at job level is `client-sdk/python`).
+        working-directory: ${{ runner.temp }}
         run: |
           curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER_VERSION}/nats-server-v${NATS_SERVER_VERSION}-linux-amd64.tar.gz" | tar xz
           sudo mv "nats-server-v${NATS_SERVER_VERSION}-linux-amd64/nats-server" /usr/local/bin/


### PR DESCRIPTION
## Summary

- Mirrors the identical `working-directory: \${{ runner.temp }}` fix applied to the agent-sdk workflows in PR #45 (commit f15755f) onto the two pre-existing client-sdk Python workflows: `client-sdk-python.yml` (CI) and `release-python.yml` (PyPI release).
- Both workflows' `Install nats-server` steps inherited `defaults.run.working-directory: client-sdk/python`, so every CI run extracted the tarball into the package tree and the `mv` to `/usr/local/bin/` left an empty `nats-server-v*-linux-amd64/` parent dir behind. Extraction now lands in the runner's auto-cleaned temp area instead.
- The inaccurate "This step has no working-directory…" comment on the CI step is rewritten — the default did apply.

## Why a separate PR

The Claude reviewer bot flagged this on PR #45 as a minor observation against the new agent-sdk workflows. We fixed those there and called the pre-existing duplicates out-of-scope rather than drive-by them. This is the follow-up sweep.

## Side-effect check

- `\${{ runner.temp }}` is provided by the runner before any step, exists on all OSes, and is emptied at job start/end.
- `sudo mv \"nats-server-v.../nats-server\" /usr/local/bin/` keeps a relative source path; with the step's `working-directory` set to `runner.temp`, that resolves against the override and still works.
- Subsequent steps don't override `working-directory`, so they continue to use the `client-sdk/python` default — no spillover.
- No CHANGELOG entry: this is CI/release plumbing, not a public-surface or wire change.

## Test plan

- [ ] CI workflow `client-sdk-python.yml` runs green on this PR (paths-filter triggers it on the workflow change).
- [ ] No `nats-server-v*-linux-amd64/` directory appears in `client-sdk/python/` after a CI run (inspectable in a workspace dump or by re-checking the unchanged-tree assertion in `bash` if anyone wires one up).
- [ ] `release-python.yml` is tag-triggered, so it can't be exercised on this PR — the change is a textual mirror of `client-sdk-python.yml`'s and `release-python-agent-service.yml`'s already-merged form, both of which have the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)