### PR TITLE
docs: drop sibling-checkout pointers to the spec repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,8 @@ view: layout, subject namespace, wire shape, quickstart. Read it before
 making changes that touch user-visible surface.
 
 The protocol spec is **not vendored here**. Canonical source:
-[`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs).
-Either checkout it as a sibling at `../nats-agent-sdk-docs/` or link to
-the GitHub URL when reasoning about wire shape. Local
+[`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs)
+— always link to the GitHub URL when reasoning about wire shape. Local
 `docs/protocol-mapping.md` files inside each SDK translate spec → impl;
 they are not the spec itself.
 

--- a/agent-sdk/python/CLAUDE.md
+++ b/agent-sdk/python/CLAUDE.md
@@ -41,12 +41,10 @@ discovery. (This rule originated in the client-sdk's `AgentService`
 and travels with it into this package.)
 
 **The protocol spec is the source of truth.** Canonical location:
-[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
-(sibling checkout at `../../../nats-agent-sdk-docs/core-protocol.md`
-when working locally). The §12 implementation checklist is what
-"compliant" means; the §3 service-registration rules and §6/§7/§8
-emission rules are the load-bearing parts for *this* SDK
-specifically.
+[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+The §12 implementation checklist is what "compliant" means; the §3
+service-registration rules and §6/§7/§8 emission rules are the
+load-bearing parts for *this* SDK specifically.
 
 **Wire compatibility with the TypeScript SDK** is a hard requirement.
 Today the TS SDK is monolithic (`@synadia-ai/agents` ships both client

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -19,12 +19,9 @@ under a generic `pysdk` value - that would pollute the subject namespace
 and break `agent`-scoped discovery.
 
 **The protocol spec is the source of truth.** Canonical location:
-[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
-(sibling checkout at `../../../nats-agent-sdk-docs/core-protocol.md`
-when working locally - that repo sits next to the `synadia-agents/`
-monorepo checkout). This subdir no longer keeps a copy - always read
-the canonical. The implementation checklist in §12 is what "compliant"
-means.
+[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+This subdir does not keep a copy — always read the canonical. The
+implementation checklist in §12 is what "compliant" means.
 
 **Wire compatibility with the TypeScript SDK** at `../typescript/` is
 a hard requirement. Both SDKs are validated against each other via


### PR DESCRIPTION
## Summary

Three `CLAUDE.md` files pointed at the protocol spec via a
`../nats-agent-sdk-docs/` sibling-checkout path in addition to the
GitHub URL. The sibling layout isn't universal across contributors,
and the GitHub link is the canonical source either way. Strip the
sibling pointers, keep the GitHub link only.

Touched:
- \`CLAUDE.md\` (root)
- \`agent-sdk/python/CLAUDE.md\`
- \`client-sdk/python/CLAUDE.md\`

Pure prose. No code, no public surface, no spec changes.

## Test plan

- [ ] Skim each diff to confirm only the sibling pointer was removed
      and the GitHub URL is still intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)