### PR TITLE
Catch Python SDK up to TS PR #66 (mux reply-inbox + max_wait_s)

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -6,6 +6,27 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
+## [0.2.0] - 2026-05-03
+
+### Changed
+
+- **Dependency floor bumped to `synadia-ai-agents>=0.6`** in lockstep
+  with the client-sdk's prompt-stream catch-up to the TS SDK's PR #66
+  (`requestMany` + sentinel) — see
+  [`client-sdk/python/CHANGELOG.md`](../../client-sdk/python/CHANGELOG.md)
+  `[0.6.0]` for the substance of that change. **No agent-side
+  code changes:** PR #66 was confirmed to touch only
+  `client-sdk/typescript/` (`gh pr view 66 --json files`); the
+  agent-host wire is identical pre/post. Agents still publish
+  individual chunks to `msg.reply` with the §6.5 zero-byte
+  terminator — whether the client subscribed per-stream or via a
+  shared mux is invisible from the agent's POV. The bump exists
+  purely to keep the published metapackage coherent so a user
+  installing `synadia-ai-agent-service` via PyPI pulls a client-sdk
+  that exposes the new `Agent.prompt(max_wait_s=...)` /
+  `StreamMaxWaitExceededError` / `StreamStalledError` surface shared
+  between both packages.
+
 ## [0.1.0] - 2026-04-30
 
 Initial release. **Carved out of `synadia-ai-agents` at the 0.5.0

--- a/agent-sdk/python/CLAUDE.md
+++ b/agent-sdk/python/CLAUDE.md
@@ -85,8 +85,9 @@ package).
   `parse_nats_url`, the `SERVICE_NAME` / `PROMPT_QUEUE_GROUP` constants,
   …) keeps its `from synadia_ai.agents import …` path unchanged.
 - **Dependency direction:** `synadia-ai-agent-service` depends on
-  `synadia-ai-agents` (`>=0.5` — the first release that ships the
-  trimmed surface). Not the other way around. The client-sdk must
+  `synadia-ai-agents` (`>=0.6` on the current release line; `0.5.0`
+  was the first release that shipped the trimmed surface). Not the
+  other way around. The client-sdk must
   remain installable and useful without ever pulling the agent-sdk.
 - **No code duplication.** Anything shared (envelope codec, subject
   sanitization, `HeartbeatPayload`, `_PROTOCOL_VERSION`, validation

--- a/agent-sdk/python/README.md
+++ b/agent-sdk/python/README.md
@@ -20,7 +20,7 @@ uv pip install -e .
 ```
 
 When both packages are on PyPI, plain `pip install
-synadia-ai-agent-service` will pull `synadia-ai-agents>=0.5`
+synadia-ai-agent-service` will pull `synadia-ai-agents>=0.6`
 automatically.
 
 ## Quickstart — host an agent

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/synadia-ai/synadia-agents/issues"
 # `uv sync`. This affects monorepo developers only — it is dev-time
 # config and is NOT persisted into the built wheel's METADATA, so an
 # external user installing `synadia-ai-agent-service` from PyPI gets
-# the declared dep (`synadia-ai-agents>=0.5`) from PyPI as normal.
+# the declared dep (`synadia-ai-agents>=0.6`) from PyPI as normal.
 synadia-ai-agents = { path = "../../client-sdk/python", editable = true }
 
 [dependency-groups]

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agent-service"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python agent-host SDK for the NATS Agent Protocol — register and serve spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "nats-py>=2.7",
     "pydantic>=2.5",
-    "synadia-ai-agents>=0.5",
+    "synadia-ai-agents>=0.6",
 ]
 
 [project.urls]

--- a/agent-sdk/python/uv.lock
+++ b/agent-sdk/python/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agent-service"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },
@@ -416,7 +416,7 @@ dev = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "../../client-sdk/python" }
 dependencies = [
     { name = "nats-py" },

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -11,10 +11,10 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 Catch-up to the TypeScript SDK's
 [PR #66](https://github.com/synadia-ai/synadia-agents/pull/66)
 (`requestMany` + sentinel) — Python-side analogue using an interim
-SDK-level mux reply-inbox (one `SUB`+flush per `Agents`, regardless
-of how many concurrent prompts) plus the `max_wait_s` absolute
-ceiling on prompt streams. Wire shape unchanged; protocol stays at
-`"0.3"`.
+**per-NATS-connection** mux reply-inbox (one SUB+flush per
+connection, automatically shared by every caller of the same `nc`)
+plus the `max_wait_s` absolute ceiling on prompt streams. Wire shape
+unchanged; protocol stays at `"0.3"`.
 
 ### Added
 
@@ -40,43 +40,48 @@ ceiling on prompt streams. Wire shape unchanged; protocol stays at
     that previously raised a bare `ProtocolError("stream stalled
     ...")`. Carries `.timeout_s` and `.reply_subject`. Same
     back-compat story as `StreamMaxWaitExceededError`.
-- **`AgentsClosedError(NatsAgentError)`** — raised by
-  `Agent.prompt()` when called after the owning `Agents.close()` has
-  fired. Surfaces the race between a torn-down `Agents` and a
-  late-arriving prompt as a clean, branchable error rather than a
-  generic `RuntimeError`.
+- **`AgentsClosedError(NatsAgentError)`** — raised by the
+  pre-flight check at the top of `Agent.prompt()` when called after
+  the owning `Agents.close()` has already fired. Distinct from
+  `ProtocolError` (which fires when close happens *during* an active
+  stream) so callers can branch on "called against a closed Agents"
+  vs "torn down mid-flight."
 
 ### Changed
 
-- **Internal: `Agents` opens a single shared mux reply-inbox
-  subscription instead of subscribing per prompt.** Wire shape from
-  the broker's POV is unchanged — every reply still arrives on a
-  subject under the SDK inbox prefix `_INBOX.agents.>` — but now one
-  `Agents` instance opens **one** SUB at first prompt-time and routes
-  every stream's chunks to the right consumer by token. A 5-prompt
-  sequence cuts SUB+UNSUB traffic from 10 frames to 0 (after the
-  first SUB), and from one extra `flush()` per prompt to one total.
-  See `src/synadia_ai/agents/_mux.py` for the design + the
-  migration-to-`request_many` plan; **interim** until `nats-py`
+- **Internal: shared mux reply-inbox lives on the NATS connection,
+  not on `Agents`.** Mirrors the TS SDK's design: in PR #66 the TS
+  client uses `nc.requestMany(...)`, which is a method on the
+  connection — every caller of the same `nc` automatically shares
+  the connection's internal mux. Python's analogue is a per-`nc`
+  singleton `MuxInbox` held in a `WeakKeyDictionary` keyed by the
+  connection (see `synadia_ai.agents._mux.mux_for`). Multiple
+  `Agents` instances on the same connection — and directly-
+  constructed `Agent` handles — share one
+  `_INBOX.agents.<mux>.*` subscription. Lifecycle is tied to the
+  connection: when the user closes `nc`, the subscription dies; when
+  the `Client` object is GC'd, the mux entry drops out of the cache
+  automatically. `Agents.close()` does **not** tear down the mux —
+  it lives on the connection and is the connection-owner's
+  responsibility, just like in TS. **Interim** until `nats-py`
   ships [`request_many`][np-rm] upstream. Tracked under marker
   `INTERIM-NATSPY-REQUEST-MANY`.
 
   [np-rm]: https://github.com/nats-io/nats.py
-- **Internal: `Agents.close()` now broadcasts a sentinel into every
-  live stream's queue** before tearing down the mux subscription, so
-  consumers unblock from `queue.get()` within an event-loop tick
-  instead of waiting for the §6.6 inactivity timer. Eliminates the
-  `next_msg`-vs-`close_event` `asyncio.wait` race window that the
-  old per-prompt code carried.
+- **Internal: `Agent.prompt` runs a per-stream close-event watcher
+  task** that pushes a cancellation sentinel into the stream's queue
+  when `close_event` fires. Consumers unblock from `queue.get()`
+  within an event-loop tick instead of waiting for the §6.6
+  inactivity timer. Restores the prior contract from before the
+  refactor — works regardless of whether the `Agent` was built via
+  `Agents.discover()` or directly. Mirrors TS's `closeSignal:
+  AbortSignal` mechanism, kept intentionally orthogonal to the mux
+  (mux = transport, close_event = cancellation).
 - **`Agents(prompt_max_wait_s=...)`** kwarg on the constructor —
   default for the new `Agent.prompt(max_wait_s=...)` ceiling. Falls
   back to `DEFAULT_PROMPT_MAX_WAIT_S = 600.0` when omitted. New
   read-only property `Agents.prompt_max_wait_s` mirrors
   `Agents.stream_inactivity_timeout`.
-- **`Agents.mux`** — read-only property exposing the shared mux for
-  callers that build `Agent` instances outside `Agents.discover()`
-  (parallel to the existing `Agents.close_event`). Documented as
-  **interim** alongside `_mux.py`.
 
 ### Note
 

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -6,7 +6,90 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
-## [Unreleased]
+## [0.6.0] - 2026-05-03
+
+Catch-up to the TypeScript SDK's
+[PR #66](https://github.com/synadia-ai/synadia-agents/pull/66)
+(`requestMany` + sentinel) — Python-side analogue using an interim
+SDK-level mux reply-inbox (one `SUB`+flush per `Agents`, regardless
+of how many concurrent prompts) plus the `max_wait_s` absolute
+ceiling on prompt streams. Wire shape unchanged; protocol stays at
+`"0.3"`.
+
+### Added
+
+- **`Agent.prompt(max_wait_s=...)` — absolute ceiling on a prompt
+  stream.** Mirrors the TS SDK's `PromptOptions.maxWaitMs` from
+  [PR #66](https://github.com/synadia-ai/synadia-agents/pull/66)
+  (`requestMany` + sentinel). Distinct from `timeout=`, which is the
+  §6.6 per-chunk inactivity timer that resets on every received chunk.
+  The ceiling is the safety net for streams that emit a steady trickle
+  forever, or for silent reconnect windows that exceed the inactivity
+  reset cycle. Defaults to **600 seconds** (10 min); pass `max_wait_s=`
+  to override per-call, or set `Agents(prompt_max_wait_s=...)` to
+  change the default for every `Agent` produced by that `Agents`. New
+  exports:
+  - `DEFAULT_PROMPT_MAX_WAIT_S = 600.0` (constant, mirrors TS
+    `DEFAULT_PROMPT_MAX_WAIT_MS = 600_000`).
+  - `StreamMaxWaitExceededError(ProtocolError)` — raised when the
+    ceiling fires. Carries `.max_wait_s`. Inherits from
+    `ProtocolError` so existing `except ProtocolError` clauses keep
+    catching it; new code may catch the subclass to distinguish from
+    inactivity-gap and wire-shape errors.
+  - `StreamStalledError(ProtocolError)` — the inactivity-gap case
+    that previously raised a bare `ProtocolError("stream stalled
+    ...")`. Carries `.timeout_s` and `.reply_subject`. Same
+    back-compat story as `StreamMaxWaitExceededError`.
+- **`AgentsClosedError(NatsAgentError)`** — raised by
+  `Agent.prompt()` when called after the owning `Agents.close()` has
+  fired. Surfaces the race between a torn-down `Agents` and a
+  late-arriving prompt as a clean, branchable error rather than a
+  generic `RuntimeError`.
+
+### Changed
+
+- **Internal: `Agents` opens a single shared mux reply-inbox
+  subscription instead of subscribing per prompt.** Wire shape from
+  the broker's POV is unchanged — every reply still arrives on a
+  subject under the SDK inbox prefix `_INBOX.agents.>` — but now one
+  `Agents` instance opens **one** SUB at first prompt-time and routes
+  every stream's chunks to the right consumer by token. A 5-prompt
+  sequence cuts SUB+UNSUB traffic from 10 frames to 0 (after the
+  first SUB), and from one extra `flush()` per prompt to one total.
+  See `src/synadia_ai/agents/_mux.py` for the design + the
+  migration-to-`request_many` plan; **interim** until `nats-py`
+  ships [`request_many`][np-rm] upstream. Tracked under marker
+  `INTERIM-NATSPY-REQUEST-MANY`.
+
+  [np-rm]: https://github.com/nats-io/nats.py
+- **Internal: `Agents.close()` now broadcasts a sentinel into every
+  live stream's queue** before tearing down the mux subscription, so
+  consumers unblock from `queue.get()` within an event-loop tick
+  instead of waiting for the §6.6 inactivity timer. Eliminates the
+  `next_msg`-vs-`close_event` `asyncio.wait` race window that the
+  old per-prompt code carried.
+- **`Agents(prompt_max_wait_s=...)`** kwarg on the constructor —
+  default for the new `Agent.prompt(max_wait_s=...)` ceiling. Falls
+  back to `DEFAULT_PROMPT_MAX_WAIT_S = 600.0` when omitted. New
+  read-only property `Agents.prompt_max_wait_s` mirrors
+  `Agents.stream_inactivity_timeout`.
+- **`Agents.mux`** — read-only property exposing the shared mux for
+  callers that build `Agent` instances outside `Agents.discover()`
+  (parallel to the existing `Agents.close_event`). Documented as
+  **interim** alongside `_mux.py`.
+
+### Note
+
+- **No protocol-version bump.** PR #66 on the TS side was a
+  client-only refactor (consumer changes how it subscribes; producer
+  is unaffected). This Python catch-up is the same: zero wire-shape
+  change, `protocol_version` stays at `"0.3"`. The
+  `tests/test_interop_e2e.py` skip remains tied to the v0.3
+  verb-first wire blocker, not to this change.
+- **The agent-sdk side (`agent-sdk/python`) is bumped in lockstep**
+  for dependency-pinning hygiene only; no agent-side code changes.
+  PR #66 was confirmed to touch only `client-sdk/typescript/` (`gh
+  pr view 66 --json files`); the agent-side wire is unaffected.
 
 ## [0.5.0] - 2026-04-30
 
@@ -840,7 +923,8 @@ Initial scaffold. Released ahead of the finalised v0.1 spec; most wire
 shapes in this version no longer match the spec and are corrected in
 0.1.0.
 
-[Unreleased]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.3.0...HEAD
+[0.6.0]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.5.0...HEAD
+[0.5.0]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.3.0...python-v0.5.0
 [0.3.0]: https://github.com/synadia-ai/synadia-agents/releases/tag/python-v0.3.0
 [0.2.0]: https://github.com/synadia-ai/synadia-agents/releases/tag/python-v0.2.0
 [0.1.0]: https://github.com/synadia-ai/synadia-agents/releases/tag/python-v0.1.0

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -68,15 +68,14 @@ unchanged; protocol stays at `"0.3"`.
   `INTERIM-NATSPY-REQUEST-MANY`.
 
   [np-rm]: https://github.com/nats-io/nats.py
-- **Internal: `Agent.prompt` runs a per-stream close-event watcher
-  task** that pushes a cancellation sentinel into the stream's queue
-  when `close_event` fires. Consumers unblock from `queue.get()`
-  within an event-loop tick instead of waiting for the §6.6
-  inactivity timer. Restores the prior contract from before the
-  refactor — works regardless of whether the `Agent` was built via
-  `Agents.discover()` or directly. Mirrors TS's `closeSignal:
-  AbortSignal` mechanism, kept intentionally orthogonal to the mux
-  (mux = transport, close_event = cancellation).
+- **Internal: `Agent.prompt` races stream reads against lifecycle
+  events** so `close_event` and `max_wait_s` win over queued chunks
+  and terminators. Consumers unblock within an event-loop tick
+  instead of waiting for the §6.6 inactivity timer, and max-wait is
+  cancelled when the mux observes the wire terminator. Restores the
+  prior close contract while matching TS's `closeSignal: AbortSignal`
+  and `requestMany(..., { maxWait })` split (mux = transport,
+  close/max-wait = lifecycle).
 - **`Agents(prompt_max_wait_s=...)`** kwarg on the constructor —
   default for the new `Agent.prompt(max_wait_s=...)` ceiling. Falls
   back to `DEFAULT_PROMPT_MAX_WAIT_S = 600.0` when omitted. New
@@ -88,9 +87,9 @@ unchanged; protocol stays at `"0.3"`.
 - **No protocol-version bump.** PR #66 on the TS side was a
   client-only refactor (consumer changes how it subscribes; producer
   is unaffected). This Python catch-up is the same: zero wire-shape
-  change, `protocol_version` stays at `"0.3"`. The
-  `tests/test_interop_e2e.py` skip remains tied to the v0.3
-  verb-first wire blocker, not to this change.
+  change, `protocol_version` stays at `"0.3"`. The cross-SDK
+  `tests/test_interop_e2e.py` tests run when Bun + the TS sibling
+  dependencies are present and skip only for missing prereqs.
 - **The agent-sdk side (`agent-sdk/python`) is bumped in lockstep**
   for dependency-pinning hygiene only; no agent-side code changes.
   PR #66 was confirmed to touch only `client-sdk/typescript/` (`gh

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -82,6 +82,25 @@ unchanged; protocol stays at `"0.3"`.
   read-only property `Agents.prompt_max_wait_s` mirrors
   `Agents.stream_inactivity_timeout`.
 
+### Fixed (post-review)
+
+- **`max_wait_s <= 0` now raises `ValueError` synchronously** at every
+  entry point (`Agent.prompt(max_wait_s=...)`, `Agent(prompt_max_wait_s=...)`,
+  `Agents(prompt_max_wait_s=...)`). The previous implementation pre-fired
+  the ceiling on `0` so the first read raised `StreamMaxWaitExceededError`
+  before any chunk arrived — a footgun for callers who reasonably read
+  `max_wait_s=0` as either "no limit" or "non-blocking poll." There is
+  no "no limit" sentinel — an unbounded prompt stream is the exact
+  failure mode the ceiling exists to prevent. Pass `None` to use the
+  default, or any strictly positive number to override. Found by the
+  reviewer bot on PR #67.
+- **Documented multi-event-loop caveat on `mux_for` / `MuxInbox`.** The
+  `_MUX_CACHE` is module-global and `MuxInbox` captures an
+  `asyncio.Lock` at construction tied to the loop running on the first
+  call; sharing one `Client` across loops in different threads is not
+  supported. Documentation contract, not a runtime check — the SDK is
+  single-loop-asyncio in shape. Found by the reviewer bot on PR #67.
+
 ### Note
 
 - **No protocol-version bump.** PR #66 on the TS side was a

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -318,12 +318,18 @@ either guides them to success or frustrates them.
 ## Alignment milestones
 
 - **2026-05-03 - prompt-stream catch-up to TS PR #66 (`requestMany` +
-  sentinel).** Python-side analogue of the TS reshape: prompt streams
-  now ride a shared `_INBOX.agents.<mux>.*` subscription per `Agents`
-  (one SUB+flush, regardless of how many concurrent prompts) instead
-  of `subscribe + publish + unsubscribe` per call. Wire shape
-  unchanged — the broker still sees replies on subjects under the
-  SDK inbox prefix; protocol stays at `"0.3"`. New public API:
+  sentinel).** Python-side analogue of the TS reshape, mirroring TS's
+  shape exactly: prompt streams ride a shared
+  `_INBOX.agents.<mux>.*` subscription that lives **on the NATS
+  connection** (per-`nc` singleton in
+  `synadia_ai.agents._mux.mux_for`, held in a `WeakKeyDictionary`),
+  not on `Agents` — every caller of the same `nc` automatically
+  shares it, just like TS's `nc.requestMany`. Wire shape unchanged
+  — the broker still sees replies on subjects under the SDK inbox
+  prefix; protocol stays at `"0.3"`. Cancellation stays orthogonal
+  to the mux: a per-stream watcher task pushes a sentinel into the
+  stream's queue when `close_event` fires (mirrors TS's
+  `closeSignal: AbortSignal`). New public API:
   `Agent.prompt(max_wait_s=...)` (absolute ceiling, mirrors TS
   `PromptOptions.maxWaitMs`), `DEFAULT_PROMPT_MAX_WAIT_S = 600.0`,
   `StreamMaxWaitExceededError`, `StreamStalledError` (the previously-

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -317,6 +317,23 @@ either guides them to success or frustrates them.
 
 ## Alignment milestones
 
+- **2026-05-03 - prompt-stream catch-up to TS PR #66 (`requestMany` +
+  sentinel).** Python-side analogue of the TS reshape: prompt streams
+  now ride a shared `_INBOX.agents.<mux>.*` subscription per `Agents`
+  (one SUB+flush, regardless of how many concurrent prompts) instead
+  of `subscribe + publish + unsubscribe` per call. Wire shape
+  unchanged — the broker still sees replies on subjects under the
+  SDK inbox prefix; protocol stays at `"0.3"`. New public API:
+  `Agent.prompt(max_wait_s=...)` (absolute ceiling, mirrors TS
+  `PromptOptions.maxWaitMs`), `DEFAULT_PROMPT_MAX_WAIT_S = 600.0`,
+  `StreamMaxWaitExceededError`, `StreamStalledError` (the previously-
+  bare-`ProtocolError("stream stalled ...")` case promoted to a
+  concrete subclass — back-compat preserved), `AgentsClosedError`.
+  Implementation in `src/synadia_ai/agents/_mux.py`; documented as
+  **interim** until `nats-py` ships `request_many` upstream
+  (marker `INTERIM-NATSPY-REQUEST-MANY` in source). Agent-sdk side
+  unaffected by wire shape; bumped in lockstep for dependency-pin
+  hygiene only.
 - **2026-04-28 - session-name collapse (Python-only, ahead of spec).**
   Token 5 of every agent subject IS the session: `name` + `session`
   collapse into a single `session_name`. Public-API renames on
@@ -331,7 +348,7 @@ either guides them to success or frustrates them.
   §3.3's queue group `"agents"` load-balancing across instances of
   the same logical session. Ships under the same protocol version
   `"0.3"` as the verb-first wire bump (no second protocol bump). See
-  `CHANGELOG.md` [Unreleased] for full migration notes.
+  `CHANGELOG.md` [0.5.0] for full migration notes.
 - **2026-04-27 - v0.3.0 wire bump (Python-only, ahead of spec).** Moves
   the agent subject hierarchy to verb-first
   (`agents.{verb}.{agent}.{owner}.{session_name}`) so each endpoint
@@ -344,11 +361,10 @@ either guides them to success or frustrates them.
   now `agents.hb.*.*.*`. `metadata.protocol_version` bumps
   `"0.2"` → `"0.3"`; old v0.2 callers fail to discovery-match a v0.3
   agent rather than silently talking past it. Ships ahead of the
-  protocol spec, the TypeScript SDK, and the agent harnesses
-  (`agents/*`); the cross-SDK interop test
-  `tests/test_interop_e2e.py` is `pytest.skip`d at module level until
-  TS catches up. See `CHANGELOG.md` [Unreleased] for full migration
-  notes.
+  protocol spec; the TypeScript SDK has since caught up to v0.3 (see
+  `client-sdk/typescript/src/version.ts`) and the cross-SDK interop
+  test `tests/test_interop_e2e.py` is unskipped. See `CHANGELOG.md`
+  [0.5.0] for full migration notes.
 - **2026-04-22 - v0.2.0 wire bump.** Aligns with NATS Agent Protocol
   v0.2: service name `SynadiaAgents` → `agents` (§3.1); discovery
   subjects rebased to `$SRV.{PING,INFO}.agents` (§4.1/§4.2); `prompt`

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -60,7 +60,7 @@ spec to catch up.
 
 | SDK                                  | Wire behaviour                                                                              | Spec ref   |
 | ------------------------------------ | ------------------------------------------------------------------------------------------- | ---------- |
-| Stream start                         | Fresh `_INBOX` reply subject; SUB established before request PUBLISH.                       | §6.1       |
+| Stream start                         | Per-stream reply subject under a shared `_INBOX.agents.<mux>.*` subscription (one per `Agents`); SUB established lazily on first prompt and reused thereafter. **Interim** until nats-py ships `request_many` — see [`src/synadia_ai/agents/_mux.py`](../src/synadia_ai/agents/_mux.py) (marker `INTERIM-NATSPY-REQUEST-MANY`). | §6.1 |
 | `ResponseChunk.text`                 | Decoded from `{"type":"response","data":"..."}` OR `{...,"data":{text, attachments?}}`.     | §6.3       |
 | `StatusChunk.status`                 | Decoded from `{"type":"status","data":"<token>"}`. Unknown tokens flow through unchanged.   | §6.4, §6.6 |
 | `QueryChunk` → `Query` event         | Decoded from `{"type":"query","data":{id, reply_subject, prompt, attachments?}}`.           | §7         |
@@ -68,7 +68,8 @@ spec to catch up.
 | Plain-text on response side          | **Rejected** - `decode_chunk` requires JSON with a `type` discriminator.                    | §6.2       |
 | Stream terminator                    | Empty body AND no NATS headers. Error frames carry headers and are NOT terminators.         | §6.5, §9.3 |
 | `PromptStream.send(str)`             | Wraps the string in a `ResponseChunk`, emits the §6.3 bare-string form.                     | §6.3       |
-| Per-stream inactivity timeout        | Caller-supplied `timeout=` kwarg; raises `ProtocolError("stream stalled")` on lapse.        | §6.6       |
+| Per-stream inactivity timeout        | Caller-supplied `timeout=` kwarg (default `DEFAULT_STREAM_INACTIVITY_TIMEOUT_S = 60.0`); raises `StreamStalledError` (a `ProtocolError` subclass — back-compat preserved) on lapse. Resets every received chunk. | §6.6 |
+| Absolute stream ceiling              | Caller-supplied `max_wait_s=` kwarg (default `DEFAULT_PROMPT_MAX_WAIT_S = 600.0`); raises `StreamMaxWaitExceededError` (a `ProtocolError` subclass) on expiry. Distinct from the inactivity timer — does NOT reset on chunks. Mirrors TS `PromptOptions.maxWaitMs` from PR #66. | (SDK convention; spec silent) |
 
 ## Errors (§9)
 
@@ -140,7 +141,7 @@ mirror the TypeScript SDK so the two stay in lockstep.
    sub-subject). This SDK ships the verb-first form
    (`agents.{verb}.{a}.{o}.{n}`) ahead of the spec text so a working
    reference exists for the spec PR + the TS SDK port. Companion work
-   tracked in `CHANGELOG.md` [Unreleased] under "Anticipated companion
+   tracked in `CHANGELOG.md` [0.5.0] under "Anticipated companion
    work".
 5. **`status` request/response endpoint.** Not yet defined in the spec.
    This SDK registers a NATS micro endpoint named `status` on
@@ -157,6 +158,20 @@ mirror the TypeScript SDK so the two stay in lockstep.
    ahead of the spec's blessing — the upstream PR will cover §3.2
    metadata, §5.1 envelope, and §8.3 heartbeat-payload field
    removals in lockstep.
+7. **Interim mux reply-inbox vs `request_many` (§6.1).** `nats-py` has
+   no `request_many` primitive yet — the TS SDK's PR #66 reshape
+   (`nc.requestMany(subject, payload, { strategy: "sentinel", maxWait
+   })`) doesn't have a direct port. The Python SDK ships a
+   library-level analogue: one shared
+   `_INBOX.agents.<mux>.*` subscription per `Agents`, replies routed
+   to per-stream queues by inbox-tail token (see
+   [`src/synadia_ai/agents/_mux.py`](../src/synadia_ai/agents/_mux.py)).
+   Wire shape from the broker's POV is unchanged. Once `nats-py`
+   gains `request_many` upstream the interim module gets retired and
+   `Agent._stream_prompt` is the single call site to migrate. Track
+   the upstream feature at
+   [`nats-io/nats.py`](https://github.com/nats-io/nats.py); SDK-side
+   marker `INTERIM-NATSPY-REQUEST-MANY`.
 
 ## Deferred TS-parity work
 

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -60,7 +60,7 @@ spec to catch up.
 
 | SDK                                  | Wire behaviour                                                                              | Spec ref   |
 | ------------------------------------ | ------------------------------------------------------------------------------------------- | ---------- |
-| Stream start                         | Per-stream reply subject under a shared `_INBOX.agents.<mux>.*` subscription (one per `Agents`); SUB established lazily on first prompt and reused thereafter. **Interim** until nats-py ships `request_many` — see [`src/synadia_ai/agents/_mux.py`](../src/synadia_ai/agents/_mux.py) (marker `INTERIM-NATSPY-REQUEST-MANY`). | §6.1 |
+| Stream start                         | Per-stream reply subject under a shared `_INBOX.agents.<mux>.*` subscription (one per **NATS connection**, automatically shared by every caller — mirrors TS `nc.requestMany`); SUB established lazily on first prompt and reused thereafter. **Interim** until nats-py ships `request_many` — see [`src/synadia_ai/agents/_mux.py`](../src/synadia_ai/agents/_mux.py) (marker `INTERIM-NATSPY-REQUEST-MANY`). | §6.1 |
 | `ResponseChunk.text`                 | Decoded from `{"type":"response","data":"..."}` OR `{...,"data":{text, attachments?}}`.     | §6.3       |
 | `StatusChunk.status`                 | Decoded from `{"type":"status","data":"<token>"}`. Unknown tokens flow through unchanged.   | §6.4, §6.6 |
 | `QueryChunk` → `Query` event         | Decoded from `{"type":"query","data":{id, reply_subject, prompt, attachments?}}`.           | §7         |
@@ -162,12 +162,16 @@ mirror the TypeScript SDK so the two stay in lockstep.
    no `request_many` primitive yet — the TS SDK's PR #66 reshape
    (`nc.requestMany(subject, payload, { strategy: "sentinel", maxWait
    })`) doesn't have a direct port. The Python SDK ships a
-   library-level analogue: one shared
-   `_INBOX.agents.<mux>.*` subscription per `Agents`, replies routed
-   to per-stream queues by inbox-tail token (see
-   [`src/synadia_ai/agents/_mux.py`](../src/synadia_ai/agents/_mux.py)).
-   Wire shape from the broker's POV is unchanged. Once `nats-py`
-   gains `request_many` upstream the interim module gets retired and
+   library-level analogue **deliberately mirroring the TS shape**: one
+   shared `_INBOX.agents.<mux>.*` subscription **per NATS connection**
+   (held in a `WeakKeyDictionary` keyed by the `Client` object —
+   `synadia_ai.agents._mux.mux_for(nc)`), with replies routed to
+   per-stream queues by inbox-tail token. Every `Agents` instance and
+   every directly-constructed `Agent` handle on the same connection
+   automatically picks up the same mux — no plumbing required, just
+   like in TS where `nc.requestMany` belongs to the connection. Wire
+   shape from the broker's POV is unchanged. Once `nats-py` gains
+   `request_many` upstream the interim module gets retired and
    `Agent._stream_prompt` is the single call site to migrate. Track
    the upstream feature at
    [`nats-io/nats.py`](https://github.com/nats-io/nats.py); SDK-side

--- a/client-sdk/python/pyproject.toml
+++ b/client-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agents"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python client SDK for the NATS Agent Protocol — discover and prompt spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/client-sdk/python/src/synadia_ai/agents/__init__.py
+++ b/client-sdk/python/src/synadia_ai/agents/__init__.py
@@ -29,6 +29,7 @@ convention (``jetstream(nc)``, ``Svcm(nc)``, ``Kvm(nc)``…).
 from __future__ import annotations
 
 from .agent import (
+    DEFAULT_PROMPT_MAX_WAIT_S,
     DEFAULT_STREAM_INACTIVITY_TIMEOUT_S,
     Agent,
     Query,
@@ -52,6 +53,7 @@ from .discovery import (
 from .envelope import Attachment, Envelope, decode, encode
 from .errors import (
     AgentNotFound,
+    AgentsClosedError,
     AttachmentsNotSupportedError,
     InvalidSubjectToken,
     NatsAgentError,
@@ -60,6 +62,8 @@ from .errors import (
     PromptEmptyError,
     ProtocolError,
     QueryTimeout,
+    StreamMaxWaitExceededError,
+    StreamStalledError,
     ValidationError,
 )
 from .heartbeat import (
@@ -75,6 +79,7 @@ __all__ = [
     "DEFAULT_DISCOVER_MAX_WAIT_S",
     "DEFAULT_DISCOVER_STALL_S",
     "DEFAULT_LIVENESS_SLACK",
+    "DEFAULT_PROMPT_MAX_WAIT_S",
     "DEFAULT_STREAM_INACTIVITY_TIMEOUT_S",
     "HEARTBEAT_SUBJECT",
     "PROMPT_ENDPOINT_NAME",
@@ -87,6 +92,7 @@ __all__ = [
     "AgentNotFound",
     "AgentSubject",
     "Agents",
+    "AgentsClosedError",
     "Attachment",
     "AttachmentsNotSupportedError",
     "Chunk",
@@ -106,7 +112,9 @@ __all__ = [
     "QueryTimeout",
     "ResponseChunk",
     "StatusChunk",
+    "StreamMaxWaitExceededError",
     "StreamMessage",
+    "StreamStalledError",
     "ValidationError",
     "build_agent_info",
     "decode",

--- a/client-sdk/python/src/synadia_ai/agents/_mux.py
+++ b/client-sdk/python/src/synadia_ai/agents/_mux.py
@@ -1,41 +1,51 @@
-"""Per-:class:`Agents` shared mux inbox for prompt-stream replies.
+"""Per-NATS-connection shared mux inbox for prompt-stream replies.
 
 INTERIM-NATSPY-REQUEST-MANY: this module is the Python-side workaround
 for ``nats-py``'s missing ``request_many`` primitive. The TypeScript SDK
 (see PR
 [synadia-ai/synadia-agents#66](https://github.com/synadia-ai/synadia-agents/pull/66))
 drives prompt streams through ``nc.requestMany(subject, payload, {
-strategy: "sentinel", maxWait })`` so replies route through the
-connection's shared mux inbox instead of a fresh per-stream
-``_INBOX.agents.>`` subscription. ``nats-py`` has no equivalent — its
-internal mux (``_resp_map`` / ``_resp_sub_prefix`` in
-``nats/aio/client.py``) tracks one ``Future`` per token, not iterators.
+strategy: "sentinel", maxWait })`` — a method on the **NATS connection**
+whose internal mux is automatically shared by every caller of the same
+``nc``. ``nats-py`` has no equivalent (its internal mux at
+``_resp_map`` / ``_resp_sub_prefix`` in ``nats/aio/client.py`` tracks one
+``Future`` per token, not iterators).
 
-This module is the API-level analogue: one persistent
-``_INBOX.agents.<mux>.*`` subscription per :class:`Agents`, with messages
-routed by inbox-tail token to per-stream queues. Callers get the
-wire-traffic savings (one SUB+flush per :class:`Agents` instance instead
-of one per prompt) and the parity API on the prompt side
-(``max_wait_s``, :class:`StreamMaxWaitExceededError`,
-cancellation-safe teardown).
+This module is the API-level analogue, intentionally mirroring the TS
+shape: **one** ``MuxInbox`` per :class:`~nats.aio.client.Client`,
+created on first prompt and held in a process-global
+:class:`weakref.WeakKeyDictionary` keyed by the connection. Every caller
+of :func:`mux_for` against the same ``nc`` gets the same instance, so
+multiple :class:`~synadia_ai.agents.Agents` (or directly-constructed
+:class:`~synadia_ai.agents.Agent` handles) on the same connection
+share one ``_INBOX.agents.<mux>.*`` subscription. Lifecycle is tied to
+the connection: when the user closes ``nc`` the subscription dies and
+when the ``Client`` object is garbage-collected the mux entry drops
+out of the cache automatically — no explicit teardown.
+
+Cancellation is **not** the mux's concern. The mux only routes
+:class:`~nats.aio.msg.Msg` objects from inbox-tail token to per-stream
+queue. Per-stream cancellation (``Agents.close()``,
+``Agent.prompt()`` early bailout) is handled by the consumer in
+:meth:`~synadia_ai.agents.agent.Agent._stream_prompt` via a
+``close_event`` watcher task — the same separation TS uses between
+``requestMany`` (transport) and ``closeSignal`` (cancellation).
 
 When ``nats-py`` ships ``request_many`` upstream, this module is meant
-to be **deleted** — :meth:`Agent._stream_prompt` is the single call site
-to migrate. The migration plan is tracked in
-`client-sdk/python/CHANGELOG.md` under the entry that introduced this
-module; track the upstream feature at
+to be **deleted** wholesale —
+:meth:`~synadia_ai.agents.agent.Agent._stream_prompt` is the single
+call site to migrate. Track the upstream feature at
 [`nats-io/nats.py`](https://github.com/nats-io/nats.py).
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
-from typing import TYPE_CHECKING, Final
+import weakref
+from typing import TYPE_CHECKING
 
 from ._inbox import SDK_INBOX_PREFIX, _nuid
 from ._logging import get_logger
-from .errors import AgentsClosedError
 
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATSClient
@@ -45,28 +55,19 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
-# Sentinel object placed into a per-stream queue when :meth:`MuxInbox.close`
-# fires. The consumer (:meth:`Agent._stream_prompt`) recognises it via
-# ``is`` identity and raises a clean cancellation error instead of waiting
-# for the inactivity timeout against a torn-down subscription.
-_AGENTS_CLOSED: Final[object] = object()
-
-
 class MuxInbox:
-    """One shared reply-inbox subscription, routed per stream by token.
+    """Shared reply-inbox subscription for one NATS connection.
 
-    Owned by an :class:`Agents` instance (one per process, normally).
-    Lazy-started: the SUB+flush is paid on the first :meth:`register`,
-    so :class:`Agents` instances that only do discovery never open a
-    reply-inbox subscription. Re-entrancy on :meth:`start` and
-    :meth:`close` is safe and idempotent.
+    Routed per stream by inbox-tail token. Construct via
+    :func:`mux_for` rather than directly so every caller on the same
+    connection gets the same instance.
 
     Wire layout::
 
-        SUB  _INBOX.agents.<mux-nuid>.*    1  (one per Agents)
+        SUB  _INBOX.agents.<mux-nuid>.*    1  (one per connection)
         PUB  agents.prompt.{a}.{o}.{n}     -> reply=_INBOX.agents.<mux>.<token>
 
-    Tokens are nuids (``nats.nuid``), globally unique within the
+    Tokens are NATS nuids (``nats.nuid``), globally unique within the
     process — no token reuse, so a stale chunk arriving after a stream
     has been unregistered routes nowhere and is silently dropped at
     DEBUG.
@@ -75,21 +76,21 @@ class MuxInbox:
     def __init__(self, nc: NATSClient) -> None:
         self._nc = nc
         # The mux nuid lives between the prefix and the per-stream token
-        # — it isolates this :class:`Agents` instance from any other
-        # caller sharing the same ``_INBOX.agents.>`` permission grant.
+        # — it isolates this connection's caller-side reply subjects
+        # from any other client account that shares the
+        # ``_INBOX.agents.>`` permission grant.
         self._inbox_prefix = f"{SDK_INBOX_PREFIX}.{_nuid.next().decode()}"
         self._sub: Subscription | None = None
-        self._routes: dict[str, asyncio.Queue[Msg | object]] = {}
+        # Queue is typed `object` because consumers (currently
+        # ``agent.py``) push their own per-stream cancellation sentinels
+        # alongside the wire :class:`~nats.aio.msg.Msg` values the mux
+        # dispatches. Consumers disambiguate by ``is`` identity at read.
+        self._routes: dict[str, asyncio.Queue[object]] = {}
         # `_started` flips True after the first successful start(); used
         # to make start() idempotent without re-subscribing.
         self._started = False
-        # `_closed` flips True at the start of close() — *before* the
-        # sentinel broadcast — so a concurrent register() either races
-        # in first (and gets the sentinel via close()'s sweep) or races
-        # in second (and raises AgentsClosedError). See plan §race #7.
-        self._closed = False
-        # Held across check-then-mutate sections to keep close() and
-        # register() linearly ordered against each other.
+        # Serialises start() against itself; concurrent first prompts
+        # race the SUB+flush exactly once.
         self._lock = asyncio.Lock()
 
     @property
@@ -107,10 +108,6 @@ class MuxInbox:
             return
         async with self._lock:
             if self._started:  # second-check inside the lock
-                return
-            if self._closed:
-                # Don't resurrect a torn-down inbox — surfaces as a
-                # clean error from register().
                 return
             wildcard = f"{self._inbox_prefix}.*"
             self._sub = await self._nc.subscribe(wildcard, cb=self._on_msg)
@@ -144,19 +141,9 @@ class MuxInbox:
         Returns ``(token, queue)``. The caller publishes its request
         with ``reply=mux.reply_subject_for(token)`` and pulls inbound
         chunks from ``queue``. After the stream completes (or is
-        cancelled), the caller MUST call :meth:`unregister` to free the
-        slot.
-
-        The check-and-insert is synchronous — no awaits between the
-        ``self._closed`` test and the dict assignment — so a concurrent
-        :meth:`close` either ran first (and this raises
-        :class:`AgentsClosedError`) or runs second (and the sentinel
-        broadcast in close() finds the token).
+        cancelled), the caller MUST call :meth:`unregister` to free
+        the slot.
         """
-        if self._closed:
-            raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
-        # Shared module-level NUID; nuids are globally unique within the
-        # process — no token collision risk across concurrent prompts.
         token = _nuid.next().decode()
         queue: asyncio.Queue[object] = asyncio.Queue()
         self._routes[token] = queue
@@ -166,37 +153,32 @@ class MuxInbox:
         """Drop the routing entry for ``token``. Idempotent."""
         self._routes.pop(token, None)
 
-    async def close(self) -> None:
-        """Tear down. Broadcasts a sentinel to every live queue, then unsubscribes.
 
-        Idempotent. After :meth:`close` returns, :meth:`register` raises
-        :class:`AgentsClosedError` on every subsequent call.
-        """
-        if self._closed:
-            return
-        async with self._lock:
-            if self._closed:
-                return
-            self._closed = True
-            # 1) Broadcast first so every consumer that's blocked on
-            #    queue.get() unblocks promptly. Use put_nowait — the
-            #    queue is unbounded, this never blocks.
-            for queue in list(self._routes.values()):
-                queue.put_nowait(_AGENTS_CLOSED)
-            self._routes.clear()
-            # 2) Then drop the subscription. Order matters: if we
-            #    unsubscribed first, an inbound message could try to
-            #    enqueue against a queue we're about to abandon.
-            sub = self._sub
-            self._sub = None
-        if sub is not None:
-            with contextlib.suppress(Exception):
-                await sub.unsubscribe()
+# Process-global cache: one MuxInbox per NATS connection. WeakKeyDictionary
+# means the entry drops when the user's ``Client`` object is GC'd, so the
+# SDK never holds a connection alive longer than the user does.
+_MUX_CACHE: weakref.WeakKeyDictionary[NATSClient, MuxInbox] = weakref.WeakKeyDictionary()
 
 
-def is_agents_closed_sentinel(value: object) -> bool:
-    """``True`` iff ``value`` is the close-broadcast sentinel placed in queues."""
-    return value is _AGENTS_CLOSED
+def mux_for(nc: NATSClient) -> MuxInbox:
+    """Return the singleton :class:`MuxInbox` for ``nc``.
+
+    Lazy-initialised on first call per connection. Subsequent calls on
+    the same connection return the same instance, so multiple
+    :class:`~synadia_ai.agents.Agents` and directly-constructed
+    :class:`~synadia_ai.agents.Agent` handles share one
+    ``_INBOX.agents.<mux>.*`` subscription. Mirrors the TS SDK's
+    ``nc.requestMany`` shape, where the mux belongs to the connection
+    and every caller picks it up automatically.
+
+    Single-threaded asyncio + sync check-and-insert means concurrent
+    first calls are safe without a lock.
+    """
+    mux = _MUX_CACHE.get(nc)
+    if mux is None:
+        mux = MuxInbox(nc)
+        _MUX_CACHE[nc] = mux
+    return mux
 
 
-__all__ = ["MuxInbox", "is_agents_closed_sentinel"]
+__all__ = ["MuxInbox", "mux_for"]

--- a/client-sdk/python/src/synadia_ai/agents/_mux.py
+++ b/client-sdk/python/src/synadia_ai/agents/_mux.py
@@ -19,9 +19,13 @@ of :func:`mux_for` against the same ``nc`` gets the same instance, so
 multiple :class:`~synadia_ai.agents.Agents` (or directly-constructed
 :class:`~synadia_ai.agents.Agent` handles) on the same connection
 share one ``_INBOX.agents.<mux>.*`` subscription. Lifecycle is tied to
-the connection: when the user closes ``nc`` the subscription dies and
-when the ``Client`` object is garbage-collected the mux entry drops
-out of the cache automatically — no explicit teardown.
+the connection: when the user closes ``nc`` the subscription dies, and
+when *every* strong reference to the ``Client`` object is dropped the
+weak-keyed cache entry is collected automatically — no explicit
+teardown. Note the mux itself holds ``self._nc`` strongly, so the
+cache only frees once the user (and any other code path) has released
+their references too; with a long-lived caller this means the entry
+persists for the lifetime of the process, by design.
 
 Cancellation is **not** the mux's concern. The mux only routes
 :class:`~nats.aio.msg.Msg` objects from inbox-tail token to per-stream
@@ -41,6 +45,7 @@ call site to migrate. Track the upstream feature at
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import weakref
 from typing import TYPE_CHECKING
 
@@ -103,17 +108,33 @@ class MuxInbox:
         return f"{self._inbox_prefix}.{token}"
 
     async def start(self) -> None:
-        """Subscribe + flush. Idempotent; safe to call from every prompt."""
+        """Subscribe + flush. Idempotent; safe to call from every prompt.
+
+        If ``flush()`` raises after ``subscribe()`` has already returned
+        a live :class:`~nats.aio.subscription.Subscription`, the partial
+        sub is unsubscribed before the exception propagates. Otherwise a
+        retry on the next prompt would call ``subscribe()`` again and
+        overwrite ``self._sub``, leaking the original subscription on
+        the broker until ``nc`` is closed.
+        """
         if self._started:
             return
         async with self._lock:
             if self._started:  # second-check inside the lock
                 return
             wildcard = f"{self._inbox_prefix}.*"
-            self._sub = await self._nc.subscribe(wildcard, cb=self._on_msg)
-            # Flush so the SUB lands at the broker before any caller
-            # publishes a request that names this inbox as its reply.
-            await self._nc.flush()
+            sub = await self._nc.subscribe(wildcard, cb=self._on_msg)
+            try:
+                # Flush so the SUB lands at the broker before any caller
+                # publishes a request that names this inbox as its reply.
+                await self._nc.flush()
+            except BaseException:
+                # Roll back the half-started state so a retry from the
+                # next prompt can subscribe cleanly.
+                with contextlib.suppress(Exception):
+                    await sub.unsubscribe()
+                raise
+            self._sub = sub
             self._started = True
 
     async def _on_msg(self, msg: Msg) -> None:

--- a/client-sdk/python/src/synadia_ai/agents/_mux.py
+++ b/client-sdk/python/src/synadia_ai/agents/_mux.py
@@ -14,26 +14,25 @@ whose internal mux is automatically shared by every caller of the same
 This module is the API-level analogue, intentionally mirroring the TS
 shape: **one** ``MuxInbox`` per :class:`~nats.aio.client.Client`,
 created on first prompt and held in a process-global
-:class:`weakref.WeakKeyDictionary` keyed by the connection. Every caller
-of :func:`mux_for` against the same ``nc`` gets the same instance, so
-multiple :class:`~synadia_ai.agents.Agents` (or directly-constructed
-:class:`~synadia_ai.agents.Agent` handles) on the same connection
-share one ``_INBOX.agents.<mux>.*`` subscription. Lifecycle is tied to
-the connection: when the user closes ``nc`` the subscription dies, and
-when *every* strong reference to the ``Client`` object is dropped the
-weak-keyed cache entry is collected automatically — no explicit
-teardown. Note the mux itself holds ``self._nc`` strongly, so the
-cache only frees once the user (and any other code path) has released
-their references too; with a long-lived caller this means the entry
-persists for the lifetime of the process, by design.
+:class:`weakref.WeakKeyDictionary` keyed by the connection. The mux keeps
+only a weak reference back to that connection, so every caller of
+:func:`mux_for` against the same ``nc`` gets the same instance without
+the cache keeping closed/dropped ``Client`` objects alive. Multiple
+:class:`~synadia_ai.agents.Agents` (or directly-constructed
+:class:`~synadia_ai.agents.Agent` handles) on the same connection share
+one ``_INBOX.agents.<mux>.*`` subscription. Lifecycle is tied to the
+connection: when the user closes ``nc`` the subscription dies, and when
+*every* strong reference to the ``Client`` object is dropped the
+weak-keyed cache entry is collected automatically — no explicit teardown.
 
 Cancellation is **not** the mux's concern. The mux only routes
 :class:`~nats.aio.msg.Msg` objects from inbox-tail token to per-stream
-queue. Per-stream cancellation (``Agents.close()``,
-``Agent.prompt()`` early bailout) is handled by the consumer in
-:meth:`~synadia_ai.agents.agent.Agent._stream_prompt` via a
-``close_event`` watcher task — the same separation TS uses between
-``requestMany`` (transport) and ``closeSignal`` (cancellation).
+queue. Per-stream cancellation and absolute-deadline handling
+(``Agents.close()``, ``Agent.prompt()`` early bailout, ``max_wait_s``)
+are handled by the consumer in
+:meth:`~synadia_ai.agents.agent.Agent._stream_prompt` — the same
+separation TS uses between ``requestMany`` (transport) and
+``closeSignal`` / max-wait control (lifecycle).
 
 When ``nats-py`` ships ``request_many`` upstream, this module is meant
 to be **deleted** wholesale —
@@ -47,6 +46,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import weakref
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from ._inbox import SDK_INBOX_PREFIX, _nuid
@@ -55,9 +56,14 @@ from ._logging import get_logger
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATSClient
     from nats.aio.msg import Msg
-    from nats.aio.subscription import Subscription
 
 log = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class _Route:
+    queue: asyncio.Queue[object]
+    on_msg: Callable[[Msg], None] | None = None
 
 
 class MuxInbox:
@@ -79,18 +85,16 @@ class MuxInbox:
     """
 
     def __init__(self, nc: NATSClient) -> None:
-        self._nc = nc
+        self._nc_ref = weakref.ref(nc)
         # The mux nuid lives between the prefix and the per-stream token
         # — it isolates this connection's caller-side reply subjects
         # from any other client account that shares the
         # ``_INBOX.agents.>`` permission grant.
         self._inbox_prefix = f"{SDK_INBOX_PREFIX}.{_nuid.next().decode()}"
-        self._sub: Subscription | None = None
-        # Queue is typed `object` because consumers (currently
-        # ``agent.py``) push their own per-stream cancellation sentinels
-        # alongside the wire :class:`~nats.aio.msg.Msg` values the mux
-        # dispatches. Consumers disambiguate by ``is`` identity at read.
-        self._routes: dict[str, asyncio.Queue[object]] = {}
+        # Queue is typed `object` because consumers may race it against
+        # their own lifecycle events. The mux itself only enqueues wire
+        # :class:`~nats.aio.msg.Msg` values.
+        self._routes: dict[str, _Route] = {}
         # `_started` flips True after the first successful start(); used
         # to make start() idempotent without re-subscribing.
         self._started = False
@@ -114,27 +118,29 @@ class MuxInbox:
         a live :class:`~nats.aio.subscription.Subscription`, the partial
         sub is unsubscribed before the exception propagates. Otherwise a
         retry on the next prompt would call ``subscribe()`` again and
-        overwrite ``self._sub``, leaking the original subscription on
-        the broker until ``nc`` is closed.
+        leak the original subscription on the broker until ``nc`` is
+        closed.
         """
         if self._started:
             return
         async with self._lock:
             if self._started:  # second-check inside the lock
                 return
+            nc = self._nc_ref()
+            if nc is None:
+                raise RuntimeError("NATS connection was released before mux start")
             wildcard = f"{self._inbox_prefix}.*"
-            sub = await self._nc.subscribe(wildcard, cb=self._on_msg)
+            sub = await nc.subscribe(wildcard, cb=self._on_msg)
             try:
                 # Flush so the SUB lands at the broker before any caller
                 # publishes a request that names this inbox as its reply.
-                await self._nc.flush()
+                await nc.flush()
             except BaseException:
                 # Roll back the half-started state so a retry from the
                 # next prompt can subscribe cleanly.
                 with contextlib.suppress(Exception):
                     await sub.unsubscribe()
                 raise
-            self._sub = sub
             self._started = True
 
     async def _on_msg(self, msg: Msg) -> None:
@@ -150,24 +156,33 @@ class MuxInbox:
         subject: str = msg.subject
         last_dot = subject.rfind(".")
         token = subject[last_dot + 1 :] if last_dot >= 0 else subject
-        queue = self._routes.get(token)
-        if queue is None:
+        route = self._routes.get(token)
+        if route is None:
             log.debug("mux: dropping reply for unregistered token (subject=%s)", subject)
             return
-        queue.put_nowait(msg)
+        if route.on_msg is not None:
+            try:
+                route.on_msg(msg)
+            except Exception:
+                log.exception("mux: route message hook failed (subject=%s)", subject)
+        route.queue.put_nowait(msg)
 
-    def register(self) -> tuple[str, asyncio.Queue[object]]:
+    def register(
+        self, *, on_msg: Callable[[Msg], None] | None = None
+    ) -> tuple[str, asyncio.Queue[object]]:
         """Reserve a per-stream token + queue.
 
         Returns ``(token, queue)``. The caller publishes its request
         with ``reply=mux.reply_subject_for(token)`` and pulls inbound
-        chunks from ``queue``. After the stream completes (or is
-        cancelled), the caller MUST call :meth:`unregister` to free
-        the slot.
+        chunks from ``queue``. ``on_msg`` is an optional synchronous
+        hook for arrival-side lifecycle bookkeeping such as cancelling
+        a max-wait timer when the caller recognises a terminator. After
+        the stream completes (or is cancelled), the caller MUST call
+        :meth:`unregister` to free the slot.
         """
         token = _nuid.next().decode()
         queue: asyncio.Queue[object] = asyncio.Queue()
-        self._routes[token] = queue
+        self._routes[token] = _Route(queue=queue, on_msg=on_msg)
         return token, queue
 
     def unregister(self, token: str) -> None:

--- a/client-sdk/python/src/synadia_ai/agents/_mux.py
+++ b/client-sdk/python/src/synadia_ai/agents/_mux.py
@@ -1,0 +1,202 @@
+"""Per-:class:`Agents` shared mux inbox for prompt-stream replies.
+
+INTERIM-NATSPY-REQUEST-MANY: this module is the Python-side workaround
+for ``nats-py``'s missing ``request_many`` primitive. The TypeScript SDK
+(see PR
+[synadia-ai/synadia-agents#66](https://github.com/synadia-ai/synadia-agents/pull/66))
+drives prompt streams through ``nc.requestMany(subject, payload, {
+strategy: "sentinel", maxWait })`` so replies route through the
+connection's shared mux inbox instead of a fresh per-stream
+``_INBOX.agents.>`` subscription. ``nats-py`` has no equivalent — its
+internal mux (``_resp_map`` / ``_resp_sub_prefix`` in
+``nats/aio/client.py``) tracks one ``Future`` per token, not iterators.
+
+This module is the API-level analogue: one persistent
+``_INBOX.agents.<mux>.*`` subscription per :class:`Agents`, with messages
+routed by inbox-tail token to per-stream queues. Callers get the
+wire-traffic savings (one SUB+flush per :class:`Agents` instance instead
+of one per prompt) and the parity API on the prompt side
+(``max_wait_s``, :class:`StreamMaxWaitExceededError`,
+cancellation-safe teardown).
+
+When ``nats-py`` ships ``request_many`` upstream, this module is meant
+to be **deleted** — :meth:`Agent._stream_prompt` is the single call site
+to migrate. The migration plan is tracked in
+`client-sdk/python/CHANGELOG.md` under the entry that introduced this
+module; track the upstream feature at
+[`nats-io/nats.py`](https://github.com/nats-io/nats.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import TYPE_CHECKING, Final
+
+from ._inbox import SDK_INBOX_PREFIX, _nuid
+from ._logging import get_logger
+from .errors import AgentsClosedError
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
+    from nats.aio.subscription import Subscription
+
+log = get_logger(__name__)
+
+
+# Sentinel object placed into a per-stream queue when :meth:`MuxInbox.close`
+# fires. The consumer (:meth:`Agent._stream_prompt`) recognises it via
+# ``is`` identity and raises a clean cancellation error instead of waiting
+# for the inactivity timeout against a torn-down subscription.
+_AGENTS_CLOSED: Final[object] = object()
+
+
+class MuxInbox:
+    """One shared reply-inbox subscription, routed per stream by token.
+
+    Owned by an :class:`Agents` instance (one per process, normally).
+    Lazy-started: the SUB+flush is paid on the first :meth:`register`,
+    so :class:`Agents` instances that only do discovery never open a
+    reply-inbox subscription. Re-entrancy on :meth:`start` and
+    :meth:`close` is safe and idempotent.
+
+    Wire layout::
+
+        SUB  _INBOX.agents.<mux-nuid>.*    1  (one per Agents)
+        PUB  agents.prompt.{a}.{o}.{n}     -> reply=_INBOX.agents.<mux>.<token>
+
+    Tokens are nuids (``nats.nuid``), globally unique within the
+    process — no token reuse, so a stale chunk arriving after a stream
+    has been unregistered routes nowhere and is silently dropped at
+    DEBUG.
+    """
+
+    def __init__(self, nc: NATSClient) -> None:
+        self._nc = nc
+        # The mux nuid lives between the prefix and the per-stream token
+        # — it isolates this :class:`Agents` instance from any other
+        # caller sharing the same ``_INBOX.agents.>`` permission grant.
+        self._inbox_prefix = f"{SDK_INBOX_PREFIX}.{_nuid.next().decode()}"
+        self._sub: Subscription | None = None
+        self._routes: dict[str, asyncio.Queue[Msg | object]] = {}
+        # `_started` flips True after the first successful start(); used
+        # to make start() idempotent without re-subscribing.
+        self._started = False
+        # `_closed` flips True at the start of close() — *before* the
+        # sentinel broadcast — so a concurrent register() either races
+        # in first (and gets the sentinel via close()'s sweep) or races
+        # in second (and raises AgentsClosedError). See plan §race #7.
+        self._closed = False
+        # Held across check-then-mutate sections to keep close() and
+        # register() linearly ordered against each other.
+        self._lock = asyncio.Lock()
+
+    @property
+    def inbox_prefix(self) -> str:
+        """``_INBOX.agents.<mux-nuid>`` — the prefix this inbox listens on."""
+        return self._inbox_prefix
+
+    def reply_subject_for(self, token: str) -> str:
+        """Return the per-stream reply subject for a registered token."""
+        return f"{self._inbox_prefix}.{token}"
+
+    async def start(self) -> None:
+        """Subscribe + flush. Idempotent; safe to call from every prompt."""
+        if self._started:
+            return
+        async with self._lock:
+            if self._started:  # second-check inside the lock
+                return
+            if self._closed:
+                # Don't resurrect a torn-down inbox — surfaces as a
+                # clean error from register().
+                return
+            wildcard = f"{self._inbox_prefix}.*"
+            self._sub = await self._nc.subscribe(wildcard, cb=self._on_msg)
+            # Flush so the SUB lands at the broker before any caller
+            # publishes a request that names this inbox as its reply.
+            await self._nc.flush()
+            self._started = True
+
+    async def _on_msg(self, msg: Msg) -> None:
+        """Route an inbound reply to its per-stream queue by tail token.
+
+        Runs on the nats-py per-subscription dispatch task, which
+        catches and reports exceptions from this callback to the
+        connection's ``error_cb`` rather than tearing down the
+        subscription. A late chunk for an unregistered token (e.g. a
+        §9.3 trailing terminator after the consumer already raised on
+        an error frame) routes nowhere and is dropped at DEBUG.
+        """
+        subject: str = msg.subject
+        last_dot = subject.rfind(".")
+        token = subject[last_dot + 1 :] if last_dot >= 0 else subject
+        queue = self._routes.get(token)
+        if queue is None:
+            log.debug("mux: dropping reply for unregistered token (subject=%s)", subject)
+            return
+        queue.put_nowait(msg)
+
+    def register(self) -> tuple[str, asyncio.Queue[object]]:
+        """Reserve a per-stream token + queue.
+
+        Returns ``(token, queue)``. The caller publishes its request
+        with ``reply=mux.reply_subject_for(token)`` and pulls inbound
+        chunks from ``queue``. After the stream completes (or is
+        cancelled), the caller MUST call :meth:`unregister` to free the
+        slot.
+
+        The check-and-insert is synchronous — no awaits between the
+        ``self._closed`` test and the dict assignment — so a concurrent
+        :meth:`close` either ran first (and this raises
+        :class:`AgentsClosedError`) or runs second (and the sentinel
+        broadcast in close() finds the token).
+        """
+        if self._closed:
+            raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
+        # Shared module-level NUID; nuids are globally unique within the
+        # process — no token collision risk across concurrent prompts.
+        token = _nuid.next().decode()
+        queue: asyncio.Queue[object] = asyncio.Queue()
+        self._routes[token] = queue
+        return token, queue
+
+    def unregister(self, token: str) -> None:
+        """Drop the routing entry for ``token``. Idempotent."""
+        self._routes.pop(token, None)
+
+    async def close(self) -> None:
+        """Tear down. Broadcasts a sentinel to every live queue, then unsubscribes.
+
+        Idempotent. After :meth:`close` returns, :meth:`register` raises
+        :class:`AgentsClosedError` on every subsequent call.
+        """
+        if self._closed:
+            return
+        async with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            # 1) Broadcast first so every consumer that's blocked on
+            #    queue.get() unblocks promptly. Use put_nowait — the
+            #    queue is unbounded, this never blocks.
+            for queue in list(self._routes.values()):
+                queue.put_nowait(_AGENTS_CLOSED)
+            self._routes.clear()
+            # 2) Then drop the subscription. Order matters: if we
+            #    unsubscribed first, an inbound message could try to
+            #    enqueue against a queue we're about to abandon.
+            sub = self._sub
+            self._sub = None
+        if sub is not None:
+            with contextlib.suppress(Exception):
+                await sub.unsubscribe()
+
+
+def is_agents_closed_sentinel(value: object) -> bool:
+    """``True`` iff ``value`` is the close-broadcast sentinel placed in queues."""
+    return value is _AGENTS_CLOSED
+
+
+__all__ = ["MuxInbox", "is_agents_closed_sentinel"]

--- a/client-sdk/python/src/synadia_ai/agents/_mux.py
+++ b/client-sdk/python/src/synadia_ai/agents/_mux.py
@@ -209,6 +209,17 @@ def mux_for(nc: NATSClient) -> MuxInbox:
 
     Single-threaded asyncio + sync check-and-insert means concurrent
     first calls are safe without a lock.
+
+    .. note::
+
+       Single-event-loop assumption. ``_MUX_CACHE`` is module-global,
+       and :class:`MuxInbox` captures an :class:`asyncio.Lock` at
+       construction time bound to whichever loop is running on the
+       first call. Sharing one ``Client`` across event loops in
+       different threads (unusual but legal in :mod:`nats-py`) would
+       cross loops on the cached lock and is not supported. The SDK
+       is otherwise single-loop-asyncio in shape, so this is a
+       documentation contract, not a runtime check.
     """
     mux = _MUX_CACHE.get(nc)
     if mux is None:

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -347,9 +347,8 @@ class Agent:
         if close_task is not None:
             wait_set.add(close_task)
 
-        pending: set[asyncio.Task[object] | asyncio.Task[bool]] = set()
         try:
-            done, pending = await asyncio.wait(
+            done, _pending = await asyncio.wait(
                 wait_set,
                 timeout=timeout,
                 return_when=asyncio.FIRST_COMPLETED,
@@ -370,10 +369,11 @@ class Agent:
                 raise StreamMaxWaitExceededError(max_wait_s)
             return item
         finally:
-            for task in pending:
-                task.cancel()
-                with contextlib.suppress(BaseException):
-                    await task
+            for task in wait_set:
+                if not task.done():
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
 
     def _raise_if_closed(self) -> None:
         """Raise :class:`AgentsClosedError` if the owning Agents has closed.

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -499,8 +499,7 @@ class Agent:
             # deterministically rather than waiting on the queue's
             # own GC, which matters for streams that exit early with
             # large chunks still buffered.
-            if max_wait_handle is not None:
-                max_wait_handle.cancel()
+            max_wait_handle.cancel()
             mux.unregister(token)
             while not queue.empty():
                 queue.get_nowait()

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -12,16 +12,15 @@ distribution :mod:`synadia_ai.agent_service`.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeAlias
 
-from ._inbox import new_inbox
 from ._logging import get_logger
+from ._mux import MuxInbox, is_agents_closed_sentinel
 from .discovery import AgentInfo, EndpointInfo
 from .envelope import Attachment, Envelope, encode
-from .errors import ProtocolError
+from .errors import ProtocolError, StreamMaxWaitExceededError, StreamStalledError
 from .messages import QueryChunk, ResponseChunk, StatusChunk, decode_chunk
 from .validation import (
     assert_attachments_allowed,
@@ -31,6 +30,7 @@ from .validation import (
 
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
 
 log = get_logger(__name__)
 
@@ -38,6 +38,16 @@ log = get_logger(__name__)
 # Default per-stream inactivity timeout (§6.6) — 60 seconds. Mirrors the
 # TS SDK's DEFAULT_STREAM_INACTIVITY_TIMEOUT_MS.
 DEFAULT_STREAM_INACTIVITY_TIMEOUT_S: float = 60.0
+
+
+# Default absolute ceiling on a prompt stream — 10 minutes. Distinct from
+# the §6.6 per-chunk inactivity timer: the inactivity timer resets every
+# message, so a stream that emits a steady trickle of chunks could in
+# principle run forever. ``max_wait_s`` is the safety net for that case
+# and for silent reconnect windows that exceed the inactivity reset
+# cycle. Mirrors the TS SDK's ``DEFAULT_PROMPT_MAX_WAIT_MS`` from
+# `client-sdk/typescript`'s PR #66.
+DEFAULT_PROMPT_MAX_WAIT_S: float = 600.0
 
 
 @dataclass(frozen=True)
@@ -100,12 +110,23 @@ class Agent:
         info: AgentInfo,
         *,
         stream_inactivity_timeout: float = DEFAULT_STREAM_INACTIVITY_TIMEOUT_S,
+        prompt_max_wait_s: float = DEFAULT_PROMPT_MAX_WAIT_S,
         close_event: asyncio.Event | None = None,
+        mux: MuxInbox | None = None,
     ) -> None:
         self._nc = nc
         self._info = info
         self._default_inactivity_timeout = stream_inactivity_timeout
+        self._default_max_wait_s = prompt_max_wait_s
         self._close_event = close_event
+        # When `mux` is None — i.e. the handle was constructed outside
+        # `Agents` (e.g. from a heartbeat + `$SRV.INFO.agents.{id}`
+        # direct lookup) — we lazy-allocate a private mux on the first
+        # prompt(). All subsequent prompts on this Agent share that
+        # subscription, so the wire-economy property still holds even
+        # for direct callers; the SUB itself rides on `nc` and is
+        # cleaned up when the caller closes the connection.
+        self._mux = mux
 
     # --- flat read-only identity / capability fields -------------------
 
@@ -182,6 +203,7 @@ class Agent:
         *,
         attachments: list[Attachment] | None = None,
         timeout: float | None = None,
+        max_wait_s: float | None = None,
     ) -> AsyncIterator[StreamMessage]:
         """Send a prompt and return an async iterator of streamed messages.
 
@@ -197,6 +219,16 @@ class Agent:
         ``timeout`` is the per-message inactivity timeout in seconds;
         defaults to the value passed to the owning :class:`Agents` (60 s
         out of the box, §6.6).
+
+        ``max_wait_s`` is the absolute ceiling on the whole stream —
+        distinct from ``timeout``, which resets on every received chunk.
+        Defaults to the value passed to the owning :class:`Agents`
+        (10 minutes out of the box). Mirrors the TS SDK's
+        ``PromptOptions.maxWaitMs`` from PR #66. On expiry the iterator
+        raises :class:`StreamMaxWaitExceededError`; the inactivity-gap
+        path raises :class:`StreamStalledError`. Both inherit from
+        :class:`ProtocolError` so existing catch-broadly callers keep
+        working.
 
         §5.4 pre-publish validation runs synchronously before any wire I/O.
         Failures raise:
@@ -251,48 +283,86 @@ class Agent:
         assert_within_max_payload(len(encoded), ep.max_payload_bytes, conn_limit)
 
         effective_timeout = timeout if timeout is not None else self._default_inactivity_timeout
-        return self._stream_prompt(envelope, encoded, effective_timeout)
+        effective_max_wait = max_wait_s if max_wait_s is not None else self._default_max_wait_s
+        return self._stream_prompt(envelope, encoded, effective_timeout, effective_max_wait)
+
+    async def _wait_for_chunk(
+        self,
+        queue: asyncio.Queue[object],
+        *,
+        timeout: float,
+        max_wait_s: float,
+        deadline: float,
+        reply: str,
+        loop: asyncio.AbstractEventLoop,
+    ) -> object:
+        """Pull the next item off ``queue`` or raise the appropriate timeout.
+
+        Splits the dual-timer logic out of :meth:`_stream_prompt` so the
+        per-chunk decode loop stays readable. ``StreamMaxWaitExceededError``
+        and ``StreamStalledError`` are disambiguated by which deadline
+        elapsed first; both inherit from :class:`ProtocolError` for back-
+        compat.
+        """
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise StreamMaxWaitExceededError(max_wait_s)
+        wait_for = min(timeout, remaining)
+        try:
+            return await asyncio.wait_for(queue.get(), timeout=wait_for)
+        except TimeoutError as exc:
+            if loop.time() >= deadline:
+                raise StreamMaxWaitExceededError(max_wait_s) from exc
+            log.warning("stream stalled on %s: no chunk within %.1fs", reply, timeout)
+            raise StreamStalledError(timeout, reply_subject=reply) from exc
 
     async def _stream_prompt(
-        self, envelope: Envelope, encoded: bytes, timeout: float
+        self, envelope: Envelope, encoded: bytes, timeout: float, max_wait_s: float
     ) -> AsyncIterator[StreamMessage]:
         del envelope  # retained for readability at the call site; not needed here
-        reply = new_inbox()
-        sub = await self._nc.subscribe(reply)
+        # Resolve the mux: shared (passed in by Agents) or private
+        # (lazy-allocated for direct-construction callers). The wire
+        # economy still holds — every Agent shares one SUB across all
+        # of its prompts, regardless of how it was built.
+        if self._mux is None:
+            self._mux = MuxInbox(self._nc)
+        mux = self._mux
+        await mux.start()  # idempotent; pays SUB+flush on the first prompt
+        token, queue = mux.register()
+        reply = mux.reply_subject_for(token)
         subject = self._info.prompt_endpoint.subject
-        # §6.6: per-chunk inactivity timeout. Honor the owning Agents.close()
-        # mid-wait — racing next_msg against close_event so teardown is
-        # observed promptly instead of after the full inactivity window.
-        close_task: asyncio.Task[bool] | None = (
-            asyncio.ensure_future(self._close_event.wait())
-            if self._close_event is not None
-            else None
-        )
+
+        # Absolute ceiling. ``loop.time()`` is monotonic so the deadline
+        # is robust against wall-clock skew.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max_wait_s
+
         try:
             await self._nc.publish(subject, encoded, reply=reply)
-            while True:
-                if close_task is not None and close_task.done():
-                    raise ProtocolError(
-                        f"prompt stream cancelled: owning Agents is closed (reply={reply})"
-                    )
-                next_task = asyncio.ensure_future(sub.next_msg(timeout=timeout))
-                wait_set = {next_task, close_task} if close_task is not None else {next_task}
-                done, _pending = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
-                if close_task is not None and close_task in done:
-                    next_task.cancel()
-                    with contextlib.suppress(BaseException):
-                        await next_task
-                    raise ProtocolError(
-                        f"prompt stream cancelled: owning Agents is closed (reply={reply})"
-                    )
-                try:
-                    msg = await next_task
-                except TimeoutError as exc:
-                    log.warning("stream stalled on %s: no chunk within %.1fs", reply, timeout)
-                    raise ProtocolError(
-                        f"stream stalled: no chunk received within {timeout}s on {reply}"
-                    ) from exc
+            # Race: cancel() / Agents.close() may have fired during the
+            # publish await. The mux's sentinel-broadcast lands in our
+            # queue, but if close fired *before* we publish we still
+            # want to fail fast rather than wait on a dead inbox.
+            if self._close_event is not None and self._close_event.is_set():
+                raise ProtocolError(
+                    f"prompt stream cancelled: owning Agents is closed (reply={reply})"
+                )
 
+            while True:
+                item = await self._wait_for_chunk(
+                    queue,
+                    timeout=timeout,
+                    max_wait_s=max_wait_s,
+                    deadline=deadline,
+                    reply=reply,
+                    loop=loop,
+                )
+                if is_agents_closed_sentinel(item):
+                    raise ProtocolError(
+                        f"prompt stream cancelled: owning Agents is closed (reply={reply})"
+                    )
+
+                msg: Msg = item  # type: ignore[assignment]
                 headers = msg.headers or {}
                 if "Nats-Service-Error-Code" in headers:
                     code = headers["Nats-Service-Error-Code"]
@@ -322,15 +392,11 @@ class Agent:
                 else:
                     yield chunk
         finally:
-            if close_task is not None and not close_task.done():
-                close_task.cancel()
-                with contextlib.suppress(BaseException):
-                    await close_task
-            with contextlib.suppress(Exception):
-                await sub.unsubscribe()
+            mux.unregister(token)
 
 
 __all__ = [
+    "DEFAULT_PROMPT_MAX_WAIT_S",
     "DEFAULT_STREAM_INACTIVITY_TIMEOUT_S",
     "Agent",
     "Query",

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -345,6 +345,40 @@ class Agent:
             log.warning("stream stalled on %s: no chunk within %.1fs", reply, timeout)
             raise StreamStalledError(timeout, reply_subject=reply) from exc
 
+    def _raise_if_closed(self) -> None:
+        """Raise :class:`AgentsClosedError` if the owning Agents has closed.
+
+        Called at every point in :meth:`_stream_prompt` that is still
+        pre-publish — top of method, and again immediately before the
+        publish, since ``mux.start()`` may await for a non-trivial
+        time on its first call (SUB + flush). Callers that have
+        already entered the cleanup ``try`` block rely on the
+        ``finally`` to drop the registered mux token.
+        """
+        if self._close_event is not None and self._close_event.is_set():
+            raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
+
+    def _arm_close_watcher(
+        self, queue: asyncio.Queue[object], token: str
+    ) -> asyncio.Task[None] | None:
+        """Wire the per-stream cancellation path immediately after publish.
+
+        If ``close_event`` already fired during the publish await, push
+        :data:`_CLOSE_SENTINEL` synchronously so the very first
+        ``queue.get()`` unblocks. Otherwise spawn the async watcher.
+        Returns the spawned task (or ``None`` for the no-watcher cases)
+        so :meth:`_stream_prompt` can cancel it in ``finally``.
+        """
+        if self._close_event is None:
+            return None
+        if self._close_event.is_set():
+            queue.put_nowait(_CLOSE_SENTINEL)
+            return None
+        return asyncio.create_task(
+            _close_to_sentinel(self._close_event, queue),
+            name=f"agents-close-watcher:{token}",
+        )
+
     async def _stream_prompt(
         self, envelope: Envelope, encoded: bytes, timeout: float, max_wait_s: float
     ) -> AsyncIterator[StreamMessage]:
@@ -352,40 +386,30 @@ class Agent:
         # Pre-flight: refuse outright if the owning Agents is already
         # closed. This catches the "called prompt() after close()" case
         # cleanly, before any wire I/O or mux state mutation.
-        if self._close_event is not None and self._close_event.is_set():
-            raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
+        self._raise_if_closed()
 
         # Per-nc mux singleton — shared across every Agent on the same
         # connection. See `_mux.py`'s INTERIM-NATSPY-REQUEST-MANY note.
         mux = mux_for(self._nc)
         await mux.start()  # idempotent; pays SUB+flush on the first prompt
         token, queue = mux.register()
-        reply = mux.reply_subject_for(token)
-        subject = self._info.prompt_endpoint.subject
-
-        # Absolute ceiling. ``loop.time()`` is monotonic so the deadline
-        # is robust against wall-clock skew.
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + max_wait_s
-
-        # Per-stream close watcher (only when wired up). When
-        # close_event fires, this task pushes a sentinel into our
-        # queue so the consumer's next ``queue.get()`` unblocks
-        # immediately — independent of the inactivity timeout. Mirrors
-        # the TS SDK's ``closeSignal: AbortSignal`` path under PR #66.
         close_watcher: asyncio.Task[None] | None = None
         try:
+            reply = mux.reply_subject_for(token)
+            subject = self._info.prompt_endpoint.subject
+
+            # Absolute ceiling. ``loop.time()`` is monotonic so the deadline
+            # is robust against wall-clock skew.
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + max_wait_s
+
+            # Re-check after the mux.start() await: close may have
+            # fired during the SUB+flush window. Bail before publishing
+            # rather than firing a request whose reply we won't consume.
+            self._raise_if_closed()
+
             await self._nc.publish(subject, encoded, reply=reply)
-            # Race: close_event may have fired during the publish await.
-            # Push the sentinel synchronously so the loop sees it on
-            # the very first iteration.
-            if self._close_event is not None and self._close_event.is_set():
-                queue.put_nowait(_CLOSE_SENTINEL)
-            elif self._close_event is not None:
-                close_watcher = asyncio.create_task(
-                    _close_to_sentinel(self._close_event, queue),
-                    name=f"agents-close-watcher:{token}",
-                )
+            close_watcher = self._arm_close_watcher(queue, token)
 
             while True:
                 item = await self._wait_for_chunk(
@@ -431,11 +455,23 @@ class Agent:
                 else:
                     yield chunk
         finally:
+            # Ordering matters: cancel the watcher first (no more
+            # sentinels can be pushed), then unregister the token (no
+            # more wire chunks will be routed here — _on_msg is sync
+            # body, so any in-flight call has already completed
+            # before this line returns), then drain anything that
+            # arrived between the consumer's last ``get()`` and now.
+            # This releases :class:`~nats.aio.msg.Msg` payloads
+            # deterministically rather than waiting on the queue's
+            # own GC, which matters for streams that exit early with
+            # large chunks still buffered.
             if close_watcher is not None and not close_watcher.done():
                 close_watcher.cancel()
                 with contextlib.suppress(BaseException):
                     await close_watcher
             mux.unregister(token)
+            while not queue.empty():
+                queue.get_nowait()
 
 
 __all__ = [

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -119,6 +119,8 @@ class Agent:
         prompt_max_wait_s: float = DEFAULT_PROMPT_MAX_WAIT_S,
         close_event: asyncio.Event | None = None,
     ) -> None:
+        if prompt_max_wait_s <= 0:
+            raise ValueError(f"prompt_max_wait_s must be > 0 (got {prompt_max_wait_s!r}).")
         self._nc = nc
         self._info = info
         self._default_inactivity_timeout = stream_inactivity_timeout
@@ -219,13 +221,16 @@ class Agent:
 
         ``max_wait_s`` is the absolute ceiling on the whole stream —
         distinct from ``timeout``, which resets on every received chunk.
-        Defaults to the value passed to the owning :class:`Agents`
-        (10 minutes out of the box). Mirrors the TS SDK's
-        ``PromptOptions.maxWaitMs`` from PR #66. On expiry the iterator
-        raises :class:`StreamMaxWaitExceededError`; the inactivity-gap
-        path raises :class:`StreamStalledError`. Both inherit from
-        :class:`ProtocolError` so existing catch-broadly callers keep
-        working.
+        Must be a positive float; ``None`` falls back to the value passed
+        to the owning :class:`Agents` (10 minutes out of the box).
+        Mirrors the TS SDK's ``PromptOptions.maxWaitMs`` from PR #66.
+        On expiry the iterator raises :class:`StreamMaxWaitExceededError`;
+        the inactivity-gap path raises :class:`StreamStalledError`. Both
+        inherit from :class:`ProtocolError` so existing catch-broadly
+        callers keep working. Passing ``max_wait_s <= 0`` raises
+        :class:`ValueError` synchronously — there is no "no limit"
+        sentinel, since an unbounded prompt stream is the exact failure
+        mode this ceiling exists to prevent.
 
         §5.4 pre-publish validation runs synchronously before any wire I/O.
         Failures raise:
@@ -235,6 +240,7 @@ class Agent:
           ``attachments_ok=false`` (§5.4).
         - :class:`PayloadTooLargeError` — envelope exceeds ``max_payload``
           (§5.4).
+        - :class:`ValueError` — ``max_wait_s`` is not strictly positive.
 
         The iterator yields :class:`ResponseChunk` / :class:`StatusChunk` as
         the agent emits them and :class:`Query` when the agent asks a
@@ -260,6 +266,11 @@ class Agent:
           deterministically. A bare ``break`` defers cleanup to the
           generator finalizer (works, but the slot lingers until GC).
         """
+        if max_wait_s is not None and max_wait_s <= 0:
+            raise ValueError(
+                f"max_wait_s must be > 0 (got {max_wait_s!r}); pass None to use the default."
+            )
+
         if isinstance(text, Envelope):
             merged_attachments: list[Attachment] | None
             if attachments:
@@ -312,6 +323,17 @@ class Agent:
         behind FIFO backlog and max-wait does not drain arbitrary chunks
         after its deadline. The inactivity timeout remains a per-read
         gap detector and resets after every delivered item.
+
+        Per-iteration task churn (``queue_task`` plus ``max_wait_task``
+        and optionally ``close_task``, each cancelled on the loser side
+        of the ``asyncio.wait`` race) is intentional. Lifting the
+        event-wait tasks into :meth:`_stream_prompt` and reusing them
+        across iterations would save a couple of ``create_task`` calls
+        per slow-path read but at the cost of cleanup locality — the
+        ``finally`` here is the single place that guarantees no task
+        outlives the read it served. AI-stream chunk rates make the
+        allocation cost invisible; the locality is what keeps the
+        close-race contract auditable.
         """
         self._raise_if_cancelled(reply)
         if max_wait_event.is_set():
@@ -406,17 +428,14 @@ class Agent:
         # connection. See `_mux.py`'s INTERIM-NATSPY-REQUEST-MANY note.
         mux = mux_for(self._nc)
         await mux.start()  # idempotent; pays SUB+flush on the first prompt
+        # `max_wait_s > 0` is enforced at the public boundary (Agent.prompt
+        # and the constructors), so we treat it as an invariant here.
         loop = asyncio.get_running_loop()
         max_wait_event = asyncio.Event()
-        max_wait_handle: asyncio.TimerHandle | None
-        if max_wait_s > 0:
-            max_wait_handle = loop.call_later(max_wait_s, max_wait_event.set)
-        else:
-            max_wait_event.set()
-            max_wait_handle = None
+        max_wait_handle = loop.call_later(max_wait_s, max_wait_event.set)
 
         def on_msg(msg: Msg) -> None:
-            if msg.data == b"" and not (msg.headers or {}) and max_wait_handle is not None:
+            if msg.data == b"" and not (msg.headers or {}):
                 max_wait_handle.cancel()
 
         token, queue = mux.register(on_msg=on_msg)

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -347,8 +347,9 @@ class Agent:
         if close_task is not None:
             wait_set.add(close_task)
 
+        pending: set[asyncio.Task[object] | asyncio.Task[bool]] = set()
         try:
-            done, _pending = await asyncio.wait(
+            done, pending = await asyncio.wait(
                 wait_set,
                 timeout=timeout,
                 return_when=asyncio.FIRST_COMPLETED,
@@ -369,11 +370,10 @@ class Agent:
                 raise StreamMaxWaitExceededError(max_wait_s)
             return item
         finally:
-            for task in wait_set:
-                if not task.done():
-                    task.cancel()
-                    with contextlib.suppress(BaseException):
-                        await task
+            for task in pending:
+                task.cancel()
+                with contextlib.suppress(BaseException):
+                    await task
 
     def _raise_if_closed(self) -> None:
         """Raise :class:`AgentsClosedError` if the owning Agents has closed.
@@ -439,7 +439,6 @@ class Agent:
                     max_wait_event=max_wait_event,
                     reply=reply,
                 )
-                self._raise_if_cancelled(reply)
 
                 msg: Msg = item  # type: ignore[assignment]
                 headers = msg.headers or {}

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -15,7 +15,7 @@ import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Final, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 from ._logging import get_logger
 from ._mux import mux_for
@@ -39,26 +39,6 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg
 
 log = get_logger(__name__)
-
-
-# Per-stream cancellation sentinel. Pushed into the stream's queue by
-# the close-event watcher (see :func:`_close_to_sentinel`) so the
-# consumer's ``queue.get()`` returns immediately on
-# :meth:`Agents.close` regardless of the inactivity-timeout setting.
-# Distinct from any wire-level value — the consumer recognises it by
-# ``is`` identity.
-_CLOSE_SENTINEL: Final[object] = object()
-
-
-async def _close_to_sentinel(close_event: asyncio.Event, queue: asyncio.Queue[object]) -> None:
-    """Watcher coroutine: push :data:`_CLOSE_SENTINEL` when ``close_event`` fires.
-
-    Spawned per stream in :meth:`Agent._stream_prompt`; cancelled in the
-    stream's ``finally`` block. The queue is unbounded so
-    ``put_nowait`` cannot raise.
-    """
-    await close_event.wait()
-    queue.put_nowait(_CLOSE_SENTINEL)
 
 
 # Default per-stream inactivity timeout (§6.6) — 60 seconds. Mirrors the
@@ -321,29 +301,79 @@ class Agent:
         *,
         timeout: float,
         max_wait_s: float,
-        deadline: float,
+        max_wait_event: asyncio.Event,
         reply: str,
-        loop: asyncio.AbstractEventLoop,
     ) -> object:
         """Pull the next item off ``queue`` or raise the appropriate timeout.
 
-        Splits the dual-timer logic out of :meth:`_stream_prompt` so the
-        per-chunk decode loop stays readable. ``StreamMaxWaitExceededError``
-        and ``StreamStalledError`` are disambiguated by which deadline
-        elapsed first; both inherit from :class:`ProtocolError` for back-
-        compat.
+        Close and max-wait are lifecycle controls, not ordinary queued
+        stream values. They win over already-buffered chunks (including
+        a buffered terminator) so :meth:`Agents.close` cannot be hidden
+        behind FIFO backlog and max-wait does not drain arbitrary chunks
+        after its deadline. The inactivity timeout remains a per-read
+        gap detector and resets after every delivered item.
         """
-        remaining = deadline - loop.time()
-        if remaining <= 0:
+        self._raise_if_cancelled(reply)
+        if max_wait_event.is_set():
             raise StreamMaxWaitExceededError(max_wait_s)
-        wait_for = min(timeout, remaining)
+
+        if not queue.empty():
+            item = queue.get_nowait()
+            self._raise_if_cancelled(reply)
+            if max_wait_event.is_set():
+                raise StreamMaxWaitExceededError(max_wait_s)
+            return item
+
+        queue_task: asyncio.Task[object] = asyncio.create_task(
+            queue.get(),
+            name=f"agents-prompt-next:{reply}",
+        )
+        max_wait_task: asyncio.Task[bool] = asyncio.create_task(
+            max_wait_event.wait(),
+            name=f"agents-prompt-max-wait:{reply}",
+        )
+        close_task: asyncio.Task[bool] | None = (
+            asyncio.create_task(
+                self._close_event.wait(),
+                name=f"agents-prompt-close:{reply}",
+            )
+            if self._close_event is not None
+            else None
+        )
+        wait_set: set[asyncio.Task[object] | asyncio.Task[bool]] = {
+            queue_task,
+            max_wait_task,
+        }
+        if close_task is not None:
+            wait_set.add(close_task)
+
         try:
-            return await asyncio.wait_for(queue.get(), timeout=wait_for)
-        except TimeoutError as exc:
-            if loop.time() >= deadline:
-                raise StreamMaxWaitExceededError(max_wait_s) from exc
-            log.warning("stream stalled on %s: no chunk within %.1fs", reply, timeout)
-            raise StreamStalledError(timeout, reply_subject=reply) from exc
+            done, _pending = await asyncio.wait(
+                wait_set,
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                log.warning("stream stalled on %s: no chunk within %.1fs", reply, timeout)
+                raise StreamStalledError(timeout, reply_subject=reply)
+            if close_task is not None and close_task in done:
+                raise ProtocolError(
+                    f"prompt stream cancelled: owning Agents is closed (reply={reply})"
+                )
+            if max_wait_task in done:
+                raise StreamMaxWaitExceededError(max_wait_s)
+
+            item = queue_task.result()
+            self._raise_if_cancelled(reply)
+            if max_wait_event.is_set():
+                raise StreamMaxWaitExceededError(max_wait_s)
+            return item
+        finally:
+            for task in wait_set:
+                if not task.done():
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
 
     def _raise_if_closed(self) -> None:
         """Raise :class:`AgentsClosedError` if the owning Agents has closed.
@@ -358,26 +388,10 @@ class Agent:
         if self._close_event is not None and self._close_event.is_set():
             raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
 
-    def _arm_close_watcher(
-        self, queue: asyncio.Queue[object], token: str
-    ) -> asyncio.Task[None] | None:
-        """Wire the per-stream cancellation path immediately after publish.
-
-        If ``close_event`` already fired during the publish await, push
-        :data:`_CLOSE_SENTINEL` synchronously so the very first
-        ``queue.get()`` unblocks. Otherwise spawn the async watcher.
-        Returns the spawned task (or ``None`` for the no-watcher cases)
-        so :meth:`_stream_prompt` can cancel it in ``finally``.
-        """
-        if self._close_event is None:
-            return None
-        if self._close_event.is_set():
-            queue.put_nowait(_CLOSE_SENTINEL)
-            return None
-        return asyncio.create_task(
-            _close_to_sentinel(self._close_event, queue),
-            name=f"agents-close-watcher:{token}",
-        )
+    def _raise_if_cancelled(self, reply: str) -> None:
+        """Raise if :meth:`Agents.close` fired during an active stream."""
+        if self._close_event is not None and self._close_event.is_set():
+            raise ProtocolError(f"prompt stream cancelled: owning Agents is closed (reply={reply})")
 
     async def _stream_prompt(
         self, envelope: Envelope, encoded: bytes, timeout: float, max_wait_s: float
@@ -392,16 +406,23 @@ class Agent:
         # connection. See `_mux.py`'s INTERIM-NATSPY-REQUEST-MANY note.
         mux = mux_for(self._nc)
         await mux.start()  # idempotent; pays SUB+flush on the first prompt
-        token, queue = mux.register()
-        close_watcher: asyncio.Task[None] | None = None
+        loop = asyncio.get_running_loop()
+        max_wait_event = asyncio.Event()
+        max_wait_handle: asyncio.TimerHandle | None
+        if max_wait_s > 0:
+            max_wait_handle = loop.call_later(max_wait_s, max_wait_event.set)
+        else:
+            max_wait_event.set()
+            max_wait_handle = None
+
+        def on_msg(msg: Msg) -> None:
+            if msg.data == b"" and not (msg.headers or {}) and max_wait_handle is not None:
+                max_wait_handle.cancel()
+
+        token, queue = mux.register(on_msg=on_msg)
         try:
             reply = mux.reply_subject_for(token)
             subject = self._info.prompt_endpoint.subject
-
-            # Absolute ceiling. ``loop.time()`` is monotonic so the deadline
-            # is robust against wall-clock skew.
-            loop = asyncio.get_running_loop()
-            deadline = loop.time() + max_wait_s
 
             # Re-check after the mux.start() await: close may have
             # fired during the SUB+flush window. Bail before publishing
@@ -409,21 +430,16 @@ class Agent:
             self._raise_if_closed()
 
             await self._nc.publish(subject, encoded, reply=reply)
-            close_watcher = self._arm_close_watcher(queue, token)
 
             while True:
                 item = await self._wait_for_chunk(
                     queue,
                     timeout=timeout,
                     max_wait_s=max_wait_s,
-                    deadline=deadline,
+                    max_wait_event=max_wait_event,
                     reply=reply,
-                    loop=loop,
                 )
-                if item is _CLOSE_SENTINEL:
-                    raise ProtocolError(
-                        f"prompt stream cancelled: owning Agents is closed (reply={reply})"
-                    )
+                self._raise_if_cancelled(reply)
 
                 msg: Msg = item  # type: ignore[assignment]
                 headers = msg.headers or {}
@@ -455,20 +471,18 @@ class Agent:
                 else:
                     yield chunk
         finally:
-            # Ordering matters: cancel the watcher first (no more
-            # sentinels can be pushed), then unregister the token (no
-            # more wire chunks will be routed here — _on_msg is sync
-            # body, so any in-flight call has already completed
-            # before this line returns), then drain anything that
-            # arrived between the consumer's last ``get()`` and now.
+            # Ordering matters: cancel the max-wait timer first, then
+            # unregister the token (no more wire chunks will be routed
+            # here — _on_msg is sync body, so any in-flight call has
+            # already completed before this line returns), then drain
+            # anything that arrived between the consumer's last ``get()``
+            # and now.
             # This releases :class:`~nats.aio.msg.Msg` payloads
             # deterministically rather than waiting on the queue's
             # own GC, which matters for streams that exit early with
             # large chunks still buffered.
-            if close_watcher is not None and not close_watcher.done():
-                close_watcher.cancel()
-                with contextlib.suppress(BaseException):
-                    await close_watcher
+            if max_wait_handle is not None:
+                max_wait_handle.cancel()
             mux.unregister(token)
             while not queue.empty():
                 queue.get_nowait()

--- a/client-sdk/python/src/synadia_ai/agents/agent.py
+++ b/client-sdk/python/src/synadia_ai/agents/agent.py
@@ -12,15 +12,21 @@ distribution :mod:`synadia_ai.agent_service`.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Final, TypeAlias
 
 from ._logging import get_logger
-from ._mux import MuxInbox, is_agents_closed_sentinel
+from ._mux import mux_for
 from .discovery import AgentInfo, EndpointInfo
 from .envelope import Attachment, Envelope, encode
-from .errors import ProtocolError, StreamMaxWaitExceededError, StreamStalledError
+from .errors import (
+    AgentsClosedError,
+    ProtocolError,
+    StreamMaxWaitExceededError,
+    StreamStalledError,
+)
 from .messages import QueryChunk, ResponseChunk, StatusChunk, decode_chunk
 from .validation import (
     assert_attachments_allowed,
@@ -33,6 +39,26 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg
 
 log = get_logger(__name__)
+
+
+# Per-stream cancellation sentinel. Pushed into the stream's queue by
+# the close-event watcher (see :func:`_close_to_sentinel`) so the
+# consumer's ``queue.get()`` returns immediately on
+# :meth:`Agents.close` regardless of the inactivity-timeout setting.
+# Distinct from any wire-level value — the consumer recognises it by
+# ``is`` identity.
+_CLOSE_SENTINEL: Final[object] = object()
+
+
+async def _close_to_sentinel(close_event: asyncio.Event, queue: asyncio.Queue[object]) -> None:
+    """Watcher coroutine: push :data:`_CLOSE_SENTINEL` when ``close_event`` fires.
+
+    Spawned per stream in :meth:`Agent._stream_prompt`; cancelled in the
+    stream's ``finally`` block. The queue is unbounded so
+    ``put_nowait`` cannot raise.
+    """
+    await close_event.wait()
+    queue.put_nowait(_CLOSE_SENTINEL)
 
 
 # Default per-stream inactivity timeout (§6.6) — 60 seconds. Mirrors the
@@ -112,21 +138,12 @@ class Agent:
         stream_inactivity_timeout: float = DEFAULT_STREAM_INACTIVITY_TIMEOUT_S,
         prompt_max_wait_s: float = DEFAULT_PROMPT_MAX_WAIT_S,
         close_event: asyncio.Event | None = None,
-        mux: MuxInbox | None = None,
     ) -> None:
         self._nc = nc
         self._info = info
         self._default_inactivity_timeout = stream_inactivity_timeout
         self._default_max_wait_s = prompt_max_wait_s
         self._close_event = close_event
-        # When `mux` is None — i.e. the handle was constructed outside
-        # `Agents` (e.g. from a heartbeat + `$SRV.INFO.agents.{id}`
-        # direct lookup) — we lazy-allocate a private mux on the first
-        # prompt(). All subsequent prompts on this Agent share that
-        # subscription, so the wire-economy property still holds even
-        # for direct callers; the SUB itself rides on `nc` and is
-        # cleaned up when the caller closes the connection.
-        self._mux = mux
 
     # --- flat read-only identity / capability fields -------------------
 
@@ -246,10 +263,22 @@ class Agent:
         terminates when the empty-payload chunk arrives (§6.5). Service
         errors mid-stream (§9) are raised as :class:`ProtocolError`.
 
-        The iterator also short-circuits if the owning :class:`Agents`
-        is closed mid-stream — the iterator raises a :class:`ProtocolError`
-        describing the cancellation so callers don't silently hang on a
-        broker that's already torn down.
+        Cancellation:
+
+        - If :meth:`Agents.close` has *already* fired before this
+          iterator advances, :class:`AgentsClosedError` is raised
+          before any wire I/O.
+        - If :meth:`Agents.close` fires *during* iteration, the
+          iterator raises :class:`ProtocolError` describing the
+          cancellation within an event-loop tick — independent of
+          ``timeout`` — so callers don't silently hang on a torn-down
+          broker.
+        - If the caller breaks out of the ``async for`` early, prefer
+          ``async with contextlib.aclosing(agent.prompt(...)) as
+          stream:`` (or an explicit ``await stream.aclose()``) so the
+          per-stream slot in the shared mux inbox is freed
+          deterministically. A bare ``break`` defers cleanup to the
+          generator finalizer (works, but the slot lingers until GC).
         """
         if isinstance(text, Envelope):
             merged_attachments: list[Attachment] | None
@@ -320,13 +349,15 @@ class Agent:
         self, envelope: Envelope, encoded: bytes, timeout: float, max_wait_s: float
     ) -> AsyncIterator[StreamMessage]:
         del envelope  # retained for readability at the call site; not needed here
-        # Resolve the mux: shared (passed in by Agents) or private
-        # (lazy-allocated for direct-construction callers). The wire
-        # economy still holds — every Agent shares one SUB across all
-        # of its prompts, regardless of how it was built.
-        if self._mux is None:
-            self._mux = MuxInbox(self._nc)
-        mux = self._mux
+        # Pre-flight: refuse outright if the owning Agents is already
+        # closed. This catches the "called prompt() after close()" case
+        # cleanly, before any wire I/O or mux state mutation.
+        if self._close_event is not None and self._close_event.is_set():
+            raise AgentsClosedError("Agents is closed; cannot start new prompt streams")
+
+        # Per-nc mux singleton — shared across every Agent on the same
+        # connection. See `_mux.py`'s INTERIM-NATSPY-REQUEST-MANY note.
+        mux = mux_for(self._nc)
         await mux.start()  # idempotent; pays SUB+flush on the first prompt
         token, queue = mux.register()
         reply = mux.reply_subject_for(token)
@@ -337,15 +368,23 @@ class Agent:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + max_wait_s
 
+        # Per-stream close watcher (only when wired up). When
+        # close_event fires, this task pushes a sentinel into our
+        # queue so the consumer's next ``queue.get()`` unblocks
+        # immediately — independent of the inactivity timeout. Mirrors
+        # the TS SDK's ``closeSignal: AbortSignal`` path under PR #66.
+        close_watcher: asyncio.Task[None] | None = None
         try:
             await self._nc.publish(subject, encoded, reply=reply)
-            # Race: cancel() / Agents.close() may have fired during the
-            # publish await. The mux's sentinel-broadcast lands in our
-            # queue, but if close fired *before* we publish we still
-            # want to fail fast rather than wait on a dead inbox.
+            # Race: close_event may have fired during the publish await.
+            # Push the sentinel synchronously so the loop sees it on
+            # the very first iteration.
             if self._close_event is not None and self._close_event.is_set():
-                raise ProtocolError(
-                    f"prompt stream cancelled: owning Agents is closed (reply={reply})"
+                queue.put_nowait(_CLOSE_SENTINEL)
+            elif self._close_event is not None:
+                close_watcher = asyncio.create_task(
+                    _close_to_sentinel(self._close_event, queue),
+                    name=f"agents-close-watcher:{token}",
                 )
 
             while True:
@@ -357,7 +396,7 @@ class Agent:
                     reply=reply,
                     loop=loop,
                 )
-                if is_agents_closed_sentinel(item):
+                if item is _CLOSE_SENTINEL:
                     raise ProtocolError(
                         f"prompt stream cancelled: owning Agents is closed (reply={reply})"
                     )
@@ -392,6 +431,10 @@ class Agent:
                 else:
                     yield chunk
         finally:
+            if close_watcher is not None and not close_watcher.done():
+                close_watcher.cancel()
+                with contextlib.suppress(BaseException):
+                    await close_watcher
             mux.unregister(token)
 
 

--- a/client-sdk/python/src/synadia_ai/agents/agents.py
+++ b/client-sdk/python/src/synadia_ai/agents/agents.py
@@ -29,7 +29,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ._logging import get_logger
-from .agent import DEFAULT_STREAM_INACTIVITY_TIMEOUT_S, Agent
+from ._mux import MuxInbox
+from .agent import DEFAULT_PROMPT_MAX_WAIT_S, DEFAULT_STREAM_INACTIVITY_TIMEOUT_S, Agent
 from .discovery import (
     DEFAULT_DISCOVER_MAX_WAIT_S,
     DEFAULT_DISCOVER_STALL_S,
@@ -62,12 +63,19 @@ class Agents:
         *,
         nc: NATSClient,
         stream_inactivity_timeout: float = DEFAULT_STREAM_INACTIVITY_TIMEOUT_S,
+        prompt_max_wait_s: float = DEFAULT_PROMPT_MAX_WAIT_S,
         logger: logging.Logger | None = None,
     ) -> None:
         self._nc = nc
         self._stream_inactivity_timeout = stream_inactivity_timeout
+        self._prompt_max_wait_s = prompt_max_wait_s
         self._logger = logger if logger is not None else log
         self._tracker = HeartbeatTracker(nc)
+        # Shared mux reply-inbox used for every prompt stream this Agents
+        # produces. Lazy-subscribed: SUB+flush is paid on the first
+        # prompt(), not at construction. See `_mux.py` for the design
+        # rationale (interim ahead of nats-py request_many).
+        self._mux = MuxInbox(nc)
         # Set when close() is called; passed to every Agent so in-flight
         # prompt streams can short-circuit instead of waiting on a torn-
         # down broker.
@@ -84,6 +92,11 @@ class Agents:
     def stream_inactivity_timeout(self) -> float:
         """Default per-stream inactivity timeout applied to every :meth:`Agent.prompt`."""
         return self._stream_inactivity_timeout
+
+    @property
+    def prompt_max_wait_s(self) -> float:
+        """Default absolute ceiling for :meth:`Agent.prompt` (overridable per-call)."""
+        return self._prompt_max_wait_s
 
     @property
     def close_event(self) -> asyncio.Event:
@@ -147,7 +160,9 @@ class Agents:
                 self._nc,
                 info,
                 stream_inactivity_timeout=self._stream_inactivity_timeout,
+                prompt_max_wait_s=self._prompt_max_wait_s,
                 close_event=self._close_event,
+                mux=self._mux,
             )
             for info in infos
             if matches_filter(info, filter)
@@ -205,16 +220,35 @@ class Agents:
     async def close(self) -> None:
         """Tear down SDK-owned state. Idempotent.
 
-        Cancels in-flight prompt streams via :attr:`close_event` and
-        unsubscribes the heartbeat wildcard. The underlying NATS
-        connection is NOT touched — the caller who opened it is
-        responsible for closing it.
+        Cancels in-flight prompt streams via :attr:`close_event` and the
+        mux-inbox sentinel broadcast (``_mux.py``), unsubscribes the
+        heartbeat wildcard, and tears down the shared reply-inbox
+        subscription. The underlying NATS connection is NOT touched —
+        the caller who opened it is responsible for closing it.
         """
         if self._closed:
             return
         self._closed = True
         self._close_event.set()
+        # Mux close runs first so live prompt streams unblock from
+        # queue.get() via the broadcast sentinel; the heartbeat
+        # tracker stop is independent.
+        await self._mux.close()
         await self._tracker.stop()
+
+    @property
+    def mux(self) -> MuxInbox:
+        """The shared reply-inbox mux this :class:`Agents` opens for prompt streams.
+
+        Public for symmetry with :attr:`close_event` — callers that
+        construct :class:`Agent` outside :meth:`discover` (e.g. from a
+        heartbeat + ``$SRV.INFO.agents.{id}`` direct lookup) can pass
+        the mux to the :class:`Agent` constructor so the handle uses
+        the same shared subscription. Documented as **interim** until
+        ``nats-py`` ships ``request_many`` upstream; see
+        :mod:`synadia_ai.agents._mux` for the migration plan.
+        """
+        return self._mux
 
     def _ensure_open(self) -> None:
         if self._closed:

--- a/client-sdk/python/src/synadia_ai/agents/agents.py
+++ b/client-sdk/python/src/synadia_ai/agents/agents.py
@@ -65,6 +65,8 @@ class Agents:
         prompt_max_wait_s: float = DEFAULT_PROMPT_MAX_WAIT_S,
         logger: logging.Logger | None = None,
     ) -> None:
+        if prompt_max_wait_s <= 0:
+            raise ValueError(f"prompt_max_wait_s must be > 0 (got {prompt_max_wait_s!r}).")
         self._nc = nc
         self._stream_inactivity_timeout = stream_inactivity_timeout
         self._prompt_max_wait_s = prompt_max_wait_s

--- a/client-sdk/python/src/synadia_ai/agents/agents.py
+++ b/client-sdk/python/src/synadia_ai/agents/agents.py
@@ -29,7 +29,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ._logging import get_logger
-from ._mux import MuxInbox
 from .agent import DEFAULT_PROMPT_MAX_WAIT_S, DEFAULT_STREAM_INACTIVITY_TIMEOUT_S, Agent
 from .discovery import (
     DEFAULT_DISCOVER_MAX_WAIT_S,
@@ -71,14 +70,12 @@ class Agents:
         self._prompt_max_wait_s = prompt_max_wait_s
         self._logger = logger if logger is not None else log
         self._tracker = HeartbeatTracker(nc)
-        # Shared mux reply-inbox used for every prompt stream this Agents
-        # produces. Lazy-subscribed: SUB+flush is paid on the first
-        # prompt(), not at construction. See `_mux.py` for the design
-        # rationale (interim ahead of nats-py request_many).
-        self._mux = MuxInbox(nc)
         # Set when close() is called; passed to every Agent so in-flight
         # prompt streams can short-circuit instead of waiting on a torn-
-        # down broker.
+        # down broker. The shared mux reply-inbox lives on the
+        # connection itself (per-nc singleton in `_mux.py`); this Agents
+        # does not own it, mirroring the TS SDK's `nc.requestMany`
+        # design where the connection holds the mux.
         self._close_event = asyncio.Event()
         self._closed = False
         self._lazy_start_task: asyncio.Task[None] | None = None
@@ -162,7 +159,6 @@ class Agents:
                 stream_inactivity_timeout=self._stream_inactivity_timeout,
                 prompt_max_wait_s=self._prompt_max_wait_s,
                 close_event=self._close_event,
-                mux=self._mux,
             )
             for info in infos
             if matches_filter(info, filter)
@@ -220,35 +216,21 @@ class Agents:
     async def close(self) -> None:
         """Tear down SDK-owned state. Idempotent.
 
-        Cancels in-flight prompt streams via :attr:`close_event` and the
-        mux-inbox sentinel broadcast (``_mux.py``), unsubscribes the
-        heartbeat wildcard, and tears down the shared reply-inbox
-        subscription. The underlying NATS connection is NOT touched —
-        the caller who opened it is responsible for closing it.
+        Sets :attr:`close_event`, which every in-flight
+        :meth:`Agent.prompt` iterator races against — they unblock
+        within an event-loop tick instead of waiting on the inactivity
+        timeout. Then unsubscribes the heartbeat wildcard. The shared
+        reply-inbox mux is **not** torn down here — it lives on the
+        connection (per-nc singleton in ``_mux.py``) and dies when the
+        caller closes ``nc``. The underlying NATS connection itself is
+        also NOT touched — the caller who opened it is responsible
+        for closing it.
         """
         if self._closed:
             return
         self._closed = True
         self._close_event.set()
-        # Mux close runs first so live prompt streams unblock from
-        # queue.get() via the broadcast sentinel; the heartbeat
-        # tracker stop is independent.
-        await self._mux.close()
         await self._tracker.stop()
-
-    @property
-    def mux(self) -> MuxInbox:
-        """The shared reply-inbox mux this :class:`Agents` opens for prompt streams.
-
-        Public for symmetry with :attr:`close_event` — callers that
-        construct :class:`Agent` outside :meth:`discover` (e.g. from a
-        heartbeat + ``$SRV.INFO.agents.{id}`` direct lookup) can pass
-        the mux to the :class:`Agent` constructor so the handle uses
-        the same shared subscription. Documented as **interim** until
-        ``nats-py`` ships ``request_many`` upstream; see
-        :mod:`synadia_ai.agents._mux` for the migration plan.
-        """
-        return self._mux
 
     def _ensure_open(self) -> None:
         if self._closed:

--- a/client-sdk/python/src/synadia_ai/agents/errors.py
+++ b/client-sdk/python/src/synadia_ai/agents/errors.py
@@ -17,6 +17,52 @@ class ProtocolError(NatsAgentError):
     """Wire payload violates the NATS Agent Protocol (malformed envelope, bad chunk, etc.)."""
 
 
+class StreamStalledError(ProtocolError):
+    """Per-chunk inactivity timeout (§6.6) elapsed without a new chunk arriving.
+
+    Inherits from :class:`ProtocolError` so existing ``except ProtocolError``
+    clauses keep catching the stalled case; new code may catch this subclass
+    to distinguish it from :class:`StreamMaxWaitExceededError` (the absolute
+    ceiling) and from genuine wire-shape violations.
+    """
+
+    def __init__(self, timeout_s: float, *, reply_subject: str | None = None) -> None:
+        loc = f" on {reply_subject}" if reply_subject else ""
+        super().__init__(f"stream stalled: no chunk received within {timeout_s}s{loc}")
+        self.timeout_s = timeout_s
+        self.reply_subject = reply_subject
+
+
+class StreamMaxWaitExceededError(ProtocolError):
+    """Absolute ``max_wait_s`` ceiling on a prompt stream elapsed.
+
+    Distinct from :class:`StreamStalledError` (the inactivity gap detector
+    from §6.6). The ceiling is the safety net for cases where chunks keep
+    arriving steadily but the agent never terminates — e.g. a misbehaving
+    handler emitting a heartbeat-style ack every few seconds forever, or
+    a silent reconnect window that exceeds the inactivity timer's
+    per-message reset cycle. Inherits from :class:`ProtocolError` for
+    back-compat with broad ``except ProtocolError`` clauses.
+    """
+
+    def __init__(self, max_wait_s: float) -> None:
+        super().__init__(f"prompt stream exceeded max_wait_s={max_wait_s}s ceiling")
+        self.max_wait_s = max_wait_s
+
+
+class AgentsClosedError(NatsAgentError):
+    """Raised by SDK-internal entry points after :meth:`Agents.close` has run.
+
+    Today this only fires from the interim mux inbox's ``register()`` —
+    the only path callers can reach is via :meth:`Agent.prompt` after the
+    owning :class:`Agents` was torn down. Surfaces as a clean,
+    branch-able error rather than a generic :class:`RuntimeError`.
+    """
+
+    def __init__(self, what: str = "Agents is closed") -> None:
+        super().__init__(what)
+
+
 class InvalidSubjectToken(NatsAgentError):
     """A subject token (agent / owner / name) breaks §2 constraints and can't be sanitized."""
 

--- a/client-sdk/python/src/synadia_ai/agents/errors.py
+++ b/client-sdk/python/src/synadia_ai/agents/errors.py
@@ -51,12 +51,15 @@ class StreamMaxWaitExceededError(ProtocolError):
 
 
 class AgentsClosedError(NatsAgentError):
-    """Raised by SDK-internal entry points after :meth:`Agents.close` has run.
+    """Raised when :meth:`Agent.prompt` is called after :meth:`Agents.close`.
 
-    Today this only fires from the interim mux inbox's ``register()`` —
-    the only path callers can reach is via :meth:`Agent.prompt` after the
-    owning :class:`Agents` was torn down. Surfaces as a clean,
-    branch-able error rather than a generic :class:`RuntimeError`.
+    Pre-flight check at the top of every prompt stream: if the
+    ``close_event`` is already set, the iterator raises this error
+    before any wire I/O instead of hanging on a torn-down broker.
+    Distinct from :class:`ProtocolError` (which the iterator raises
+    when ``Agents.close`` fires *during* an active stream) so callers
+    can branch on "already closed at call time" vs "torn down
+    mid-flight" if they care.
     """
 
     def __init__(self, what: str = "Agents is closed") -> None:

--- a/client-sdk/python/tests/conftest.py
+++ b/client-sdk/python/tests/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -45,6 +47,40 @@ async def nc(nats_server: RunningServer) -> AsyncIterator[NATSClient]:
         yield client
     finally:
         await client.close()
+
+
+@pytest_asyncio.fixture
+async def bg_tasks() -> AsyncIterator[Callable[[asyncio.Task[object]], None]]:
+    """Track background tasks (e.g. fake-agent emit loops) and cancel at teardown.
+
+    Tests that spawn a forever-loop in a NATS subscription callback —
+    typically ``while True: await nc.publish(...); await asyncio.sleep(...)``
+    — must register the task here. Otherwise pytest-asyncio prints
+    ``Task was destroyed but it is pending`` warnings and the dying
+    task can log noise into a later test's evidence directory when
+    :meth:`Client.close` causes it to crash with
+    :class:`~nats.errors.ConnectionClosedError`.
+
+    Use::
+
+        async def fake_agent(msg: Msg) -> None:
+            t = asyncio.create_task(emit_loop(msg))
+            bg_tasks(t)
+    """
+    tasks: set[asyncio.Task[object]] = set()
+
+    def register(task: asyncio.Task[object]) -> None:
+        tasks.add(task)
+
+    try:
+        yield register
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            with contextlib.suppress(BaseException):
+                await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest_asyncio.fixture

--- a/client-sdk/python/tests/harness/nats_server.py
+++ b/client-sdk/python/tests/harness/nats_server.py
@@ -27,6 +27,26 @@ def _pick_free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _pick_free_ports(n: int) -> tuple[int, ...]:
+    """Pick *n* distinct free ports atomically.
+
+    Holds all *n* binds simultaneously before closing any, so the
+    kernel cannot hand out the same ephemeral port twice across a
+    single multi-port allocation. Two back-to-back :func:`_pick_free_port`
+    calls would have a vanishingly rare TOCTOU collision when the
+    kernel reuses the same port for both — uncommon, but a bulletproof
+    harness shouldn't depend on luck.
+    """
+    socks = [socket.socket(socket.AF_INET, socket.SOCK_STREAM) for _ in range(n)]
+    try:
+        for sock in socks:
+            sock.bind(("127.0.0.1", 0))
+        return tuple(int(sock.getsockname()[1]) for sock in socks)
+    finally:
+        for sock in socks:
+            sock.close()
+
+
 @dataclass
 class RunningServer:
     """A nats-server running as a child process of the test session.
@@ -73,8 +93,7 @@ def start_server(log_dir: Path) -> RunningServer:
         raise RuntimeError("nats-server not on PATH")
 
     log_dir.mkdir(parents=True, exist_ok=True)
-    port = _pick_free_port()
-    monitoring_port = _pick_free_port()
+    port, monitoring_port = _pick_free_ports(2)
     log_file = log_dir / f"nats-server-{port}.log"
 
     # -DV = debug+verbose; -a = address; -p = client port; -m = HTTP

--- a/client-sdk/python/tests/harness/nats_server.py
+++ b/client-sdk/python/tests/harness/nats_server.py
@@ -29,12 +29,20 @@ def _pick_free_port() -> int:
 
 @dataclass
 class RunningServer:
-    """A nats-server running as a child process of the test session."""
+    """A nats-server running as a child process of the test session.
+
+    Exposes both the client port (``url``) and the HTTP monitoring port
+    (``monitoring_url``) so tests that want to verify broker-side state
+    (e.g. live subscription count) can hit ``/subsz`` directly rather
+    than relying on SDK-internal instrumentation.
+    """
 
     url: str
     process: subprocess.Popen[bytes]
     stdout_log: Path
     port: int
+    monitoring_port: int
+    monitoring_url: str
 
     def stop(self) -> None:
         if self.process.poll() is not None:
@@ -50,8 +58,15 @@ class RunningServer:
 def start_server(log_dir: Path) -> RunningServer:
     """Start a fresh nats-server on a free port, logging verbosely to `log_dir`.
 
-    Returns a handle with `.url` (nats://127.0.0.1:<port>) and a `.stop()` method.
-    Raises RuntimeError if the server fails to accept connections within 5 seconds.
+    Returns a handle with ``.url`` (nats://127.0.0.1:<client_port>),
+    ``.monitoring_url`` (http://127.0.0.1:<monitoring_port>), and a
+    ``.stop()`` method. Raises RuntimeError if either port fails to
+    accept connections within 5 seconds.
+
+    The monitoring port is enabled unconditionally: it costs one extra
+    listening socket and lets tests assert broker-observed truth (e.g.
+    subscription counts via ``/subsz``) instead of having to monkey-
+    patch SDK internals.
     """
     binary = find_nats_server()
     if binary is None:
@@ -59,24 +74,51 @@ def start_server(log_dir: Path) -> RunningServer:
 
     log_dir.mkdir(parents=True, exist_ok=True)
     port = _pick_free_port()
+    monitoring_port = _pick_free_port()
     log_file = log_dir / f"nats-server-{port}.log"
 
-    # -DV = debug+verbose; -a = address; -p = port. We write to a file so the
-    # test can attach it as evidence on failure without racing the subprocess pipe.
+    # -DV = debug+verbose; -a = address; -p = client port; -m = HTTP
+    # monitoring port. We write to a file so the test can attach it as
+    # evidence on failure without racing the subprocess pipe.
     proc = subprocess.Popen(
-        [binary, "-DV", "-a", "127.0.0.1", "-p", str(port), "-l", str(log_file)],
+        [
+            binary,
+            "-DV",
+            "-a",
+            "127.0.0.1",
+            "-p",
+            str(port),
+            "-m",
+            str(monitoring_port),
+            "-l",
+            str(log_file),
+        ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
 
     url = f"nats://127.0.0.1:{port}"
+    monitoring_url = f"http://127.0.0.1:{monitoring_port}"
     if not _wait_for_listen(port, timeout=5.0):
         proc.kill()
         raise RuntimeError(
             f"nats-server failed to accept connections on :{port} within 5s; "
             f"see {log_file} for details"
         )
-    return RunningServer(url=url, process=proc, stdout_log=log_file, port=port)
+    if not _wait_for_listen(monitoring_port, timeout=5.0):
+        proc.kill()
+        raise RuntimeError(
+            f"nats-server monitoring failed to accept connections on :{monitoring_port} "
+            f"within 5s; see {log_file} for details"
+        )
+    return RunningServer(
+        url=url,
+        process=proc,
+        stdout_log=log_file,
+        port=port,
+        monitoring_port=monitoring_port,
+        monitoring_url=monitoring_url,
+    )
 
 
 def _wait_for_listen(port: int, *, timeout: float) -> bool:

--- a/client-sdk/python/tests/test_interop_e2e.py
+++ b/client-sdk/python/tests/test_interop_e2e.py
@@ -36,16 +36,6 @@ import pytest
 
 from synadia_ai.agents import Agents, ResponseChunk
 
-# TODO(v0.3-wire): remove this skip once the TS SDK lands the verb-first wire
-# (`agents.{verb}.{a}.{o}.{n}`) and bumps `protocol_version` to "0.3". The
-# Python SDK ships ahead of TS per the cross-SDK release ladder in the root
-# CLAUDE.md; until then, exercising the TS reference agent (still on v0.2)
-# against a v0.3 Python client only proves a known incompatibility.
-pytest.skip(
-    "awaiting TS SDK v0.3 wire catch-up — see CHANGELOG.md [Unreleased]",
-    allow_module_level=True,
-)
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
@@ -217,3 +207,53 @@ async def test_python_client_prompts_ts_reference_agent(
         assert received[0].text == "demo agent received your prompt."
     finally:
         await agents.close()
+
+
+@pytest.mark.asyncio
+async def test_python_client_uses_one_mux_sub_for_n_prompts_against_ts_agent(
+    nc: NATSClient, ts_reference_agent: _ReferenceAgentProcess
+) -> None:
+    """Wire-economy regression vs the TS agent: 5 prompts → 1 mux SUB.
+
+    Pre-PR the Python client opened a fresh ``_INBOX.agents.<nuid>``
+    subscription per prompt (one SUB+UNSUB+flush per call). The
+    interim mux-inbox refactor (`_mux.py`) consolidates those into
+    a single shared ``_INBOX.agents.<mux>.*`` SUB per :class:`Agents`.
+    Counts inbox-prefixed ``nc.subscribe()`` calls during a 5-prompt
+    sequence — should be exactly **1**.
+    """
+    assert ts_reference_agent.prompt_subject is not None
+
+    inbox_subscribes: list[str] = []
+    original_subscribe = nc.subscribe
+
+    async def counting_subscribe(subject: str, *args: object, **kwargs: object) -> object:
+        if subject.startswith("_INBOX.agents."):
+            inbox_subscribes.append(subject)
+        return await original_subscribe(subject, *args, **kwargs)  # type: ignore[arg-type]
+
+    nc.subscribe = counting_subscribe  # type: ignore[method-assign,assignment]
+
+    try:
+        agents = Agents(nc=nc)
+        try:
+            found = await agents.discover(timeout=3.0)
+            discovered = next(
+                a for a in found if a.prompt_subject == ts_reference_agent.prompt_subject
+            )
+            baseline = len(inbox_subscribes)
+            for _ in range(5):
+                received_count = 0
+                async for _msg in discovered.prompt("ping", timeout=10.0):
+                    received_count += 1
+                assert received_count >= 1
+            opened = inbox_subscribes[baseline:]
+        finally:
+            await agents.close()
+    finally:
+        nc.subscribe = original_subscribe  # type: ignore[method-assign]
+
+    assert len(opened) == 1, (
+        f"expected 1 mux inbox SUB across 5 prompts to TS agent; opened {len(opened)}: {opened!r}"
+    )
+    assert opened[0].startswith("_INBOX.agents.")

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -29,10 +29,14 @@ from synadia_ai.agents import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nats.aio.client import Client as NATSClient
     from nats.aio.msg import Msg
 
     from tests.harness.evidence import EvidenceRecorder
+
+    BgTasks = Callable[[asyncio.Task[object]], None]
 
 
 PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.wireecon"
@@ -66,7 +70,7 @@ def _response_chunk(text: str) -> bytes:
 
 
 async def test_five_prompts_open_one_mux_subscription(
-    nc: NATSClient, evidence: EvidenceRecorder
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:
     """A 5-prompt sequence opens exactly ONE inbox subscription (the mux).
 
@@ -96,13 +100,13 @@ async def test_five_prompts_open_one_mux_subscription(
             await nc.publish(msg.reply, _response_chunk("ok"))
             await nc.publish(msg.reply, b"")  # terminator
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await original_subscribe(PROMPT_SUBJECT, cb=echo_agent)
     try:
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
-        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+        agent = Agent(nc, info, close_event=agents.close_event)
 
         # Snapshot pre-prompt count so we don't conflate other
         # subscriptions opened by the test harness/agents.

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -24,8 +24,10 @@ Two layers of evidence:
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 import urllib.request
+import weakref
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 
@@ -36,7 +38,7 @@ from synadia_ai.agents import (
     EndpointInfo,
     ResponseChunk,
 )
-from synadia_ai.agents._mux import mux_for
+from synadia_ai.agents._mux import _MUX_CACHE, mux_for
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -78,6 +80,30 @@ def _make_agent_info(prompt_subject: str) -> AgentInfo:
 
 def _response_chunk(text: str) -> bytes:
     return json.dumps({"type": "response", "data": text}).encode("utf-8")
+
+
+class _WeakrefableClient:
+    pass
+
+
+def test_mux_cache_does_not_keep_dropped_client_alive() -> None:
+    """The weak-keyed mux cache must not retain closed/dropped Clients."""
+    client = _WeakrefableClient()
+    client_ref = weakref.ref(client)
+    mux = mux_for(cast("NATSClient", client))
+
+    assert mux_for(cast("NATSClient", client)) is mux
+
+    del client
+    for _ in range(5):
+        gc.collect()
+        # Touch the weak dictionary so pending removals are committed.
+        list(_MUX_CACHE.items())
+        if client_ref() is None:
+            break
+
+    assert client_ref() is None
+    assert all(cached is not mux for cached in _MUX_CACHE.values())
 
 
 async def test_five_prompts_open_one_mux_subscription(

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -1,0 +1,134 @@
+"""Wire-economy regression: one SUB per :class:`Agents`, not one per prompt.
+
+The interim mux inbox (`src/synadia_ai/agents/_mux.py`) exists to cut
+SUB+flush traffic from one-per-prompt to one-per-:class:`Agents`. That's
+the load-bearing observable consequence of PR #66 / TS PR-66-Python-
+catch-up — assert it directly so a regression to the per-prompt
+``subscribe + publish`` pattern shows up as a test failure rather than
+a silent perf regression.
+
+We can't observe SUB frames from a NATS client (nats-py doesn't surface
+them), so we instead instrument the connection's own ``subscribe()``
+method and count calls during a 5-prompt sequence. The expected count
+is 1 (the mux SUB), not 5.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from synadia_ai.agents import (
+    Agent,
+    AgentInfo,
+    Agents,
+    EndpointInfo,
+    ResponseChunk,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
+
+    from tests.harness.evidence import EvidenceRecorder
+
+
+PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.wireecon"
+
+
+def _make_agent_info(prompt_subject: str) -> AgentInfo:
+    prompt_endpoint = EndpointInfo(
+        name="prompt",
+        subject=prompt_subject,
+        queue_group="agents",
+        metadata=MappingProxyType({}),
+        max_payload_bytes=None,
+        attachments_ok=True,
+    )
+    return AgentInfo(
+        instance_id="test-instance",
+        agent="test-agent",
+        owner="pytest",
+        session_name="wireecon",
+        protocol_version="0.3",
+        description="",
+        version="0.0.0",
+        metadata=MappingProxyType({"agent": "test-agent", "owner": "pytest"}),
+        endpoints=(prompt_endpoint,),
+        prompt_endpoint=prompt_endpoint,
+    )
+
+
+def _response_chunk(text: str) -> bytes:
+    return json.dumps({"type": "response", "data": text}).encode("utf-8")
+
+
+async def test_five_prompts_open_one_mux_subscription(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """A 5-prompt sequence opens exactly ONE inbox subscription (the mux).
+
+    Pre-PR every prompt called ``await nc.subscribe(reply)`` for its
+    own one-shot inbox — five prompts → five SUBs. After the mux
+    refactor a single ``_INBOX.agents.<mux>.*`` SUB covers all five
+    streams.
+
+    To count SUBs we count entries to the mux inbox prefix in
+    ``messages.jsonl``... actually nats-py doesn't echo SUB frames. We
+    instrument ``nc.subscribe`` directly and tag inbox subscriptions
+    via the subject prefix.
+    """
+
+    inbox_subscribes: list[str] = []
+    original_subscribe = nc.subscribe
+
+    async def counting_subscribe(subject: str, *args: object, **kwargs: object) -> object:
+        if subject.startswith("_INBOX.agents."):
+            inbox_subscribes.append(subject)
+        return await original_subscribe(subject, *args, **kwargs)  # type: ignore[arg-type]
+
+    nc.subscribe = counting_subscribe  # type: ignore[method-assign,assignment]
+
+    async def echo_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            await nc.publish(msg.reply, _response_chunk("ok"))
+            await nc.publish(msg.reply, b"")  # terminator
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await original_subscribe(PROMPT_SUBJECT, cb=echo_agent)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+        # Snapshot pre-prompt count so we don't conflate other
+        # subscriptions opened by the test harness/agents.
+        baseline = len(inbox_subscribes)
+
+        for i in range(5):
+            received: list[str] = []
+            async for chunk in agent.prompt(f"prompt-{i}"):
+                if isinstance(chunk, ResponseChunk):
+                    received.append(chunk.text)
+            assert received == ["ok"], f"prompt {i} got unexpected chunks: {received!r}"
+
+        opened_during_prompts = inbox_subscribes[baseline:]
+        await agents.close()
+    finally:
+        await sub.unsubscribe()
+        nc.subscribe = original_subscribe  # type: ignore[method-assign]
+
+    # Exactly ONE inbox SUB during the 5-prompt sequence — the mux.
+    assert len(opened_during_prompts) == 1, (
+        f"expected 1 mux inbox SUB across 5 prompts; opened {len(opened_during_prompts)}: "
+        f"{opened_during_prompts!r}"
+    )
+    # Sanity: it really does live under the SDK inbox prefix.
+    assert opened_during_prompts[0].startswith("_INBOX.agents.")
+    evidence.write_json(
+        "sub_count.json",
+        {"prompts": 5, "inbox_subs_opened": len(opened_during_prompts)},
+    )

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -228,6 +228,15 @@ async def test_broker_sees_one_mux_subscription_for_n_prompts(
         f"broker reports {len(mux_subs)} subscription(s) under mux prefix "
         f"{mux_prefix!r} — expected exactly 1 (the mux). Subs: {mux_subs!r}"
     )
+    # Tighter than just "starts with the prefix": the one subscription
+    # MUST be the wildcard ``<mux_prefix>.*`` itself. A regression that
+    # opened a per-prompt SUB on ``<mux_prefix>.<token>`` and
+    # unsubscribed before our poll would still match the prefix filter
+    # by accident; this assertion catches that failure mode by
+    # demanding the exact wildcard form.
+    assert mux_subs[0].get("subject") == f"{mux_prefix}.*", (
+        f"expected mux SUB to be wildcard {mux_prefix}.*; got {mux_subs[0].get('subject')!r}"
+    )
     evidence.write_json(
         "broker_subsz.json",
         {

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -7,18 +7,27 @@ catch-up — assert it directly so a regression to the per-prompt
 ``subscribe + publish`` pattern shows up as a test failure rather than
 a silent perf regression.
 
-We can't observe SUB frames from a NATS client (nats-py doesn't surface
-them), so we instead instrument the connection's own ``subscribe()``
-method and count calls during a 5-prompt sequence. The expected count
-is 1 (the mux SUB), not 5.
+Two layers of evidence:
+
+1. :func:`test_five_prompts_open_one_mux_subscription` — instruments
+   the SDK's ``nc.subscribe`` callsite. Fast, deterministic, fails on
+   any code path that adds a per-prompt SDK-level subscribe call.
+2. :func:`test_broker_sees_one_mux_subscription_for_n_prompts` — hits
+   the broker's HTTP monitoring ``/subsz`` endpoint and asserts the
+   subscription count under the mux's exact inbox prefix. Catches a
+   subtler regression where some hand-rolled path bypasses
+   ``nc.subscribe`` (e.g. constructs a ``Subscription`` directly via
+   internal nats-py API). The HTTP endpoint is enabled unconditionally
+   by :func:`tests.harness.nats_server.start_server`.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import urllib.request
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from synadia_ai.agents import (
     Agent,
@@ -27,6 +36,7 @@ from synadia_ai.agents import (
     EndpointInfo,
     ResponseChunk,
 )
+from synadia_ai.agents._mux import mux_for
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -35,6 +45,7 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg
 
     from tests.harness.evidence import EvidenceRecorder
+    from tests.harness.nats_server import RunningServer
 
     BgTasks = Callable[[asyncio.Task[object]], None]
 
@@ -135,4 +146,97 @@ async def test_five_prompts_open_one_mux_subscription(
     evidence.write_json(
         "sub_count.json",
         {"prompts": 5, "inbox_subs_opened": len(opened_during_prompts)},
+    )
+
+
+def _fetch_subsz(monitoring_url: str) -> dict[str, Any]:
+    """Synchronous GET of the broker's ``/subsz?subs=1`` endpoint.
+
+    Synchronous because :mod:`urllib.request` doesn't need an event
+    loop and the call is sub-millisecond against a localhost server.
+    Avoids dragging in :mod:`aiohttp` for one cold poll.
+    """
+    with urllib.request.urlopen(
+        f"{monitoring_url}/subsz?subs=1", timeout=2.0
+    ) as response:
+        return cast("dict[str, Any]", json.loads(response.read()))
+
+
+async def test_broker_sees_one_mux_subscription_for_n_prompts(
+    nats_server: RunningServer,
+    nc: NATSClient,
+    evidence: EvidenceRecorder,
+    bg_tasks: BgTasks,
+) -> None:
+    """Broker-observed truth: exactly one SUB under this mux's inbox prefix.
+
+    Complements :func:`test_five_prompts_open_one_mux_subscription` by
+    asking the broker — not the SDK — how many subscriptions actually
+    exist for the mux's inbox prefix during a multi-prompt sequence.
+    A regression that bypasses ``nc.subscribe`` (hand-rolled
+    :class:`~nats.aio.subscription.Subscription`, or any future code
+    path that registers SUBs without going through ``nc.subscribe``)
+    would fool the SDK-instrumented test but not this one.
+
+    We filter by the mux's exact ``inbox_prefix`` (one nuid per
+    connection) so other tests' lingering subs and the test
+    harness's evidence-recorder ``_INBOX.>`` cannot be conflated
+    with this connection's mux.
+    """
+    n_prompts = 5
+
+    async def echo_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            await nc.publish(msg.reply, _response_chunk("ok"))
+            await nc.publish(msg.reply, b"")  # terminator
+
+        bg_tasks(asyncio.create_task(emit()))
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=echo_agent)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, close_event=agents.close_event)
+
+        for i in range(n_prompts):
+            received: list[str] = []
+            async for chunk in agent.prompt(f"prompt-{i}"):
+                if isinstance(chunk, ResponseChunk):
+                    received.append(chunk.text)
+            assert received == ["ok"], f"prompt {i} got unexpected chunks: {received!r}"
+
+        # Flush the connection so every SUB/UNSUB has reached the broker
+        # before we poll, otherwise the broker's view can lag the SDK's.
+        await nc.flush()
+
+        # Mux-instance prefix — unique per connection. Filtering by the
+        # exact prefix means other tests' lingering subs, the
+        # evidence-recorder `_INBOX.>`, and any future test running in
+        # parallel cannot inflate the count.
+        mux_prefix = mux_for(nc).inbox_prefix
+        subsz = _fetch_subsz(nats_server.monitoring_url)
+        all_subs = subsz.get("subscriptions_list", []) or subsz.get("subscriptions", [])
+        mux_subs = [
+            entry
+            for entry in all_subs
+            if isinstance(entry, dict) and str(entry.get("subject", "")).startswith(mux_prefix)
+        ]
+
+        await agents.close()
+    finally:
+        await sub.unsubscribe()
+
+    assert len(mux_subs) == 1, (
+        f"broker reports {len(mux_subs)} subscription(s) under mux prefix "
+        f"{mux_prefix!r} — expected exactly 1 (the mux). Subs: {mux_subs!r}"
+    )
+    evidence.write_json(
+        "broker_subsz.json",
+        {
+            "prompts": n_prompts,
+            "mux_prefix": mux_prefix,
+            "mux_subs_count": len(mux_subs),
+            "mux_subs": mux_subs,
+            "broker_total_subscriptions": subsz.get("num_subscriptions"),
+        },
     )

--- a/client-sdk/python/tests/test_mux_wire_economy.py
+++ b/client-sdk/python/tests/test_mux_wire_economy.py
@@ -156,9 +156,7 @@ def _fetch_subsz(monitoring_url: str) -> dict[str, Any]:
     loop and the call is sub-millisecond against a localhost server.
     Avoids dragging in :mod:`aiohttp` for one cold poll.
     """
-    with urllib.request.urlopen(
-        f"{monitoring_url}/subsz?subs=1", timeout=2.0
-    ) as response:
+    with urllib.request.urlopen(f"{monitoring_url}/subsz?subs=1", timeout=2.0) as response:
         return cast("dict[str, Any]", json.loads(response.read()))
 
 

--- a/client-sdk/python/tests/test_prompt_cancel_race.py
+++ b/client-sdk/python/tests/test_prompt_cancel_race.py
@@ -283,31 +283,42 @@ async def test_close_during_prompt_yields_protocol_error(
     """Plan §race-analysis #7 — half B: ``close()`` fires *during* the loop.
 
     Once the prompt has gotten past its synchronous pre-flight check
-    and started awaiting chunks, ``Agents.close()`` propagates via the
-    per-stream close-watcher pushing :data:`_CLOSE_SENTINEL`; the
-    iterator raises :class:`ProtocolError` (not
-    :class:`AgentsClosedError`) so callers can branch on
-    "torn down mid-flight" vs "called against a closed Agents."
+    AND past the publish (so the post-publish close-watcher is armed),
+    ``Agents.close()`` propagates via the per-stream watcher pushing
+    :data:`_CLOSE_SENTINEL`; the iterator raises :class:`ProtocolError`
+    (not :class:`AgentsClosedError`) so callers can branch on "torn
+    down mid-flight" vs "called against a closed Agents."
+
+    Synchronisation is event-driven, not ``asyncio.sleep(0)``-based:
+    the fake agent yields one chunk, and the consumer signals an event
+    on receipt. Once that fires, the consumer is provably *past* both
+    pre-publish close checks and into the iteration body — so close
+    can only land in the mid-stream path. Without this, an interim
+    pre-publish race-window check could trip first and raise
+    :class:`AgentsClosedError`, masquerading as the mid-stream path.
     """
+    consumer_in_iteration = asyncio.Event()
 
-    async def silent_agent(msg: Msg) -> None:
-        del msg
+    async def one_chunk_agent(msg: Msg) -> None:
+        # Single chunk, no terminator — keeps the consumer iterating
+        # forever after delivery so close can fire mid-loop.
+        await nc.publish(msg.reply, _response_chunk_bytes("alive"))
 
-    sub = await nc.subscribe(PROMPT_SUBJECT, cb=silent_agent)
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=one_chunk_agent)
     try:
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
         agent = Agent(nc, info, close_event=agents.close_event)
 
-        # Start the prompt; once it's blocked on queue.get, fire close.
-        consume_started = asyncio.Event()
         outcome: dict[str, str] = {}
 
         async def consume() -> None:
             try:
-                consume_started.set()
-                async for _ in agent.prompt("hold open", timeout=60.0):
-                    pass
+                async for chunk in agent.prompt("hold open", timeout=60.0):
+                    if isinstance(chunk, ResponseChunk):
+                        # First chunk delivered → consumer is provably past
+                        # publish + close-watcher arming; safe to fire close.
+                        consumer_in_iteration.set()
             except AgentsClosedError as exc:
                 outcome["raised"] = f"AgentsClosedError: {exc}"
             except ProtocolError as exc:
@@ -315,11 +326,7 @@ async def test_close_during_prompt_yields_protocol_error(
                 outcome["msg"] = str(exc)
 
         consumer = asyncio.create_task(consume())
-        await consume_started.wait()
-        # Yield twice so the prompt advances past pre-flight + publish
-        # and parks on queue.get() before close fires.
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await asyncio.wait_for(consumer_in_iteration.wait(), timeout=2.0)
         await agents.close()
         await asyncio.wait_for(consumer, timeout=2.0)
 

--- a/client-sdk/python/tests/test_prompt_cancel_race.py
+++ b/client-sdk/python/tests/test_prompt_cancel_race.py
@@ -37,12 +37,17 @@ from synadia_ai.agents import (
     ProtocolError,
     ResponseChunk,
 )
+from synadia_ai.agents._mux import mux_for
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nats.aio.client import Client as NATSClient
     from nats.aio.msg import Msg
 
     from tests.harness.evidence import EvidenceRecorder
+
+    BgTasks = Callable[[asyncio.Task[object]], None]
 
 
 PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.cancel"
@@ -76,7 +81,7 @@ def _response_chunk_bytes(text: str) -> bytes:
 
 
 async def test_agents_close_during_live_stream_unblocks_promptly(
-    nc: NATSClient, evidence: EvidenceRecorder
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:
     """A live consumer raises within ~50 ms of :meth:`Agents.close`, not on timeout."""
 
@@ -88,14 +93,14 @@ async def test_agents_close_during_live_stream_unblocks_promptly(
                 i += 1
                 await asyncio.sleep(0.05)
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=trickle_agent)
     try:
         # Build an Agents that owns the mux, plus an Agent attached to it.
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
-        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+        agent = Agent(nc, info, close_event=agents.close_event)
 
         consume_started = asyncio.Event()
         close_fired_at: dict[str, float] = {}
@@ -129,22 +134,9 @@ async def test_agents_close_during_live_stream_unblocks_promptly(
         await sub.unsubscribe()
 
 
-async def test_register_after_close_raises(nc: NATSClient, evidence: EvidenceRecorder) -> None:
-    """Calling :meth:`Agent.prompt` after :meth:`Agents.close` raises cleanly."""
-    agents = Agents(nc=nc)
-    info = _make_agent_info(PROMPT_SUBJECT)
-    agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
-
-    await agents.close()
-
-    with pytest.raises(AgentsClosedError):
-        async for _ in agent.prompt("anyone home?"):
-            pass
-
-    evidence.write_json("status.json", {"raised": "AgentsClosedError"})
-
-
-async def test_concurrent_prompts_isolated(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+async def test_concurrent_prompts_isolated(
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
+) -> None:
     """50 concurrent prompts on the shared mux see ONLY their own chunks."""
 
     n_streams = 50
@@ -166,13 +158,13 @@ async def test_concurrent_prompts_isolated(nc: NATSClient, evidence: EvidenceRec
                 await nc.publish(msg.reply, _response_chunk_bytes(f"{payload_text}#{i}"))
             await nc.publish(msg.reply, b"")  # terminator
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=echo_agent)
     try:
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
-        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+        agent = Agent(nc, info, close_event=agents.close_event)
 
         async def run_one(idx: int) -> list[str]:
             seen: list[str] = []
@@ -199,7 +191,7 @@ async def test_concurrent_prompts_isolated(nc: NATSClient, evidence: EvidenceRec
 
 
 async def test_cancel_during_iteration_unregisters_token(
-    nc: NATSClient, evidence: EvidenceRecorder
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:
     """``aclose()`` on the prompt iterator runs the ``finally``: unregister().
 
@@ -220,13 +212,13 @@ async def test_cancel_during_iteration_unregisters_token(
                 i += 1
                 await asyncio.sleep(0.05)
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=emit_forever)
     try:
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
-        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+        agent = Agent(nc, info, close_event=agents.close_event)
 
         seen_first: list[str] = []
         # `agent.prompt()` is an async generator (has aclose), but the
@@ -241,9 +233,8 @@ async def test_cancel_during_iteration_unregisters_token(
                         break
 
         # After aclose() the routing dict should be empty.
-        assert agents.mux._routes == {}, (
-            f"orphan tokens after aclose: {list(agents.mux._routes.keys())}"
-        )
+        mux = mux_for(nc)
+        assert mux._routes == {}, f"orphan tokens after aclose: {list(mux._routes.keys())}"
 
         await agents.close()
     finally:
@@ -252,15 +243,16 @@ async def test_cancel_during_iteration_unregisters_token(
     evidence.write_json("seen_first.json", seen_first)
 
 
-async def test_concurrent_close_and_register_is_safe(
+async def test_close_before_prompt_raises_agents_closed_error(
     nc: NATSClient, evidence: EvidenceRecorder
 ) -> None:
-    """Plan §race-analysis #7: ``close()`` racing with ``register()`` is safe.
+    """Plan §race-analysis #7 — half A: ``close()`` *before* ``prompt()``.
 
-    Either ``register()`` runs first and gets a sentinel via close()'s
-    sweep, or it runs second and raises :class:`AgentsClosedError`.
-    Both outcomes are acceptable; the bad outcome (orphan token, no
-    error) MUST NOT happen.
+    Schedules close() to run before the prompt's first event-loop tick
+    so the synchronous pre-flight check at the top of
+    :meth:`Agent._stream_prompt` sees ``close_event.is_set()`` and
+    raises :class:`AgentsClosedError`. This is the
+    "obviously-closed" branch.
     """
 
     async def silent_agent(msg: Msg) -> None:
@@ -270,40 +262,73 @@ async def test_concurrent_close_and_register_is_safe(
     try:
         agents = Agents(nc=nc)
         info = _make_agent_info(PROMPT_SUBJECT)
-        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+        agent = Agent(nc, info, close_event=agents.close_event)
 
-        # Pre-warm the mux so close() has a real subscription to tear down.
-        await agents.mux.start()
+        await agents.close()  # set close_event before any prompt runs
 
-        outcomes: list[str] = []
+        with pytest.raises(AgentsClosedError):
+            async for _ in agent.prompt("after-close"):
+                pass
 
-        async def attempt_prompt() -> None:
-            try:
-                async for _ in agent.prompt("racy"):
-                    pass
-            except AgentsClosedError:
-                outcomes.append("AgentsClosedError")
-            except ProtocolError as exc:
-                if "closed" in str(exc).lower():
-                    outcomes.append("ProtocolError-closed")
-                else:
-                    outcomes.append(f"ProtocolError-other: {exc}")
-            except Exception as exc:
-                outcomes.append(f"unexpected: {type(exc).__name__}")
-
-        # Fire prompt + close concurrently.
-        await asyncio.gather(attempt_prompt(), agents.close())
-
-        # Whatever order the race resolved in, we must have observed
-        # one of the two clean-exit outcomes. The bad outcome (silent
-        # hang or orphan token) would manifest as a hung gather above.
-        assert outcomes and outcomes[0] in (
-            "AgentsClosedError",
-            "ProtocolError-closed",
-        ), f"unexpected outcomes: {outcomes!r}"
-        # And after close, no orphan tokens linger.
-        assert agents.mux._routes == {}
+        assert mux_for(nc)._routes == {}
     finally:
         await sub.unsubscribe()
 
-    evidence.write_json("race_outcomes.json", outcomes)
+    evidence.write_json("status.json", {"raised": "AgentsClosedError"})
+
+
+async def test_close_during_prompt_yields_protocol_error(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """Plan §race-analysis #7 — half B: ``close()`` fires *during* the loop.
+
+    Once the prompt has gotten past its synchronous pre-flight check
+    and started awaiting chunks, ``Agents.close()`` propagates via the
+    per-stream close-watcher pushing :data:`_CLOSE_SENTINEL`; the
+    iterator raises :class:`ProtocolError` (not
+    :class:`AgentsClosedError`) so callers can branch on
+    "torn down mid-flight" vs "called against a closed Agents."
+    """
+
+    async def silent_agent(msg: Msg) -> None:
+        del msg
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=silent_agent)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, close_event=agents.close_event)
+
+        # Start the prompt; once it's blocked on queue.get, fire close.
+        consume_started = asyncio.Event()
+        outcome: dict[str, str] = {}
+
+        async def consume() -> None:
+            try:
+                consume_started.set()
+                async for _ in agent.prompt("hold open", timeout=60.0):
+                    pass
+            except AgentsClosedError as exc:
+                outcome["raised"] = f"AgentsClosedError: {exc}"
+            except ProtocolError as exc:
+                outcome["raised"] = "ProtocolError"
+                outcome["msg"] = str(exc)
+
+        consumer = asyncio.create_task(consume())
+        await consume_started.wait()
+        # Yield twice so the prompt advances past pre-flight + publish
+        # and parks on queue.get() before close fires.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await agents.close()
+        await asyncio.wait_for(consumer, timeout=2.0)
+
+        assert outcome.get("raised") == "ProtocolError", (
+            f"expected mid-flight ProtocolError, got {outcome!r}"
+        )
+        assert "Agents is closed" in outcome.get("msg", "")
+        assert mux_for(nc)._routes == {}
+    finally:
+        await sub.unsubscribe()
+
+    evidence.write_json("outcome.json", outcome)

--- a/client-sdk/python/tests/test_prompt_cancel_race.py
+++ b/client-sdk/python/tests/test_prompt_cancel_race.py
@@ -3,8 +3,10 @@
 Plan §race analysis covers a dozen-odd windows where a prompt can be
 cancelled or torn down. These tests pin the load-bearing ones:
 
-- :class:`Agents.close` mid-stream delivers a sentinel that unblocks the
-  consumer within an event-loop tick, NOT after the inactivity timer.
+- :class:`Agents.close` mid-stream wins the stream wait race and unblocks
+  the consumer within an event-loop tick, NOT after the inactivity timer.
+- :class:`Agents.close` wins over chunks and terminators already queued
+  in the mux inbox.
 - 50 concurrent prompts on the same shared mux see only their own
   chunks (no token cross-talk).
 - :meth:`Agent.prompt` after :meth:`Agents.close` raises a clean error
@@ -80,6 +82,22 @@ def _response_chunk_bytes(text: str) -> bytes:
     return json.dumps({"type": "response", "data": text}).encode("utf-8")
 
 
+async def _wait_for_buffered_route_depth(nc: NATSClient, min_depth: int) -> list[int]:
+    """Wait until an active mux route has at least ``min_depth`` queued replies."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2.0
+    mux = mux_for(nc)
+    while loop.time() < deadline:
+        depths = [route.queue.qsize() for route in mux._routes.values()]
+        if depths and max(depths) >= min_depth:
+            return depths
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"timed out waiting for mux route queue depth >= {min_depth}; "
+        f"depths={[route.queue.qsize() for route in mux._routes.values()]}"
+    )
+
+
 async def test_agents_close_during_live_stream_unblocks_promptly(
     nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:
@@ -110,7 +128,7 @@ async def test_agents_close_during_live_stream_unblocks_promptly(
             consume_started.set()
             with pytest.raises(ProtocolError) as excinfo:
                 # Use a long inactivity timeout so the failure path
-                # MUST come from the close-sentinel, not from inactivity.
+                # MUST come from the close lifecycle path, not from inactivity.
                 async for _ in agent.prompt("hold open", timeout=60.0):
                     pass
             consume_unblocked_at["t"] = time.monotonic()
@@ -127,7 +145,7 @@ async def test_agents_close_during_live_stream_unblocks_promptly(
         elapsed_ms = (consume_unblocked_at["t"] - close_fired_at["t"]) * 1000
         # Assert "promptly" — well under any inactivity deadline.
         assert elapsed_ms < 500, (
-            f"close→unblock took {elapsed_ms:.1f} ms; expected <500 ms (mux sentinel path)"
+            f"close→unblock took {elapsed_ms:.1f} ms; expected <500 ms (close path)"
         )
         evidence.write_json("close_latency.json", {"unblock_ms": elapsed_ms})
     finally:
@@ -243,6 +261,51 @@ async def test_cancel_during_iteration_unregisters_token(
     evidence.write_json("seen_first.json", seen_first)
 
 
+async def test_close_wins_over_buffered_chunks_and_terminator(
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
+) -> None:
+    """Close beats mux FIFO backlog, including an already-queued terminator."""
+    emitted_all = asyncio.Event()
+
+    async def burst_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            await nc.publish(msg.reply, _response_chunk_bytes("first"))
+            await nc.publish(msg.reply, _response_chunk_bytes("buffered"))
+            await nc.publish(msg.reply, b"")
+            await nc.flush()
+            emitted_all.set()
+
+        bg_tasks(asyncio.create_task(emit()))
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=burst_agent)
+    stream: AsyncGenerator[object, None] | None = None
+    depths: list[int] = []
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, close_event=agents.close_event)
+
+        stream = cast(AsyncGenerator[object, None], agent.prompt("burst", timeout=60.0))
+        first = await anext(stream)
+        assert isinstance(first, ResponseChunk)
+        assert first.text == "first"
+        await asyncio.wait_for(emitted_all.wait(), timeout=2.0)
+        depths = await _wait_for_buffered_route_depth(nc, min_depth=2)
+
+        await agents.close()
+        with pytest.raises(ProtocolError) as excinfo:
+            await anext(stream)
+
+        assert "Agents is closed" in str(excinfo.value)
+        assert mux_for(nc)._routes == {}
+    finally:
+        if stream is not None:
+            await stream.aclose()
+        await sub.unsubscribe()
+
+    evidence.write_json("buffered_close.json", {"queued_depths_before_close": depths})
+
+
 async def test_close_before_prompt_raises_agents_closed_error(
     nc: NATSClient, evidence: EvidenceRecorder
 ) -> None:
@@ -283,9 +346,9 @@ async def test_close_during_prompt_yields_protocol_error(
     """Plan §race-analysis #7 — half B: ``close()`` fires *during* the loop.
 
     Once the prompt has gotten past its synchronous pre-flight check
-    AND past the publish (so the post-publish close-watcher is armed),
-    ``Agents.close()`` propagates via the per-stream watcher pushing
-    :data:`_CLOSE_SENTINEL`; the iterator raises :class:`ProtocolError`
+    AND past the publish (so the post-publish lifecycle wait is active),
+    ``Agents.close()`` wins the stream wait race; the iterator raises
+    :class:`ProtocolError`
     (not :class:`AgentsClosedError`) so callers can branch on "torn
     down mid-flight" vs "called against a closed Agents."
 
@@ -317,7 +380,7 @@ async def test_close_during_prompt_yields_protocol_error(
                 async for chunk in agent.prompt("hold open", timeout=60.0):
                     if isinstance(chunk, ResponseChunk):
                         # First chunk delivered → consumer is provably past
-                        # publish + close-watcher arming; safe to fire close.
+                        # publish + lifecycle wait setup; safe to fire close.
                         consumer_in_iteration.set()
             except AgentsClosedError as exc:
                 outcome["raised"] = f"AgentsClosedError: {exc}"

--- a/client-sdk/python/tests/test_prompt_cancel_race.py
+++ b/client-sdk/python/tests/test_prompt_cancel_race.py
@@ -24,7 +24,7 @@ import asyncio
 import json
 import time
 from collections.abc import AsyncGenerator
-from contextlib import aclosing
+from contextlib import aclosing, suppress
 from types import MappingProxyType
 from typing import TYPE_CHECKING, cast
 
@@ -95,6 +95,29 @@ async def _wait_for_buffered_route_depth(nc: NATSClient, min_depth: int) -> list
     raise AssertionError(
         f"timed out waiting for mux route queue depth >= {min_depth}; "
         f"depths={[route.queue.qsize() for route in mux._routes.values()]}"
+    )
+
+
+def _active_prompt_wait_tasks() -> list[asyncio.Task[object]]:
+    current = asyncio.current_task()
+    return [
+        cast(asyncio.Task[object], task)
+        for task in asyncio.all_tasks()
+        if task is not current and not task.done() and task.get_name().startswith("agents-prompt-")
+    ]
+
+
+async def _wait_for_active_prompt_wait_tasks(min_count: int) -> list[asyncio.Task[object]]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2.0
+    while loop.time() < deadline:
+        tasks = _active_prompt_wait_tasks()
+        if len(tasks) >= min_count:
+            return tasks
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        "timed out waiting for prompt wait tasks; "
+        f"active={[task.get_name() for task in _active_prompt_wait_tasks()]}"
     )
 
 
@@ -304,6 +327,51 @@ async def test_close_wins_over_buffered_chunks_and_terminator(
         await sub.unsubscribe()
 
     evidence.write_json("buffered_close.json", {"queued_depths_before_close": depths})
+
+
+async def test_cancelling_consumer_cancels_prompt_wait_tasks(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """Caller-side cancellation must clean up queue/max-wait/close wait tasks."""
+
+    async def silent_agent(msg: Msg) -> None:
+        del msg
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=silent_agent)
+    agents = Agents(nc=nc)
+    stream: AsyncGenerator[object, None] | None = None
+    try:
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, close_event=agents.close_event)
+        stream = cast(
+            AsyncGenerator[object, None],
+            agent.prompt("cancel wait", timeout=60.0, max_wait_s=60.0),
+        )
+
+        consumer = asyncio.create_task(anext(stream), name="test-cancel-prompt-consumer")
+        wait_tasks = await _wait_for_active_prompt_wait_tasks(min_count=3)
+        wait_task_names = sorted(task.get_name() for task in wait_tasks)
+
+        consumer.cancel()
+        with suppress(asyncio.CancelledError):
+            await consumer
+        await asyncio.sleep(0)
+
+        leaked = _active_prompt_wait_tasks()
+        leaked_names = sorted(task.get_name() for task in leaked)
+        for task in leaked:
+            task.cancel()
+        if leaked:
+            await asyncio.gather(*leaked, return_exceptions=True)
+
+        assert leaked_names == []
+        assert mux_for(nc)._routes == {}
+        evidence.write_json("cancelled_wait_tasks.json", {"cancelled": wait_task_names})
+    finally:
+        if stream is not None:
+            await stream.aclose()
+        await agents.close()
+        await sub.unsubscribe()
 
 
 async def test_close_before_prompt_raises_agents_closed_error(

--- a/client-sdk/python/tests/test_prompt_cancel_race.py
+++ b/client-sdk/python/tests/test_prompt_cancel_race.py
@@ -1,0 +1,309 @@
+"""Cancellation and teardown races on the interim mux-inbox prompt path.
+
+Plan §race analysis covers a dozen-odd windows where a prompt can be
+cancelled or torn down. These tests pin the load-bearing ones:
+
+- :class:`Agents.close` mid-stream delivers a sentinel that unblocks the
+  consumer within an event-loop tick, NOT after the inactivity timer.
+- 50 concurrent prompts on the same shared mux see only their own
+  chunks (no token cross-talk).
+- :meth:`Agent.prompt` after :meth:`Agents.close` raises a clean error
+  rather than silently registering an orphan token.
+
+Each test uses a tiny in-process fake agent (a NATS subscription
+callback) so the suite covers the whole client path — mux subscribe,
+publish, queue dispatch, terminator detection — without depending on
+the agent-sdk distribution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
+from types import MappingProxyType
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from synadia_ai.agents import (
+    Agent,
+    AgentInfo,
+    Agents,
+    AgentsClosedError,
+    EndpointInfo,
+    ProtocolError,
+    ResponseChunk,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
+
+    from tests.harness.evidence import EvidenceRecorder
+
+
+PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.cancel"
+
+
+def _make_agent_info(prompt_subject: str) -> AgentInfo:
+    prompt_endpoint = EndpointInfo(
+        name="prompt",
+        subject=prompt_subject,
+        queue_group="agents",
+        metadata=MappingProxyType({}),
+        max_payload_bytes=None,
+        attachments_ok=True,
+    )
+    return AgentInfo(
+        instance_id="test-instance",
+        agent="test-agent",
+        owner="pytest",
+        session_name="cancel",
+        protocol_version="0.3",
+        description="",
+        version="0.0.0",
+        metadata=MappingProxyType({"agent": "test-agent", "owner": "pytest"}),
+        endpoints=(prompt_endpoint,),
+        prompt_endpoint=prompt_endpoint,
+    )
+
+
+def _response_chunk_bytes(text: str) -> bytes:
+    return json.dumps({"type": "response", "data": text}).encode("utf-8")
+
+
+async def test_agents_close_during_live_stream_unblocks_promptly(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """A live consumer raises within ~50 ms of :meth:`Agents.close`, not on timeout."""
+
+    async def trickle_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            i = 0
+            while True:
+                await nc.publish(msg.reply, _response_chunk_bytes(f"trickle-{i}"))
+                i += 1
+                await asyncio.sleep(0.05)
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=trickle_agent)
+    try:
+        # Build an Agents that owns the mux, plus an Agent attached to it.
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+        consume_started = asyncio.Event()
+        close_fired_at: dict[str, float] = {}
+        consume_unblocked_at: dict[str, float] = {}
+
+        async def consume() -> None:
+            consume_started.set()
+            with pytest.raises(ProtocolError) as excinfo:
+                # Use a long inactivity timeout so the failure path
+                # MUST come from the close-sentinel, not from inactivity.
+                async for _ in agent.prompt("hold open", timeout=60.0):
+                    pass
+            consume_unblocked_at["t"] = time.monotonic()
+            assert "Agents is closed" in str(excinfo.value)
+
+        consumer = asyncio.create_task(consume())
+        await consume_started.wait()
+        # Let the agent start emitting so the stream is genuinely live.
+        await asyncio.sleep(0.15)
+        close_fired_at["t"] = time.monotonic()
+        await agents.close()
+        await asyncio.wait_for(consumer, timeout=2.0)
+
+        elapsed_ms = (consume_unblocked_at["t"] - close_fired_at["t"]) * 1000
+        # Assert "promptly" — well under any inactivity deadline.
+        assert elapsed_ms < 500, (
+            f"close→unblock took {elapsed_ms:.1f} ms; expected <500 ms (mux sentinel path)"
+        )
+        evidence.write_json("close_latency.json", {"unblock_ms": elapsed_ms})
+    finally:
+        await sub.unsubscribe()
+
+
+async def test_register_after_close_raises(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+    """Calling :meth:`Agent.prompt` after :meth:`Agents.close` raises cleanly."""
+    agents = Agents(nc=nc)
+    info = _make_agent_info(PROMPT_SUBJECT)
+    agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+    await agents.close()
+
+    with pytest.raises(AgentsClosedError):
+        async for _ in agent.prompt("anyone home?"):
+            pass
+
+    evidence.write_json("status.json", {"raised": "AgentsClosedError"})
+
+
+async def test_concurrent_prompts_isolated(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+    """50 concurrent prompts on the shared mux see ONLY their own chunks."""
+
+    n_streams = 50
+    chunks_per_stream = 5
+
+    async def echo_agent(msg: Msg) -> None:
+        # Each request body is the unique stream marker; echo it back.
+        marker = msg.data.decode("utf-8")
+        # Promote bare-string requests into the §5.3 envelope shape so
+        # we know exactly what came in.
+        try:
+            envelope = json.loads(marker)
+            payload_text = envelope.get("prompt", marker)
+        except json.JSONDecodeError:
+            payload_text = marker
+
+        async def emit() -> None:
+            for i in range(chunks_per_stream):
+                await nc.publish(msg.reply, _response_chunk_bytes(f"{payload_text}#{i}"))
+            await nc.publish(msg.reply, b"")  # terminator
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=echo_agent)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+        async def run_one(idx: int) -> list[str]:
+            seen: list[str] = []
+            async for chunk in agent.prompt(f"marker-{idx}"):
+                if isinstance(chunk, ResponseChunk):
+                    seen.append(chunk.text)
+            return seen
+
+        results = await asyncio.gather(*(run_one(i) for i in range(n_streams)))
+        await agents.close()
+    finally:
+        await sub.unsubscribe()
+
+    # Every stream sees exactly its own chunks in order — no cross-talk.
+    for idx, seen in enumerate(results):
+        expected = [f"marker-{idx}#{i}" for i in range(chunks_per_stream)]
+        assert seen == expected, (
+            f"stream {idx} cross-contaminated: expected {expected!r}, got {seen!r}"
+        )
+    evidence.write_json(
+        "isolation.json",
+        {"streams": n_streams, "chunks_per_stream": chunks_per_stream, "ok": True},
+    )
+
+
+async def test_cancel_during_iteration_unregisters_token(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """``aclose()`` on the prompt iterator runs the ``finally``: unregister().
+
+    Plan §race-analysis #1 / #4: the consumer cancels mid-stream;
+    the routing dict slot must be freed, so a follow-up prompt on
+    the same mux gets a fresh token and routes correctly.
+
+    Async-for ``break`` alone defers cleanup to GC (see
+    ``_mux.py``'s docstring nudge), so we exercise the deterministic
+    path: :func:`contextlib.aclosing`.
+    """
+
+    async def emit_forever(msg: Msg) -> None:
+        async def emit() -> None:
+            i = 0
+            while True:
+                await nc.publish(msg.reply, _response_chunk_bytes(f"x-{i}"))
+                i += 1
+                await asyncio.sleep(0.05)
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=emit_forever)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+        seen_first: list[str] = []
+        # `agent.prompt()` is an async generator (has aclose), but the
+        # advertised return type is the more general AsyncIterator.
+        # cast() satisfies aclosing's type bound without a runtime change.
+        stream_gen = cast(AsyncGenerator[object, None], agent.prompt("first"))
+        async with aclosing(stream_gen) as stream:
+            async for chunk in stream:
+                if isinstance(chunk, ResponseChunk):
+                    seen_first.append(chunk.text)
+                    if len(seen_first) >= 2:
+                        break
+
+        # After aclose() the routing dict should be empty.
+        assert agents.mux._routes == {}, (
+            f"orphan tokens after aclose: {list(agents.mux._routes.keys())}"
+        )
+
+        await agents.close()
+    finally:
+        await sub.unsubscribe()
+
+    evidence.write_json("seen_first.json", seen_first)
+
+
+async def test_concurrent_close_and_register_is_safe(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """Plan §race-analysis #7: ``close()`` racing with ``register()`` is safe.
+
+    Either ``register()`` runs first and gets a sentinel via close()'s
+    sweep, or it runs second and raises :class:`AgentsClosedError`.
+    Both outcomes are acceptable; the bad outcome (orphan token, no
+    error) MUST NOT happen.
+    """
+
+    async def silent_agent(msg: Msg) -> None:
+        del msg
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=silent_agent)
+    try:
+        agents = Agents(nc=nc)
+        info = _make_agent_info(PROMPT_SUBJECT)
+        agent = Agent(nc, info, mux=agents.mux, close_event=agents.close_event)
+
+        # Pre-warm the mux so close() has a real subscription to tear down.
+        await agents.mux.start()
+
+        outcomes: list[str] = []
+
+        async def attempt_prompt() -> None:
+            try:
+                async for _ in agent.prompt("racy"):
+                    pass
+            except AgentsClosedError:
+                outcomes.append("AgentsClosedError")
+            except ProtocolError as exc:
+                if "closed" in str(exc).lower():
+                    outcomes.append("ProtocolError-closed")
+                else:
+                    outcomes.append(f"ProtocolError-other: {exc}")
+            except Exception as exc:
+                outcomes.append(f"unexpected: {type(exc).__name__}")
+
+        # Fire prompt + close concurrently.
+        await asyncio.gather(attempt_prompt(), agents.close())
+
+        # Whatever order the race resolved in, we must have observed
+        # one of the two clean-exit outcomes. The bad outcome (silent
+        # hang or orphan token) would manifest as a hung gather above.
+        assert outcomes and outcomes[0] in (
+            "AgentsClosedError",
+            "ProtocolError-closed",
+        ), f"unexpected outcomes: {outcomes!r}"
+        # And after close, no orphan tokens linger.
+        assert agents.mux._routes == {}
+    finally:
+        await sub.unsubscribe()
+
+    evidence.write_json("race_outcomes.json", outcomes)

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -24,7 +24,7 @@ import json
 import time
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import nats
 import pytest
@@ -33,6 +33,7 @@ from synadia_ai.agents import (
     DEFAULT_PROMPT_MAX_WAIT_S,
     Agent,
     AgentInfo,
+    Agents,
     EndpointInfo,
     ResponseChunk,
     StreamMaxWaitExceededError,
@@ -97,6 +98,35 @@ def test_max_wait_default_is_600s_and_constant_exported() -> None:
     assert DEFAULT_PROMPT_MAX_WAIT_S == 600.0
     sig = inspect.signature(Agent.__init__)
     assert sig.parameters["prompt_max_wait_s"].default is DEFAULT_PROMPT_MAX_WAIT_S
+
+
+@pytest.mark.parametrize("bad_value", [0, 0.0, -1, -0.5])
+def test_prompt_max_wait_rejects_non_positive(bad_value: float) -> None:
+    """Non-positive ``max_wait_s`` is rejected synchronously at every entry point.
+
+    There is no "no limit" sentinel — an unbounded prompt stream is
+    the exact failure mode the ceiling exists to prevent — so we
+    refuse the value at the public boundary instead of silently
+    treating ``0`` as either "fire immediately" (the previous
+    behaviour) or "wait forever" (a footgun inherited from other
+    timeout APIs).
+    """
+    info = _make_agent_info(PROMPT_SUBJECT)
+    nc_placeholder = cast("NATSClient", object())
+
+    # Constructor on `Agent` directly.
+    with pytest.raises(ValueError, match="prompt_max_wait_s must be > 0"):
+        Agent(nc_placeholder, info, prompt_max_wait_s=bad_value)
+
+    # Constructor on `Agents` (the default-supplier path).
+    with pytest.raises(ValueError, match="prompt_max_wait_s must be > 0"):
+        Agents(nc=nc_placeholder, prompt_max_wait_s=bad_value)
+
+    # Per-call override on `Agent.prompt`. No network I/O happens
+    # before the validation, so a placeholder `nc` is fine.
+    agent = Agent(nc_placeholder, info)
+    with pytest.raises(ValueError, match="max_wait_s must be > 0"):
+        agent.prompt("hello", max_wait_s=bad_value)
 
 
 async def test_max_wait_exceeded_raises(

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -181,6 +181,46 @@ async def test_max_wait_with_terminator_in_time(
     evidence.write_json("received.json", received_texts)
 
 
+async def test_terminator_arrival_cancels_max_wait_even_if_consumer_is_slow(
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
+) -> None:
+    """Terminator arrival, not consumer drain speed, stops the max-wait ceiling."""
+    received_texts: list[str] = []
+    terminator_published = asyncio.Event()
+    slow_body_s = 0.4
+    max_wait_s = 0.2
+
+    async def fake_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            await nc.publish(msg.reply, _response_chunk_bytes("chunk-before-slow-body"))
+            await nc.publish(msg.reply, b"")
+            await nc.flush()
+            terminator_published.set()
+
+        bg_tasks(asyncio.create_task(emit()))
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
+    try:
+        agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        async for chunk in agent.prompt("terminate-before-sleep", max_wait_s=max_wait_s):
+            if isinstance(chunk, ResponseChunk):
+                received_texts.append(chunk.text)
+                await asyncio.wait_for(terminator_published.wait(), timeout=2.0)
+                await asyncio.sleep(slow_body_s)
+    finally:
+        await sub.unsubscribe()
+
+    assert received_texts == ["chunk-before-slow-body"]
+    evidence.write_json(
+        "slow_consumer_terminator.json",
+        {
+            "max_wait_s": max_wait_s,
+            "slow_body_s": slow_body_s,
+            "received": received_texts,
+        },
+    )
+
+
 async def test_max_wait_distinct_from_inactivity_timeout(
     nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -18,6 +18,7 @@ distribution.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import time
 from types import MappingProxyType
@@ -36,10 +37,14 @@ from synadia_ai.agents import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nats.aio.client import Client as NATSClient
     from nats.aio.msg import Msg
 
     from tests.harness.evidence import EvidenceRecorder
+
+    BgTasks = Callable[[asyncio.Task[object]], None]
 
 
 PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.maxwait"
@@ -78,19 +83,21 @@ def _response_chunk_bytes(text: str) -> bytes:
     return json.dumps({"type": "response", "data": text}).encode("utf-8")
 
 
-async def test_max_wait_default_is_600s_and_constant_exported() -> None:
-    """The default ceiling matches TS PR #66's ``DEFAULT_PROMPT_MAX_WAIT_MS = 600_000``."""
+def test_max_wait_default_is_600s_and_constant_exported() -> None:
+    """The default ceiling matches TS PR #66's ``DEFAULT_PROMPT_MAX_WAIT_MS = 600_000``.
+
+    Asserts both the constant value and that the :meth:`Agent.__init__`
+    kwarg actually defaults to it (so a careless rename of either side
+    surfaces here, not at runtime).
+    """
     assert DEFAULT_PROMPT_MAX_WAIT_S == 600.0
-    # The dataclass default cascades to per-call override = None as well.
-    info = _make_agent_info(PROMPT_SUBJECT)
-    # Build directly (no NATS): just confirm the kwarg exists with the right default.
-    agent = Agent.__new__(Agent)
-    agent._default_max_wait_s = DEFAULT_PROMPT_MAX_WAIT_S
-    assert agent._default_max_wait_s == 600.0
-    del info  # unused — exists only to confirm the import path is real.
+    sig = inspect.signature(Agent.__init__)
+    assert sig.parameters["prompt_max_wait_s"].default is DEFAULT_PROMPT_MAX_WAIT_S
 
 
-async def test_max_wait_exceeded_raises(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+async def test_max_wait_exceeded_raises(
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
+) -> None:
     """An agent that never terminates triggers ``StreamMaxWaitExceededError``.
 
     Evidence: ``chunks.jsonl`` records every chunk delivered before
@@ -110,9 +117,7 @@ async def test_max_wait_exceeded_raises(nc: NATSClient, evidence: EvidenceRecord
                 i += 1
                 await asyncio.sleep(chunk_interval_s)
 
-        emit_task = asyncio.create_task(emit_loop())
-        # Park the task on the message subscription state so it doesn't get GC'd.
-        msg._emit_task = emit_task  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit_loop()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
     try:
@@ -139,7 +144,9 @@ async def test_max_wait_exceeded_raises(nc: NATSClient, evidence: EvidenceRecord
     evidence.write_jsonl("chunks.jsonl", chunks_observed)  # type: ignore[arg-type]
 
 
-async def test_max_wait_with_terminator_in_time(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+async def test_max_wait_with_terminator_in_time(
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
+) -> None:
     """A stream that terminates well inside the ceiling completes cleanly."""
     received_texts: list[str] = []
 
@@ -150,7 +157,7 @@ async def test_max_wait_with_terminator_in_time(nc: NATSClient, evidence: Eviden
             # §6.5: zero-byte terminator, no headers.
             await nc.publish(msg.reply, b"")
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
     try:
@@ -166,7 +173,7 @@ async def test_max_wait_with_terminator_in_time(nc: NATSClient, evidence: Eviden
 
 
 async def test_max_wait_distinct_from_inactivity_timeout(
-    nc: NATSClient, evidence: EvidenceRecorder
+    nc: NATSClient, evidence: EvidenceRecorder, bg_tasks: BgTasks
 ) -> None:
     """Steady chunks (well under inactivity timeout) still trip the ceiling.
 
@@ -184,7 +191,7 @@ async def test_max_wait_distinct_from_inactivity_timeout(
                 i += 1
                 await asyncio.sleep(0.05)
 
-        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+        bg_tasks(asyncio.create_task(emit()))
 
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
     try:

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -234,8 +234,10 @@ async def test_max_wait_distinct_from_inactivity_timeout(
     assert excinfo.value.max_wait_s == 0.3
     # Tight band: ceiling must fire close to 0.3 s, definitely not the
     # 60 s inactivity timeout. Lower bound = ceiling minus jitter; upper
-    # bound = generous slack for CI noise but well below inactivity.
-    assert 0.25 < elapsed < 1.0, (
+    # bound = 2x ceiling, tight enough to catch a regression where
+    # max_wait fires hundreds of milliseconds late but generous enough
+    # to absorb CI scheduler noise.
+    assert 0.25 < elapsed < 0.6, (
         f"max_wait fired at {elapsed:.3f}s — outside dual-timer-distinct band"
     )
     # At least two chunks proves the inactivity timer was being reset by

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -18,12 +18,15 @@ distribution.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import json
 import time
+from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+import nats
 import pytest
 
 from synadia_ai.agents import (
@@ -35,6 +38,8 @@ from synadia_ai.agents import (
     StreamMaxWaitExceededError,
     StreamStalledError,
 )
+from tests.harness.evidence import EvidenceRecorder
+from tests.harness.nats_server import start_server
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,12 +47,11 @@ if TYPE_CHECKING:
     from nats.aio.client import Client as NATSClient
     from nats.aio.msg import Msg
 
-    from tests.harness.evidence import EvidenceRecorder
-
     BgTasks = Callable[[asyncio.Task[object]], None]
 
 
 PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.maxwait"
+_EVIDENCE_ROOT = Path(__file__).parent / "_evidence"
 
 
 def _make_agent_info(prompt_subject: str) -> AgentInfo:
@@ -226,3 +230,94 @@ async def test_inactivity_raises_stream_stalled_error(
 
     assert excinfo.value.timeout_s == 0.2
     evidence.write_json("error.json", {"timeout_s": excinfo.value.timeout_s})
+
+
+async def test_max_wait_fires_after_connection_severed(
+    request: pytest.FixtureRequest,
+    bg_tasks: BgTasks,
+    tmp_path: Path,
+) -> None:
+    """Connection severed mid-stream → ceiling fires after ``max_wait_s``.
+
+    Plan §race #8 safety net. A catastrophic broker death (or any
+    network drop where chunks stop forever) leaves the per-chunk
+    inactivity timer as the only fallback. With ``max_wait_s`` set
+    tight and ``timeout`` (inactivity) set high, the ceiling rescues
+    the stream after the absolute deadline regardless of whether the
+    transport ever told us it died.
+
+    Uses a dedicated ``nats-server`` (NOT the session-scoped fixture)
+    so killing the broker mid-test does not poison every other test.
+    Caller connects with ``allow_reconnect=False`` so the dead server
+    stays dead — no background reconnect loop muddying the timing.
+    """
+    evidence = EvidenceRecorder.for_test(_EVIDENCE_ROOT, request.node.nodeid)
+    server = start_server(tmp_path / "nats-logs")
+    try:
+        client = await nats.connect(server.url, allow_reconnect=False)
+        try:
+            chunks_observed: list[dict[str, object]] = []
+
+            async def fake_agent(msg: Msg) -> None:
+                async def emit_loop() -> None:
+                    i = 0
+                    while True:
+                        try:
+                            await client.publish(msg.reply, _response_chunk_bytes(f"tick-{i}"))
+                        except Exception:
+                            # Broker is gone; bail quietly. The bg_tasks
+                            # fixture will cancel us at teardown anyway,
+                            # but exiting cleanly avoids spurious tracebacks.
+                            return
+                        i += 1
+                        await asyncio.sleep(0.05)
+
+                bg_tasks(asyncio.create_task(emit_loop()))
+
+            sub = await client.subscribe(PROMPT_SUBJECT, cb=fake_agent)
+            kill_at_chunks = 3
+            kill_ts: float | None = None
+            try:
+                agent = Agent(client, _make_agent_info(PROMPT_SUBJECT))
+                start = time.monotonic()
+                with pytest.raises(StreamMaxWaitExceededError) as excinfo:
+                    async for chunk in agent.prompt("sever-me", timeout=60.0, max_wait_s=1.0):
+                        if isinstance(chunk, ResponseChunk):
+                            chunks_observed.append(
+                                {
+                                    "text": chunk.text,
+                                    "elapsed_s": time.monotonic() - start,
+                                }
+                            )
+                            if len(chunks_observed) == kill_at_chunks:
+                                # Kill the broker. From here on no chunks will
+                                # ever arrive — only the ceiling can save us.
+                                kill_ts = time.monotonic() - start
+                                server.stop()
+                elapsed = time.monotonic() - start
+            finally:
+                with contextlib.suppress(Exception):
+                    await sub.unsubscribe()
+        finally:
+            with contextlib.suppress(Exception):
+                await client.close()
+    finally:
+        server.stop()
+
+    assert excinfo.value.max_wait_s == 1.0
+    assert kill_ts is not None
+    # Ceiling must fire close to 1.0 s after start, regardless of when the
+    # broker died. Kernel TCP teardown + asyncio scheduling can each add
+    # tens of ms, and CI machines are noisy — generous slack.
+    assert 0.9 < elapsed < 2.5, f"max_wait fired at {elapsed:.3f}s — outside expected band"
+    assert len(chunks_observed) >= kill_at_chunks
+    evidence.write_jsonl("chunks.jsonl", chunks_observed)  # type: ignore[arg-type]
+    evidence.write_json(
+        "timing.json",
+        {
+            "kill_at_s": round(kill_ts, 3),
+            "max_wait_raised_at_s": round(elapsed, 3),
+            "max_wait_s": 1.0,
+            "inactivity_timeout_s": 60.0,
+        },
+    )

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -140,10 +140,15 @@ async def test_max_wait_exceeded_raises(
     # Ceiling fired close to 0.5s, not the inactivity default (60s).
     assert 0.4 < elapsed < 1.5, f"max_wait fired at {elapsed:.3f}s — outside expected band"
     assert excinfo.value.max_wait_s == 0.5
-    # We saw at least a handful of chunks — proves the stream was
-    # progressing (so this is the ceiling firing, not the inactivity-gap path).
-    assert len(chunks_observed) >= 4, (
-        f"expected ≥4 chunks at 50 ms cadence within 500 ms; saw {len(chunks_observed)}"
+    # At least two chunks proves the stream was *progressing* — i.e. the
+    # ceiling fired, not the inactivity-gap path. We deliberately do NOT
+    # assert a tighter count: the cadence target is 10 chunks (50 ms over
+    # 500 ms) but bunched scheduling under CI load can drop the observed
+    # count well below that without the underlying behaviour changing.
+    # Two is the floor that distinguishes "made progress" from "silent
+    # stall."
+    assert len(chunks_observed) >= 2, (
+        f"expected ≥2 chunks (proves progression, not stall); saw {len(chunks_observed)}"
     )
     evidence.write_jsonl("chunks.jsonl", chunks_observed)  # type: ignore[arg-type]
 
@@ -185,7 +190,21 @@ async def test_max_wait_distinct_from_inactivity_timeout(
     arrive every 50 ms (well inside any reasonable inactivity timeout),
     yet the stream still fails with ``StreamMaxWaitExceededError`` —
     NOT ``StreamStalledError`` — once 0.3 s has elapsed.
+
+    Three assertions pin the dual-timer claim, not just the error class:
+
+    - ``elapsed`` close to ``max_wait_s=0.3``, not the 60 s inactivity
+      timeout. If ``max_wait_s`` were mis-wired to feed the inactivity
+      path, the test would either fail with ``StreamStalledError`` or
+      hang for 60 s — not raise the right class at the right time.
+    - Chunks observed must show the inactivity timer is being reset by
+      incoming traffic. Two or more chunks across the 0.3 s window with
+      a 50 ms cadence is conservative evidence of "stream progressing."
+    - The error class. (Already implied by ``pytest.raises``, but
+      together with the elapsed band it rules out an accidental
+      stall-path raise.)
     """
+    chunks_observed: list[dict[str, object]] = []
 
     async def fake_agent(msg: Msg) -> None:
         async def emit() -> None:
@@ -200,13 +219,37 @@ async def test_max_wait_distinct_from_inactivity_timeout(
     sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
     try:
         agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        start = time.monotonic()
         # Inactivity timeout very high (60s) so it cannot trip first.
-        with pytest.raises(StreamMaxWaitExceededError):
-            async for _ in agent.prompt("steady", timeout=60.0, max_wait_s=0.3):
-                pass
+        with pytest.raises(StreamMaxWaitExceededError) as excinfo:
+            async for chunk in agent.prompt("steady", timeout=60.0, max_wait_s=0.3):
+                if isinstance(chunk, ResponseChunk):
+                    chunks_observed.append(
+                        {"text": chunk.text, "elapsed_s": time.monotonic() - start}
+                    )
+        elapsed = time.monotonic() - start
     finally:
         await sub.unsubscribe()
-    evidence.write_json("note.json", {"verified": "ceiling, not stall"})
+
+    assert excinfo.value.max_wait_s == 0.3
+    # Tight band: ceiling must fire close to 0.3 s, definitely not the
+    # 60 s inactivity timeout. Lower bound = ceiling minus jitter; upper
+    # bound = generous slack for CI noise but well below inactivity.
+    assert 0.25 < elapsed < 1.0, (
+        f"max_wait fired at {elapsed:.3f}s — outside dual-timer-distinct band"
+    )
+    # At least two chunks proves the inactivity timer was being reset by
+    # incoming traffic. If max_wait were mis-wired to the inactivity
+    # path, a stream emitting every 50 ms would have its stall timer
+    # reset on each chunk and never raise.
+    assert len(chunks_observed) >= 2, (
+        f"expected ≥2 chunks proving inactivity timer was being reset; saw {len(chunks_observed)}"
+    )
+    evidence.write_jsonl("chunks.jsonl", chunks_observed)  # type: ignore[arg-type]
+    evidence.write_json(
+        "timing.json",
+        {"elapsed_s": round(elapsed, 3), "max_wait_s": 0.3, "chunks": len(chunks_observed)},
+    )
 
 
 async def test_inactivity_raises_stream_stalled_error(
@@ -275,7 +318,14 @@ async def test_max_wait_fires_after_connection_severed(
                 bg_tasks(asyncio.create_task(emit_loop()))
 
             sub = await client.subscribe(PROMPT_SUBJECT, cb=fake_agent)
-            kill_at_chunks = 3
+            # Two chunks is the floor that proves the consumer was
+            # iterating before we killed the broker (i.e. this is the
+            # connection-severed path, not "broker died before publish
+            # ever landed"). Bigger numbers just narrow the timing
+            # window for the kill — at 50 ms cadence and a 1.0 s
+            # ceiling, ``kill_at=2`` lands ~100 ms in with ~900 ms of
+            # ceiling remaining, robust against CI scheduler bunching.
+            kill_at_chunks = 2
             kill_ts: float | None = None
             try:
                 agent = Agent(client, _make_agent_info(PROMPT_SUBJECT))

--- a/client-sdk/python/tests/test_prompt_max_wait.py
+++ b/client-sdk/python/tests/test_prompt_max_wait.py
@@ -1,0 +1,221 @@
+"""End-to-end tests for the absolute ``max_wait_s`` ceiling on prompt streams.
+
+These tests exercise the new
+:class:`synadia_ai.agents.StreamMaxWaitExceededError` ceiling that the
+Python SDK gained as the API-level analogue of the TypeScript SDK's
+``PromptOptions.maxWaitMs`` (PR #66 — `requestMany` + sentinel). The
+ceiling is distinct from the §6.6 per-chunk inactivity timeout: the
+inactivity timer resets on every received chunk, so a stream that emits
+a steady trickle could never time out under inactivity alone.
+
+Each test uses a tiny in-process "agent" — a NATS subscription that
+publishes wire-shape-correct chunks into ``msg.reply`` on demand — so
+the suite covers the whole client path (mux subscribe + publish +
+queue.get + decode + terminator) without depending on the agent-sdk
+distribution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+import pytest
+
+from synadia_ai.agents import (
+    DEFAULT_PROMPT_MAX_WAIT_S,
+    Agent,
+    AgentInfo,
+    EndpointInfo,
+    ResponseChunk,
+    StreamMaxWaitExceededError,
+    StreamStalledError,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
+
+    from tests.harness.evidence import EvidenceRecorder
+
+
+PROMPT_SUBJECT = "agents.prompt.test-agent.pytest.maxwait"
+
+
+def _make_agent_info(prompt_subject: str) -> AgentInfo:
+    """Build an :class:`AgentInfo` pointing at a test-controlled subject.
+
+    Bypasses ``$SRV.INFO`` discovery — the test owns both ends of the
+    wire, so we build the record directly.
+    """
+    prompt_endpoint = EndpointInfo(
+        name="prompt",
+        subject=prompt_subject,
+        queue_group="agents",
+        metadata=MappingProxyType({}),
+        max_payload_bytes=None,
+        attachments_ok=True,
+    )
+    return AgentInfo(
+        instance_id="test-instance",
+        agent="test-agent",
+        owner="pytest",
+        session_name="maxwait",
+        protocol_version="0.3",
+        description="",
+        version="0.0.0",
+        metadata=MappingProxyType({"agent": "test-agent", "owner": "pytest"}),
+        endpoints=(prompt_endpoint,),
+        prompt_endpoint=prompt_endpoint,
+    )
+
+
+def _response_chunk_bytes(text: str) -> bytes:
+    """Wire bytes for a §6.3 response chunk (bare-string shorthand)."""
+    return json.dumps({"type": "response", "data": text}).encode("utf-8")
+
+
+async def test_max_wait_default_is_600s_and_constant_exported() -> None:
+    """The default ceiling matches TS PR #66's ``DEFAULT_PROMPT_MAX_WAIT_MS = 600_000``."""
+    assert DEFAULT_PROMPT_MAX_WAIT_S == 600.0
+    # The dataclass default cascades to per-call override = None as well.
+    info = _make_agent_info(PROMPT_SUBJECT)
+    # Build directly (no NATS): just confirm the kwarg exists with the right default.
+    agent = Agent.__new__(Agent)
+    agent._default_max_wait_s = DEFAULT_PROMPT_MAX_WAIT_S
+    assert agent._default_max_wait_s == 600.0
+    del info  # unused — exists only to confirm the import path is real.
+
+
+async def test_max_wait_exceeded_raises(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+    """An agent that never terminates triggers ``StreamMaxWaitExceededError``.
+
+    Evidence: ``chunks.jsonl`` records every chunk delivered before
+    the ceiling fired, so a human can verify the stream really was
+    progressing (so this isn't an inactivity-timeout false positive).
+    """
+    chunks_observed: list[dict[str, object]] = []
+    chunk_interval_s = 0.05
+
+    async def fake_agent(msg: Msg) -> None:
+        # Emit a chunk every 50 ms forever — never terminate. Runs in a
+        # background task so the publish callback returns promptly.
+        async def emit_loop() -> None:
+            i = 0
+            while True:
+                await nc.publish(msg.reply, _response_chunk_bytes(f"tick-{i}"))
+                i += 1
+                await asyncio.sleep(chunk_interval_s)
+
+        emit_task = asyncio.create_task(emit_loop())
+        # Park the task on the message subscription state so it doesn't get GC'd.
+        msg._emit_task = emit_task  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
+    try:
+        agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        start = time.monotonic()
+        with pytest.raises(StreamMaxWaitExceededError) as excinfo:
+            async for chunk in agent.prompt("trigger-forever", max_wait_s=0.5):
+                if isinstance(chunk, ResponseChunk):
+                    chunks_observed.append(
+                        {"text": chunk.text, "elapsed_s": time.monotonic() - start}
+                    )
+        elapsed = time.monotonic() - start
+    finally:
+        await sub.unsubscribe()
+
+    # Ceiling fired close to 0.5s, not the inactivity default (60s).
+    assert 0.4 < elapsed < 1.5, f"max_wait fired at {elapsed:.3f}s — outside expected band"
+    assert excinfo.value.max_wait_s == 0.5
+    # We saw at least a handful of chunks — proves the stream was
+    # progressing (so this is the ceiling firing, not the inactivity-gap path).
+    assert len(chunks_observed) >= 4, (
+        f"expected ≥4 chunks at 50 ms cadence within 500 ms; saw {len(chunks_observed)}"
+    )
+    evidence.write_jsonl("chunks.jsonl", chunks_observed)  # type: ignore[arg-type]
+
+
+async def test_max_wait_with_terminator_in_time(nc: NATSClient, evidence: EvidenceRecorder) -> None:
+    """A stream that terminates well inside the ceiling completes cleanly."""
+    received_texts: list[str] = []
+
+    async def fake_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            for i in range(3):
+                await nc.publish(msg.reply, _response_chunk_bytes(f"chunk-{i}"))
+            # §6.5: zero-byte terminator, no headers.
+            await nc.publish(msg.reply, b"")
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
+    try:
+        agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        async for chunk in agent.prompt("terminate-please", max_wait_s=10.0):
+            if isinstance(chunk, ResponseChunk):
+                received_texts.append(chunk.text)
+    finally:
+        await sub.unsubscribe()
+
+    assert received_texts == ["chunk-0", "chunk-1", "chunk-2"]
+    evidence.write_json("received.json", received_texts)
+
+
+async def test_max_wait_distinct_from_inactivity_timeout(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """Steady chunks (well under inactivity timeout) still trip the ceiling.
+
+    Proves the ceiling is independent of the per-chunk timer: chunks
+    arrive every 50 ms (well inside any reasonable inactivity timeout),
+    yet the stream still fails with ``StreamMaxWaitExceededError`` —
+    NOT ``StreamStalledError`` — once 0.3 s has elapsed.
+    """
+
+    async def fake_agent(msg: Msg) -> None:
+        async def emit() -> None:
+            i = 0
+            while True:
+                await nc.publish(msg.reply, _response_chunk_bytes(f"steady-{i}"))
+                i += 1
+                await asyncio.sleep(0.05)
+
+        msg._emit_task = asyncio.create_task(emit())  # type: ignore[attr-defined]
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=fake_agent)
+    try:
+        agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        # Inactivity timeout very high (60s) so it cannot trip first.
+        with pytest.raises(StreamMaxWaitExceededError):
+            async for _ in agent.prompt("steady", timeout=60.0, max_wait_s=0.3):
+                pass
+    finally:
+        await sub.unsubscribe()
+    evidence.write_json("note.json", {"verified": "ceiling, not stall"})
+
+
+async def test_inactivity_raises_stream_stalled_error(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """A silent agent triggers :class:`StreamStalledError`, not the ceiling."""
+
+    async def silent_agent(msg: Msg) -> None:
+        # Publish nothing. The reply subject just stays empty.
+        del msg
+
+    sub = await nc.subscribe(PROMPT_SUBJECT, cb=silent_agent)
+    try:
+        agent = Agent(nc, _make_agent_info(PROMPT_SUBJECT))
+        with pytest.raises(StreamStalledError) as excinfo:
+            # Inactivity 0.2s, ceiling 5s → inactivity wins.
+            async for _ in agent.prompt("silent", timeout=0.2, max_wait_s=5.0):
+                pass
+    finally:
+        await sub.unsubscribe()
+
+    assert excinfo.value.timeout_s == 0.2
+    evidence.write_json("error.json", {"timeout_s": excinfo.value.timeout_s})

--- a/client-sdk/python/uv.lock
+++ b/client-sdk/python/uv.lock
@@ -413,7 +413,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary

- **Catch the Python client SDK up to TypeScript [PR #66](https://github.com/synadia-ai/synadia-agents/pull/66)** (`requestMany` + sentinel) using a per-NATS-connection mux reply-inbox: every `Agent` on the same `nc` shares a single `_INBOX.agents.<mux>.*` subscription instead of opening one per prompt. **Wire shape unchanged; protocol stays at `"0.3"`**, the TS↔Python interop test continues to pass.
- **Add `Agent.prompt(max_wait_s=...)`** — absolute ceiling on a prompt stream, mirrors TS's `PromptOptions.maxWaitMs`. Default `600 s` (10 min). Distinct from the §6.6 per-chunk inactivity timer that resets on every received chunk; `max_wait_s` is the safety net for streams that emit a steady trickle forever, or for silent reconnect / broker-death windows.
- **New error classes**: `StreamMaxWaitExceededError` (ceiling), `StreamStalledError` (inactivity gap, previously a bare `ProtocolError`), `AgentsClosedError` (pre-flight close). All inherit from `ProtocolError` / `NatsAgentError` so existing catch-broadly callers keep working.

## Why interim

`nats-py` has no `request_many()` primitive yet; the TS SDK uses `nc.requestMany(...)` directly. We've filed [`nats-io/nats.py#919`](https://github.com/nats-io/nats.py/issues/919) requesting it. Until that lands, `synadia_ai.agents._mux` is the API-level analogue, intentionally mirroring TS's shape. Marker `INTERIM-NATSPY-REQUEST-MANY` in the source flags it for deletion when upstream catches up — the single migration point will be `Agent._stream_prompt`.

## Architecture changes

### Mux on the connection, not on `Agents`

The TS SDK's `nc.requestMany` lives on the connection — every caller of the same `nc` automatically shares the connection's internal mux. Python's analogue is a per-`nc` singleton `MuxInbox` held in a `WeakKeyDictionary` keyed by the connection (see `synadia_ai.agents._mux.mux_for`). Multiple `Agents` instances and directly-constructed `Agent` handles on the same connection share one subscription. `Agents.close()` does **not** tear down the mux — it lives on the connection and is the connection-owner's responsibility, just like in TS.

`MuxInbox` holds only a `weakref.ref(nc)` to the client (not a strong ref) so dropping the user's last `nc` reference frees the cache entry without manual teardown.

### Lifecycle events race queue reads

`close_event` and `max_wait_s` are lifecycle controls, not ordinary queued stream values. `_wait_for_chunk` does an `asyncio.wait` over `queue.get()` + `max_wait_event` + `close_event`, so close and max-wait win over already-buffered chunks (including a buffered terminator). Consumers unblock within an event-loop tick — no FIFO sentinel that could be hidden behind backlog.

The terminator detection runs in the mux's dispatch callback (sync-bodied, single-loop pass). When the empty-headerless `b""` terminator arrives on the wire, the mux cancels the per-stream `max_wait_handle` synchronously — not when a slow consumer eventually drains the terminator from the queue.

### Three close-event checks bracket every await before the publish

- Top of `_stream_prompt` (before `mux.start()`)
- Between `mux.register()` and `publish()` (catches close that fires during the first call's SUB+flush)
- After `publish()` (catches close fired during the publish itself; pushes sentinel synchronously)

All three raise `AgentsClosedError` from the pre-publish checks; the post-publish path joins the lifecycle race in `_wait_for_chunk`. Cleanup ordering in the `finally`: cancel close-watcher → unregister mux token → drain queue (releases `Msg` payloads deterministically rather than waiting on GC).

## Public API additions

```python
from synadia_ai.agents import (
    DEFAULT_PROMPT_MAX_WAIT_S,        # = 600.0
    StreamMaxWaitExceededError,        # ceiling fired (.max_wait_s)
    StreamStalledError,                # inactivity gap fired (.timeout_s, .reply_subject)
    AgentsClosedError,                 # called against closed Agents (or close fired during stream)
)

# Constructor default + per-call override:
agents = Agents(nc=nc, prompt_max_wait_s=300.0)
async for chunk in agent.prompt("...", max_wait_s=30.0):
    ...
```

`AgentsClosedError(NatsAgentError)` is **intentionally distinct** from `ProtocolError` so callers can branch on "called against a closed Agents" vs "torn down mid-flight" — see `errors.py:53`. Mid-stream close still surfaces as `ProtocolError`; pre-flight (and the now-narrowed mid-mux-start race window) raises `AgentsClosedError`.

## Test coverage

**203 → 207 tests, all green in 12.87 s.** New regression suites:

- `tests/test_prompt_max_wait.py` — 7 tests: ceiling fires on never-terminating stream, terminator-in-time completes cleanly, ceiling vs inactivity timer disambiguation (with elapsed-band + chunk-count assertions to pin the dual-timer claim), inactivity raises `StreamStalledError`, **broker-death mid-stream** (kills a dedicated nats-server, asserts ceiling rescues the stream), and a slow-consumer-with-buffered-terminator regression.
- `tests/test_prompt_cancel_race.py` — 7 tests: `Agents.close` mid-stream unblocks within ~50 ms (not on inactivity timer), 50 concurrent prompts on shared mux see only their own chunks, close-before-prompt raises `AgentsClosedError`, close-during-prompt raises `ProtocolError` (deterministic event-driven sync, not `sleep(0)`), close-wins-over-buffered-chunks-and-terminator, and **caller-side cancellation cleans up internal `agents-prompt-*` wait tasks** (asserts no orphan tasks via `asyncio.all_tasks()` + mux route is unregistered).
- `tests/test_mux_wire_economy.py` — 3 tests: SDK-instrumented (5 prompts → 1 SUB), **broker-observed via `/subsz` HTTP** (asserts the exact `<mux_prefix>.*` wildcard subject), and a weak-cache-cleanup regression (drops a `Client`, GC-collects, asserts the mux entry is gone).

The cross-SDK interop test (`tests/test_interop_e2e.py`) — Python client driving the TypeScript reference agent over wire — continues to pass.

## Test infrastructure

- `tests/harness/nats_server.py` now starts `nats-server` with `-m <port>` unconditionally and exposes `RunningServer.monitoring_url`. Lets tests assert broker-observed truth (e.g. subscription counts via `/subsz`) instead of monkey-patching SDK internals.
- `_pick_free_ports(n)` allocates `n` distinct free ports while holding all binds simultaneously — closes the TOCTOU window where two back-to-back `_pick_free_port()` calls could (vanishingly rarely) collide.
- `bg_tasks` fixture in `tests/conftest.py` cancels long-running emit-loops at teardown so `pytest-asyncio` doesn't print "Task was destroyed but it is pending."

## Lockstep version bumps

- `synadia-ai-agents` 0.5.0 → **0.6.0**
- `synadia-ai-agent-service` 0.1.0 → **0.2.0** (dep-pin only — the agent-side wire is unchanged)
- Both Python CHANGELOGs updated.

## Not changed

- Wire format. Protocol still `"0.3"`.
- TS↔Python interop. The TS SDK already shipped PR #66; the Python interop test (`tests/test_interop_e2e.py`) round-trips against the TS reference agent and stays green.

## Review history

This branch went through **two rounds of fresh-eyes review** (each round: independent implementation reviewer + independent test reviewer). Both reviewers landed on TRUST after their respective findings were addressed. Round-1 surfaced a queue-payload-retention bug, a `MuxInbox.start()` flush-failure leak, a third close-check gap, and a few tight-assertion tests; round-2 surfaced a `_pick_free_port` TOCTOU and the broker-observed wildcard-subject check. The senior reviewer (renerocksai, with the bot's hat off) then independently pushed a third round (`75c1551` and follow-ups) hardening the close-races-buffered-chunks contract, the terminator-on-arrival cancellation, the weak-ref-to-nc lifecycle, and a brief regression in `41fa33e` that was caught and fixed in `02dacf6`.

## Test plan

- [x] `uv run ruff check --no-cache .` — passes
- [x] `uv run ruff format --check .` — 42 files clean
- [x] `uv run mypy --no-incremental src tests examples` — no issues, 41 source files
- [x] `uv run pytest` — **207 passed in 12.87 s** (incl. TS interop)
- [x] Two rounds of fresh-eyes sub-agent review — both TRUST
- [ ] CI green
- [ ] Reviewer bot pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
