### PR TITLE
Docs: refresh post-release stale facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ compatibility between the two SDKs.
 | Path | Package | Published as | Notes |
 | --- | --- | --- | --- |
 | `client-sdk/typescript/` | `@synadia-ai/agents` | npm (restricted) | TS SDK — Node/Bun callers |
-| `client-sdk/python/` | `synadia-ai-agents` (import: `synadia_ai.agents`) | PyPI (not yet published) | Python SDK — has its own CLAUDE.md |
+| `client-sdk/python/` | `synadia-ai-agents` (import: `synadia_ai.agents`) | PyPI | Python SDK — has its own CLAUDE.md |
 | `agents/pi/` | `@synadia-ai/nats-pi-channel` | npm (restricted) | PI extension plugin |
 | `agents/openclaw/` | `@synadia-ai/nats-channel` | npm (restricted) | OpenClaw plugin |
 | `agents/claude-code/` | `claude-channel-nats` | npm (restricted) | Claude Code MCP plugin |
@@ -113,8 +113,9 @@ Two distinct version axes:
 - **Package version (npm/PyPI)** — independent per SDK pair.
   - TS: `@synadia-ai/agents` + `@synadia-ai/agent-service` — both at
     `0.4.0` in lockstep, neither published to npm yet.
-  - Python: `synadia-ai-agents` + `synadia-ai-agent-service` — not
-    yet published to PyPI.
+  - Python: `synadia-ai-agents` (`0.6.0`) +
+    `synadia-ai-agent-service` (`0.2.0`) — both published to PyPI;
+    versions diverge per package.
 
 The package versions differ for historical reasons. They are **not** a
 protocol skew. The Python `tests/test_interop_e2e.py` runs the TS

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -946,7 +946,7 @@ Initial scaffold. Released ahead of the finalised v0.1 spec; most wire
 shapes in this version no longer match the spec and are corrected in
 0.1.0.
 
-[0.6.0]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.5.0...HEAD
+[0.6.0]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.5.0...python-v0.6.0
 [0.5.0]: https://github.com/synadia-ai/synadia-agents/compare/python-v0.3.0...python-v0.5.0
 [0.3.0]: https://github.com/synadia-ai/synadia-agents/releases/tag/python-v0.3.0
 [0.2.0]: https://github.com/synadia-ai/synadia-agents/releases/tag/python-v0.2.0


### PR DESCRIPTION
## Summary

Three small post-publish doc fixes after `python-v0.6.0` / `python-agent-service-v0.2.0` shipped:

- `client-sdk/python/CHANGELOG.md` — `[0.6.0]` compare URL now points at `...python-v0.6.0` instead of `...HEAD` now that the tag exists (Keep-a-Changelog convention; flagged by the reviewer bot on PR #67 as release-time housekeeping).
- Root `CLAUDE.md` repo-layout table — drop `(not yet published)` from the `synadia-ai-agents` row. Stale since 0.5.0 went up; now at 0.6.0.
- Root `CLAUDE.md` package-version section — Python pair is published with per-package versions (`synadia-ai-agents 0.6.0` + `synadia-ai-agent-service 0.2.0`). TS pair note unchanged (still unpublished).

No code changes. No CHANGELOG entry — the change is the CHANGELOG itself.

## Test plan

- [x] `git diff` shows exactly the three intended edits, nothing else
- [ ] Reviewer bot verifies links resolve and table cells are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)