### PR TITLE
docs(agent-sdk): correct extraction lineage in [0.1.0] (was 0.5.0, should be pre-0.5.0)

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -8,19 +8,24 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [0.1.0] - 2026-04-30
 
-Initial release. **Extracted from `synadia-ai-agents@0.5.0`** so the
-agent-host surface ships as a focused dependency for harness authors
-while callers can install just the client SDK.
+Initial release. **Carved out of `synadia-ai-agents` at the 0.5.0
+cut**: through 0.4.x the agent-host surface lived inside
+`synadia-ai-agents`; the 0.5.0 release removed it there and shipped
+it here as 0.1.0. Both packages were cut together —
+`synadia-ai-agents@0.5.0` is the first PyPI version that no longer
+carries this surface. Harness authors get a focused dependency;
+callers install just the client SDK.
 
 ### Added
 
 - `synadia_ai.agent_service.AgentService` — service registration,
   prompt endpoint, status endpoint, heartbeat publisher loop, and
   mid-stream `ask` per the §12 implementation checklist. Sourced
-  from `synadia-ai-agents@0.5.0`'s `service.py` (which carries the
-  full lineage including the post-0.3.0 server-`max_payload` clamp
-  and the v0.3 verb-first wire); rewired to import shared wire
-  types (`Envelope`, `HeartbeatPayload`, `AgentSubject`, error
+  from `synadia-ai-agents`'s pre-0.5.0 `service.py` (the file moved
+  here at the split — `synadia-ai-agents@0.5.0` no longer carries
+  it; the lineage includes the post-0.3.0 server-`max_payload`
+  clamp and the v0.3 verb-first wire); rewired to import shared
+  wire types (`Envelope`, `HeartbeatPayload`, `AgentSubject`, error
   classes, discovery constants) from `synadia_ai.agents`.
 - `synadia_ai.agent_service.PromptStream` — emit response chunks /
   ask mid-stream queries / observe terminator semantics.

--- a/agent-sdk/python/CLAUDE.md
+++ b/agent-sdk/python/CLAUDE.md
@@ -3,8 +3,10 @@
 This file provides guidance to Claude Code (claude.ai/code) when working
 with code in this repository.
 
-> **Status (2026-04-30).** Extracted from
-> `synadia-ai-agents@0.5.0`; this package now hosts `AgentService`,
+> **Status (2026-04-30).** Carved out of `synadia-ai-agents` at
+> the 0.5.0 cut (the surface previously lived in `synadia-ai-agents`
+> through 0.4.x; `synadia-ai-agents@0.5.0` is the first PyPI version
+> that no longer carries it). This package now hosts `AgentService`,
 > the heartbeat publisher, the status handler, and the reference
 > agent. Shared wire primitives (`Envelope`, `HeartbeatPayload`,
 > `AgentSubject`, error classes, discovery constants,
@@ -451,8 +453,11 @@ them to success or frustrates them.
 
 ## Alignment milestones
 
-- **2026-04-30 — package extracted from `synadia-ai-agents@0.5.0`.**
-  `service.py`, the publisher half of `heartbeat.py`, the status
+- **2026-04-30 — package carved out of `synadia-ai-agents` at the
+  0.5.0 cut.** The surface (`AgentService` and friends) lived in
+  `synadia-ai-agents` through 0.4.x; at 0.5.0 it was removed there
+  and shipped here as 0.1.0. `service.py`, the publisher half of
+  `heartbeat.py`, the status
   handler, `examples/_reference_agent.py`, and the agent-side e2e
   tests all moved here under `synadia_ai.agent_service`; imports
   were rewired to pull shared primitives from `synadia_ai.agents`


### PR DESCRIPTION
## Summary

Two refs in `agent-sdk/python/CHANGELOG.md`'s `[0.1.0]` entry framed
the agent-host surface as "extracted from `synadia-ai-agents@0.5.0`."
That gets the relationship backward — `0.5.0` is the version that
**removed** the surface from `synadia-ai-agents`, not the version
that contained it. The surface lived in `synadia-ai-agents` through
`0.4.x`; both packages were cut together at the 0.5.0 / 0.1.0 split.

Worse, the `AgentService` bullet originally said *"Sourced from
`synadia-ai-agents@0.5.0`'s `service.py`"* — `synadia-ai-agents@0.5.0`
doesn't have a `service.py` at that path. The file moved here. So
the original text was literally false on a path you can grep.

This PR catches that wording before it ships inside the
`synadia-ai-agent-service@0.1.0` wheel — re-tagging after publish
would mean a `0.1.1` cut just to fix CHANGELOG framing.

### Changes

- `[0.1.0]` preamble now reads "Carved out of `synadia-ai-agents`
  at the 0.5.0 cut" and clarifies the 0.4.x / 0.5.0 split.
- `AgentService` bullet now reads "Sourced from `synadia-ai-agents`'s
  pre-0.5.0 `service.py` (the file moved here at the split)."

No code change. Doc-only.

## Test plan

- [ ] Reviewer-bot pass on the doc diff.
- [ ] After merge: tag `python-agent-service-v0.1.0` with the
      already-corrected tag-annotation message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)