### PR TITLE
docs(release): note the pypi env tag-policy gotcha + list both Python releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,12 @@ gh api -X POST repos/synadia-ai/synadia-agents/environments/pypi/deployment-bran
   -f name='new-prefix-v*' -f type=tag
 ```
 
-(Repo Admin required —
+(Repo Admin required. Sanity check:
 `gh api repos/synadia-ai/synadia-agents --jq '.permissions.admin'`
-should return `true`.)
+should print exactly `true`. Anything else means no admin in the
+current auth context — `false` is a real "you don't have it,"
+while `null` typically means a fine-grained PAT or GitHub App
+token that doesn't surface the permissions sub-object at all.)
 
 ## CI and the Claude reviewer bot
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,11 +187,30 @@ Sequence:
    verify `bun run typecheck` in each example.
 5. Merge the example-migration PR.
 
-The same shape applies to the Python SDK, except releases are
-tag-driven (`python-v*` tag in `.github/workflows/release-python.yml`)
-and publish to PyPI via `pypa/gh-action-pypi-publish` with PyPI
-trusted publishing — no long-lived API token; the workflow runs in
-the `pypi` GitHub Environment, which is gated to `python-v*` tags.
+The same shape applies to each Python SDK. Releases are tag-driven
+and publish to PyPI via `pypa/gh-action-pypi-publish` (trusted
+publishing — no long-lived API token):
+
+- `python-v*` → `synadia-ai-agents` via `release-python.yml`
+- `python-agent-service-v*` → `synadia-ai-agent-service` via
+  `release-python-agent-service.yml`
+
+Both workflows run in the `pypi` GitHub Environment, whose
+tag-deployment policy gates them to those two prefixes. **Gotcha
+when adding a new tag-triggered release workflow:** the `pypi` env
+policy must be extended to cover the new tag prefix, or the
+publish job fails with *"Tag X is not allowed to deploy to pypi
+due to environment protection rules"* before OIDC ever runs. Add
+it via:
+
+```sh
+gh api -X POST repos/synadia-ai/synadia-agents/environments/pypi/deployment-branch-policies \
+  -f name='new-prefix-v*' -f type=tag
+```
+
+(Repo Admin required —
+`gh api repos/synadia-ai/synadia-agents --jq '.permissions.admin'`
+should return `true`.)
 
 ## CI and the Claude reviewer bot
 


### PR DESCRIPTION
## Summary

Updates the Python release-ladder paragraph in root `CLAUDE.md` to:

1. **List both Python release workflows / tag prefixes** —
   `python-v*` for `synadia-ai-agents` and `python-agent-service-v*`
   for `synadia-ai-agent-service`. The previous text was written
   when only the first existed and read as if the env was
   single-purpose.
2. **Document the `pypi` env tag-policy gotcha** that bit the
   `synadia-ai-agent-service@0.1.0` publish: env protection
   rejected the tag because only `python-v*` was in the
   deployment-branch policy at the time. The workflow YAML was
   correct; the gap was on the GitHub-side env config.
3. **Provide the exact `gh api` one-liner** to extend the env
   policy when adding a new tag-triggered release workflow, plus
   the admin-check command to verify perms.

### Why now

This sharp edge cost ~15 min and a chain of *"can you grant
admin? wait, did the role propagate? wait, was Phil joking?"*
turn-arounds during the agent-sdk first publish. Future
contributors adding a third release workflow (e.g. when the TS
SDK gets a tag-driven publish) will hit the same wall unless the
ladder section warns them.

### Out of scope

- Updating `client-sdk/python/CLAUDE.md` or `agent-sdk/python/CLAUDE.md`
  with the same gotcha. The package-level files defer to root for
  release-ladder details, so a single mention here is enough.

## Test plan

- [ ] Reviewer-bot pass on the doc diff.
- [ ] Spot-check that the `gh api` POST and admin-check commands
      copy-paste cleanly (no smart-quote mangling from this PR
      description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)