### PR TITLE
examples/agent-web-ui: mark `private: true` — github-only test client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ compatibility between the two SDKs.
 | `agents/claude-code/` | `claude-channel-nats` | npm (restricted) | Claude Code MCP plugin |
 | `agents/hermes/` | — | not in repo | README only; ships from upstream Hermes |
 | `examples/pi-headless/` | `@synadia-ai/nats-pi-headless` | npm (restricted) | depends on `@synadia-ai/agents@^0.1.x` |
-| `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | npm (restricted) | depends on `@synadia-ai/agents@^0.1.x` |
+| `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | github only | local-clone test client; `private: true` so it never publishes |
 | `examples/dspy/` | `@synadia-ai/nats-dspy-agent` | private | uses `file:` link to local SDK |
 
 **No root `package.json`, no workspace manager.** Each subtree manages
@@ -164,8 +164,8 @@ description.
 
 ## Release ladder for SDK changes that examples need
 
-The trap: examples (`pi-headless`, `agent-web-ui`) pin
-`@synadia-ai/agents@^0.1.x` from npm, not via `file:` links. A new SDK
+The trap: published examples (`pi-headless`, `claude-code-headless`) pin
+`@synadia-ai/agents@^0.4.x` from npm, not via `file:` links. A new SDK
 export does not exist for them until it is **published**. Don't try to
 land an example migration alongside an unpublished SDK change — typecheck
 will fail in CI, and you'll waste a force-push fixing it.

--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -21,9 +21,7 @@
   "bugs": {
     "url": "https://github.com/synadia-ai/synadia-agents/issues"
   },
-  "publishConfig": {
-    "access": "restricted"
-  },
+  "private": true,
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

`agent-web-ui` is a Bun + Vue 3 test client for poking at NATS Agent Protocol
agents. Its server is built on `Bun.serve` / `Bun.file` / `import.meta.dir` —
porting to Node would mean rewriting the whole HTTP + WebSocket layer on top
of `node:http` + the `ws` package. Real engineering for a tool whose audience
already has the repo cloned.

Aligns with the convention `examples/dspy/` already uses: `private: true`,
clone-and-run, never published. The existing README's Setup / Run sections
already document the local-clone path, so no content rewrite is needed.

## Changes

- `examples/agent-web-ui/package.json` — adds `"private": true`, drops the
  now-redundant `publishConfig.access` block (npm refuses to publish a
  private package regardless of access).
- `CLAUDE.md` package table — flips the agent-web-ui row from
  `npm (restricted)` to `github only` with a `private: true` note. Also
  refreshes the stale `pi-headless, agent-web-ui pin ^0.1.x` line in the
  release-ladder section to `pi-headless, claude-code-headless pin ^0.4.x`,
  reflecting the post-0.4.x npm-publish state.

## Test plan

- [x] `jq '{private, publishConfig}' examples/agent-web-ui/package.json` →
  `{ private: true, publishConfig: null }`.
- [x] No code changes; `bun run dev` / `bun run build` / `bun run start` all
  unchanged.
- [ ] Optional: confirm `npm publish --dry-run` from `examples/agent-web-ui/`
  refuses with "this package is marked private" (post-merge sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)