### PR TITLE
Feature(client-sdk/ts): Drive PromptStream with requestMany + sentinel

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+> **Release-tag note:** the `replySubject` removal under "Removed" below
+> is a breaking public API change (the getter was listed in the 0.4.0
+> public surface). Cut this as **0.5.0**, not a 0.4.x patch.
+
 ### Changed
 
 - `PromptStream` now drives the response with `nc.requestMany` using

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `PromptStream` now drives the response with `nc.requestMany` using
+  the `sentinel` strategy (the wire terminator's empty-body shape
+  doubles as the sentinel). Replies route through the connection's
+  shared mux inbox instead of a fresh per-stream subscription, removing
+  the explicit `subscribe → flush → publish` dance and per-call
+  `_INBOX.agents.>` subject. Behavior over the wire is unchanged.
+
+### Added
+
+- `PromptOptions.maxWaitMs` — absolute ceiling for a single prompt
+  response, passed through to `requestMany`'s `maxWait`. Distinct from
+  `inactivityTimeoutMs` (which still enforces §6.6 idle-gap
+  detection). Default exported as `DEFAULT_PROMPT_MAX_WAIT_MS`
+  (10 minutes).
+- `StreamMaxWaitExceededError` — thrown when a prompt stream runs past
+  its absolute `maxWaitMs` ceiling without seeing the wire terminator,
+  even if chunks were still arriving under the inactivity gap.
+
+### Removed
+
+- `PromptStream.replySubject` getter. With the requestMany / mux move
+  the inbox is shared across all in-flight requests on the connection,
+  so the per-stream value lost meaning. The getter was documented as a
+  debugging aid and is not used by any tests or examples in-tree.
+
 ## [0.4.0] - 2026-04-30
 
 > **Note:** `0.3.0` was tagged in code (verb-first wire bump + max_payload

--- a/client-sdk/typescript/src/agent.ts
+++ b/client-sdk/typescript/src/agent.ts
@@ -9,7 +9,7 @@ import type { EndpointInfo } from "./discovery/endpoint-info.js";
 import { combineAbortSignals } from "./internal/abort.js";
 import { normalizeAttachments } from "./prompt/attachments.js";
 import { encodedEnvelopeSize, type RequestEnvelope } from "./prompt/envelope.js";
-import type { PromptOptions } from "./prompt/options.js";
+import { DEFAULT_PROMPT_MAX_WAIT_MS, type PromptOptions } from "./prompt/options.js";
 import {
   assertAttachmentsAllowed,
   assertPromptNonEmpty,
@@ -119,6 +119,7 @@ export class Agent {
       this.promptEndpoint.subject,
       envelope,
       opts.inactivityTimeoutMs ?? this.#defaultInactivityTimeoutMs,
+      opts.maxWaitMs ?? DEFAULT_PROMPT_MAX_WAIT_MS,
       signal,
     );
   }

--- a/client-sdk/typescript/src/agent.ts
+++ b/client-sdk/typescript/src/agent.ts
@@ -79,8 +79,11 @@ export class Agent {
    *   - {@link PayloadTooLargeError}         — envelope exceeds `max_payload` (§5.4).
    *
    * Wire errors thrown from the iterator:
-   *   - {@link ServiceError}       — `Nats-Service-Error-Code` header (§9.1).
-   *   - {@link StreamStalledError} — inactivity timeout (§6.6).
+   *   - {@link ServiceError}              — `Nats-Service-Error-Code` header (§9.1).
+   *   - {@link StreamStalledError}        — inactivity timeout (§6.6).
+   *   - {@link StreamMaxWaitExceededError} — total response time exceeded
+   *     `maxWaitMs` (default {@link DEFAULT_PROMPT_MAX_WAIT_MS}, 10 minutes)
+   *     without seeing the wire terminator.
    */
   prompt(text: string, opts: PromptOptions = {}): Promise<PromptStream> {
     assertPromptNonEmpty(text);

--- a/client-sdk/typescript/src/errors.ts
+++ b/client-sdk/typescript/src/errors.ts
@@ -90,6 +90,19 @@ export class StreamStalledError extends NatsAgentError {
   }
 }
 
+/**
+ * The stream ran past its absolute deadline without seeing the wire
+ * terminator (spec §6.5). Distinct from {@link StreamStalledError}: the
+ * agent may still be sending chunks at less than the inactivity gap, but
+ * the total time exceeded the per-prompt `maxWaitMs` ceiling.
+ */
+export class StreamMaxWaitExceededError extends NatsAgentError {
+  constructor(public readonly maxWaitMs: number) {
+    super(`stream exceeded maxWait of ${maxWaitMs}ms without terminator`);
+    this.name = "StreamMaxWaitExceededError";
+  }
+}
+
 /** A received wire payload could not be interpreted per spec. */
 export class ProtocolError extends NatsAgentError {
   constructor(message: string, options?: ErrorOptions) {

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -86,7 +86,7 @@ export {
   normalizeAttachment,
   normalizeAttachments,
 } from "./prompt/attachments.js";
-export { type PromptOptions } from "./prompt/options.js";
+export { type PromptOptions, DEFAULT_PROMPT_MAX_WAIT_MS } from "./prompt/options.js";
 export {
   PromptStream,
   type StreamMessage,
@@ -111,6 +111,7 @@ export {
   PayloadTooLargeError,
   ServiceError,
   StreamStalledError,
+  StreamMaxWaitExceededError,
   ProtocolError,
   NatsContextError,
   type ServiceErrorBody,

--- a/client-sdk/typescript/src/prompt/options.ts
+++ b/client-sdk/typescript/src/prompt/options.ts
@@ -8,6 +8,17 @@ export interface PromptOptions {
   readonly attachments?: ReadonlyArray<AttachmentInput>;
   /** Per-stream inactivity timeout (§6.6). Default: the `Agents`-level configured value (60_000ms). */
   readonly inactivityTimeoutMs?: number;
+  /**
+   * Absolute ceiling for the entire prompt response, in milliseconds. Passed
+   * straight through to `nc.requestMany`'s `maxWait`. The stream throws
+   * `StreamMaxWaitExceededError` if the terminator hasn't arrived by then,
+   * even if chunks are still trickling under the inactivity gap.
+   * Default: {@link DEFAULT_PROMPT_MAX_WAIT_MS} (10 minutes).
+   */
+  readonly maxWaitMs?: number;
   /** `AbortSignal` that aborts the stream when triggered (added in M5). */
   readonly signal?: AbortSignal;
 }
+
+/** Default absolute ceiling for a single `prompt()` response — 10 minutes. */
+export const DEFAULT_PROMPT_MAX_WAIT_MS = 600_000;

--- a/client-sdk/typescript/src/stream/prompt-stream.ts
+++ b/client-sdk/typescript/src/stream/prompt-stream.ts
@@ -96,6 +96,16 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
       maxWait: this.#maxWaitMs,
     })) as QueuedIterator<Msg>;
     this.#iter = iter;
+    // cancel() may have fired during the requestMany await — the early
+    // check above only covers cancellation before iteration started.
+    if (this.#cancelled) {
+      iter.stop();
+      return;
+    }
+    if (this.#signal?.aborted) {
+      iter.stop();
+      throw abortError(this.#signal);
+    }
 
     let onAbort: (() => void) | undefined;
     if (this.#signal) {

--- a/client-sdk/typescript/src/stream/prompt-stream.ts
+++ b/client-sdk/typescript/src/stream/prompt-stream.ts
@@ -122,14 +122,12 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
         this.#inactivityTimeoutMs,
         () => new StreamStalledError(this.#inactivityTimeoutMs),
       );
-      let sawTerminator = false;
       for await (const msg of timed) {
         if (this.#signal?.aborted) throw abortError(this.#signal);
         if (isErrorSignal(msg)) {
           throw buildServiceErrorFromMsg(msg);
         }
         if (isTerminator(msg)) {
-          sawTerminator = true;
           yield { type: "status", status: "done" };
           return;
         }
@@ -145,19 +143,16 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
         if (!decoded) continue; // unknown `type` silently dropped per §6.6
         yield toStreamMessage(decoded, this.#nc);
       }
-      // Iterator drained without a terminator. Sources:
-      //   - explicit cancel() / AbortSignal fired → exit cleanly (cancel)
-      //     or throw the signal's reason (abort).
-      //   - sentinel hit on an empty body that wasn't a clean terminator
-      //     (handled above; sawTerminator catches the standard case).
+      // The terminator branch above always `return`s, so reaching here
+      // means the iterator drained without one. Possible sources:
+      //   - AbortSignal fired → throw the signal's reason.
+      //   - cancel() fired → exit cleanly.
       //   - maxWait elapsed → throw StreamMaxWaitExceededError.
       if (this.#signal?.aborted) {
         throw abortError(this.#signal);
       }
       if (this.#cancelled) return;
-      if (!sawTerminator) {
-        throw new StreamMaxWaitExceededError(this.#maxWaitMs);
-      }
+      throw new StreamMaxWaitExceededError(this.#maxWaitMs);
     } finally {
       if (onAbort && this.#signal) this.#signal.removeEventListener("abort", onAbort);
       iter.stop();

--- a/client-sdk/typescript/src/stream/prompt-stream.ts
+++ b/client-sdk/typescript/src/stream/prompt-stream.ts
@@ -2,21 +2,29 @@
 // `Agent.prompt`. Implements `AsyncIterable<StreamMessage>` so the
 // caller writes `for await (const msg of stream) { ... }`.
 //
-// Wire behaviour:
-//   - Subscribes to a fresh reply inbox, flushes the SUB to the server,
-//     publishes the request envelope with that inbox as `reply`.
+// Wire behavior:
+//   - Calls `nc.requestMany(subject, payload, { strategy: "sentinel", maxWait })`.
+//     The connection's mux inbox handles the reply routing; the empty-body
+//     terminator (§6.5) ends the iterator.
 //   - Yields `{ type: "response" }`, `{ type: "status" }`, `QueryEvent` per
 //     §6.3–§7.
 //   - Emits a synthetic `{ type: "status", status: "done" }` when the wire
 //     terminator (empty body + no headers, §6.5) arrives.
 //   - Throws `ServiceError` on a `Nats-Service-Error-Code` header (§9.1).
 //   - Throws `StreamStalledError` on inactivity timeout (§6.6).
-//   - `cancel()` and early break from `for await` both unsubscribe cleanly.
+//   - Throws `StreamMaxWaitExceededError` if `maxWaitMs` elapses without
+//     a terminator (sentinel strategy's absolute ceiling).
+//   - `cancel()` and early break from `for await` both stop the iterator
+//     cleanly.
 
-import type { Msg, NatsConnection, Subscription } from "@nats-io/nats-core";
-import { ServiceError, StreamStalledError, type ServiceErrorBody } from "../errors.js";
+import type { Msg, NatsConnection, QueuedIterator } from "@nats-io/nats-core";
+import {
+  ServiceError,
+  StreamMaxWaitExceededError,
+  StreamStalledError,
+  type ServiceErrorBody,
+} from "../errors.js";
 import { abortError } from "../internal/abort.js";
-import { newInbox } from "../internal/inbox.js";
 import { encodeEnvelope, type RequestEnvelope } from "../prompt/envelope.js";
 import { buildQueryEvent, type QueryEvent } from "../query/query-event.js";
 import { decodeChunk, type DecodedAttachment, type DecodedChunk } from "./chunk-decoder.js";
@@ -38,10 +46,10 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
   readonly #nc: NatsConnection;
   readonly #requestSubject: string;
   readonly #envelope: RequestEnvelope;
-  readonly #replySubject: string;
   readonly #inactivityTimeoutMs: number;
+  readonly #maxWaitMs: number;
   readonly #signal: AbortSignal | undefined;
-  #sub: Subscription | null = null;
+  #iter: QueuedIterator<Msg> | null = null;
   #iterated = false;
   #cancelled = false;
 
@@ -50,28 +58,24 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
     requestSubject: string,
     envelope: RequestEnvelope,
     inactivityTimeoutMs: number,
+    maxWaitMs: number,
     signal?: AbortSignal,
   ) {
     this.#nc = nc;
     this.#requestSubject = requestSubject;
     this.#envelope = envelope;
-    this.#replySubject = newInbox();
     this.#inactivityTimeoutMs = inactivityTimeoutMs;
+    this.#maxWaitMs = maxWaitMs;
     this.#signal = signal;
   }
 
-  /** The NATS reply inbox this stream is listening on. Exposed for debugging. */
-  get replySubject(): string {
-    return this.#replySubject;
-  }
-
   /**
-   * Unsubscribe the reply inbox and end the stream cleanly. Subsequent
-   * `for await` iterations over this stream exit without throwing.
+   * Stop the underlying request iterator and end the stream cleanly.
+   * Subsequent `for await` iterations over this stream exit without throwing.
    */
   cancel(): void {
     this.#cancelled = true;
-    this.#sub?.unsubscribe();
+    this.#iter?.stop();
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<StreamMessage> {
@@ -82,36 +86,40 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
     if (this.#cancelled) return;
     if (this.#signal?.aborted) throw abortError(this.#signal);
 
-    const sub = this.#nc.subscribe(this.#replySubject);
-    this.#sub = sub;
-    // Flush so the SUB is at the server before the request is published —
-    // otherwise the agent could start replying before we're subscribed.
-    await this.#nc.flush();
-    this.#nc.publish(this.#requestSubject, encodeEnvelope(this.#envelope), {
-      reply: this.#replySubject,
-    });
+    // The `NatsConnection` interface types `requestMany` as returning a bare
+    // `AsyncIterable<Msg>`, but the concrete implementations (nats-core /
+    // transport-node / Bun ws) all return a `QueuedIterator<Msg>` whose
+    // `.stop()` is the only way to bail out early without waiting for
+    // `maxWait` to expire. Cast at the boundary.
+    const iter = (await this.#nc.requestMany(this.#requestSubject, encodeEnvelope(this.#envelope), {
+      strategy: "sentinel",
+      maxWait: this.#maxWaitMs,
+    })) as QueuedIterator<Msg>;
+    this.#iter = iter;
 
     let onAbort: (() => void) | undefined;
     if (this.#signal) {
       onAbort = (): void => {
         this.#cancelled = true; // mark so we distinguish "closed by abort" vs "stalled"
-        sub.unsubscribe();
+        iter.stop();
       };
       this.#signal.addEventListener("abort", onAbort, { once: true });
     }
 
     try {
-      const iter = withInactivityTimeout(
-        sub,
+      const timed = withInactivityTimeout(
+        iter,
         this.#inactivityTimeoutMs,
         () => new StreamStalledError(this.#inactivityTimeoutMs),
       );
-      for await (const msg of iter) {
+      let sawTerminator = false;
+      for await (const msg of timed) {
         if (this.#signal?.aborted) throw abortError(this.#signal);
         if (isErrorSignal(msg)) {
           throw buildServiceErrorFromMsg(msg);
         }
         if (isTerminator(msg)) {
+          sawTerminator = true;
           yield { type: "status", status: "done" };
           return;
         }
@@ -127,20 +135,23 @@ export class PromptStream implements AsyncIterable<StreamMessage> {
         if (!decoded) continue; // unknown `type` silently dropped per §6.6
         yield toStreamMessage(decoded, this.#nc);
       }
-      // Subscription closed without a terminator. Three possibilities:
-      //   - explicit cancel() / AbortSignal fired → exit cleanly (for
-      //     cancel) or throw the signal's reason (for abort).
-      //   - network / server closed the subscription → stalled.
+      // Iterator drained without a terminator. Sources:
+      //   - explicit cancel() / AbortSignal fired → exit cleanly (cancel)
+      //     or throw the signal's reason (abort).
+      //   - sentinel hit on an empty body that wasn't a clean terminator
+      //     (handled above; sawTerminator catches the standard case).
+      //   - maxWait elapsed → throw StreamMaxWaitExceededError.
       if (this.#signal?.aborted) {
         throw abortError(this.#signal);
       }
-      if (!this.#cancelled) {
-        throw new StreamStalledError(this.#inactivityTimeoutMs);
+      if (this.#cancelled) return;
+      if (!sawTerminator) {
+        throw new StreamMaxWaitExceededError(this.#maxWaitMs);
       }
     } finally {
       if (onAbort && this.#signal) this.#signal.removeEventListener("abort", onAbort);
-      sub.unsubscribe();
-      this.#sub = null;
+      iter.stop();
+      this.#iter = null;
     }
   }
 }


### PR DESCRIPTION
## Summary

  - Switch `PromptStream` to `nc.requestMany(subject, payload, { strategy: "sentinel", maxWait })`. The §6.5 terminator's empty body is the sentinel; the response routes
  through the connection's mux inbox instead of a per-stream `_INBOX.agents.>` subscription. Wire shape unchanged.
  - Add `PromptOptions.maxWaitMs` (override) and `DEFAULT_PROMPT_MAX_WAIT_MS = 600_000` (10 min default). Independent of the existing `inactivityTimeoutMs` — one is an
  absolute ceiling, the other an idle-gap detector.
  - Add `StreamMaxWaitExceededError` for the new failure mode (chunks still arriving under the inactivity gap, but total time exceeded the ceiling).
  - Drop the `PromptStream.replySubject` getter — under the mux inbox it loses its per-stream meaning. Documented as a debugging aid; no tests or examples in-tree consume
  it.

## Why

  The hand-rolled `subscribe → flush → publish` was a faithful re-implementation of what `requestMany` already does, plus extra round-trips (one SUB, one flush) per prompt
  and an extra inbox subject the broker has to track. The sentinel strategy lines up exactly with the protocol's terminator shape, so we get the same observable behavior
  with less code and less wire traffic.

## Notes for reviewers

  - `nc.requestMany` is typed in the `NatsConnection` interface as returning `AsyncIterable<Msg>`, but every concrete implementation returns the wider
  `QueuedIterator<Msg>`. We cast at the boundary with a comment, since `.stop()` is the only way to bail out early without waiting for `maxWait` to expire (used by
  `cancel()` and the abort-signal path).
  - `withInactivityTimeout` still wraps the iterator — `requestMany` only honors the absolute `maxWait`, not idle-gap reset.
  - Sentinel triggers on any empty-body message; the §9.1 error-signal (empty body + headers) ends iteration the same way as the §6.5 terminator. We still inspect the
  message inside the loop to decide whether to `throw ServiceError` or yield the synthetic `{status:"done"}`. The §9.3 trailing terminator after an error signal won't be
  observed, which is harmless — we're throwing anyway.
  - `examples/agent-web-ui/server/bridge.ts` references `StreamStalledError` only; it falls through to the generic `internal` handler for the new
  `StreamMaxWaitExceededError`. Out of scope here per the release ladder — the example pins `^0.4.x` and migrates after publish.