### PR TITLE
Fix(examples/agent-web-ui): handle StreamMaxWaitExceededError in bridge

### DIFF
--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -13,6 +13,7 @@ import {
   AttachmentsNotSupportedError,
   PayloadTooLargeError,
   ServiceError,
+  StreamMaxWaitExceededError,
   StreamStalledError,
   type NatsConnection,
   type QueryEvent,
@@ -632,6 +633,10 @@ export class Bridge {
     }
     if (err instanceof StreamStalledError) {
       this.sendError(id, "stream_stalled", err.message, { timeoutMs: err.timeoutMs });
+      return;
+    }
+    if (err instanceof StreamMaxWaitExceededError) {
+      this.sendError(id, "stream_max_wait_exceeded", err.message, { maxWaitMs: err.maxWaitMs });
       return;
     }
     // AbortError from user-initiated cancel — surface as a neutral "stopped" status


### PR DESCRIPTION
## Summary

- Map the new `StreamMaxWaitExceededError` (added to the TS SDK in #66) to a typed wire error code `stream_max_wait_exceeded` with `{ maxWaitMs }`, mirroring the existing `StreamStalledError` → `stream_stalled` branch in `mapAndSendError`.
- Without this, a stream that exceeded the 10-min absolute ceiling fell through to the generic `internal` handler at `bridge.ts:644`, surfacing an opaque error to the UI.

## Why follow-up now

PR #66's description called this out as "out of scope per the release ladder, the example pins `^0.4.x` and migrates after publish." That pin claim doesn't match current state — all four examples (`agent-web-ui`, `pi-headless`, `claude-code-headless`, `dspy`) currently resolve `@synadia-ai/agents` via `file:../../client-sdk/typescript` (devmode). The bridge already builds against the new SDK surface locally, so the error mapping should also reflect it.

## Scope check

Audited the rest of the monorepo for follow-ups from PR #66:
- **agents/** — none. The `replySubject` matches in `agents/pi/` and `agents/claude-code/` are agent-side `msg.reply` publishing, unrelated to the removed `PromptStream.replySubject` getter.
- **examples/** — only this one. `examples/dspy/` uses `inactivityTimeoutMs` (unchanged); `examples/claude-code-headless/`'s `replySubject` is the §7 interactive-query `reply_subject` field, also unrelated.
- The removed `PromptStream.replySubject` getter is not referenced anywhere outside the SDK itself.

## Test plan

- [x] `bun run typecheck` in `examples/agent-web-ui/` is clean (after rebuilding the SDK so its `dist/` ships the new export).
- [ ] Visual: trigger a prompt that runs past `maxWaitMs` and confirm the UI receives `code: "stream_max_wait_exceeded"` with `details.maxWaitMs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)