### PR TITLE
docs: agents/README.md — drop misleading "1 MB / system-defined"

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -10,10 +10,10 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 
 | Path                | Type token | Underlying harness                          | Prompt subject (v0.3 verb-first)                              | `max_payload` | `attachments_ok` |
 | ------------------- | ---------- | ------------------------------------------- | ------------------------------------------------------------- | ------------- | ---------------- |
-| `pi/`               | `pi`       | [PI Agent](https://github.com/badlogic/pi-mono) | `agents.prompt.pi.<owner>.<session>`                      | 1 MB / system-defined | true |
-| `openclaw/`         | `oc`       | [OpenClaw](https://openclaw.ai)             | `agents.prompt.oc.<owner>.<agentName>`                        | 1 MB / system-defined | true |
-| `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | 1 MB / system-defined | true |
-| `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | 1 MB / system-defined (config can request a smaller cap) | true |
+| `pi/`               | `pi`       | [PI Agent](https://github.com/badlogic/pi-mono) | `agents.prompt.pi.<owner>.<session>`                      | server-negotiated | true |
+| `openclaw/`         | `oc`       | [OpenClaw](https://openclaw.ai)             | `agents.prompt.oc.<owner>.<agentName>`                        | server-negotiated | true |
+| `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | server-negotiated | true |
+| `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 
 `max_payload` is read from the NATS connection's `INFO` block at startup and advertised verbatim, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and the agents track it.
 


### PR DESCRIPTION
## Summary

- The harness plugins table in `agents/README.md` listed `max_payload` as "1 MB / system-defined" for every agent. That's been inaccurate since #41 (`max_payload: derive from nc.info, clamp on advertise, cap on publish`) — the harnesses read `nc.info.max_payload` from the broker at connect time and advertise it verbatim. 1 MB is just what a default `nats-server` reports; against `--max_payload 8MB` the table cells would all advertise `8MB`.
- Replaced each row's cell with `server-negotiated`. The explanatory paragraph below the table (read from `INFO` at startup, §2.1 grammar, tracks `--max_payload`) already had the detail; the table just needed to stop asserting a fixed number.
- Per-agent READMEs (`agents/{pi,openclaw,claude-code,hermes}/README.md`) already describe the server-negotiated mechanism correctly and are unchanged.

Flagged by Mario. Doc-only — no code touched.

## Sweep notes (what was checked but left alone)

- All other `.md` files mentioning `1MB` either correctly frame it as "default `nats-server`" or use it as a unit-conversion / grammar example. No other doc inaccuracies found.
- Examples that pass `maxPayload: "1MB"` to `AgentService` / `ReferenceAgent` (`examples/dspy`, `examples/{pi,claude-code}-headless`, `client-sdk/typescript/examples/_run-reference-agent.ts`) match the SDK's documented `DEFAULT_MAX_PAYLOAD = "1MB"` fallback. Not a doc inaccuracy — if we want examples to demonstrate server-derivation (read `nc.info.max_payload` and format it like the agent harnesses do), that's a separate behavior change.
- `agents/openclaw/src/channel.ts:241` `textChunkLimit: 1024 * 1024` is OpenClaw chat-UI chunking, unrelated to NATS payload.
- `agents/claude-code/scripts/roundtrip-test.ts:19` `MAX_PAYLOAD = 1024 * 1024` is a test fixture pinning the value to exercise chunking logic.

## Test plan

- [ ] `agents/README.md` table renders cleanly on GitHub
- [ ] Explanatory paragraph below the table still flows from the new cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)