### PR TITLE
examples/agent-web-ui: small UX fixes (title, max-wait error, empty-discovery banner)

### DIFF
--- a/examples/agent-web-ui/index.html
+++ b/examples/agent-web-ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>nats-ai-testui</title>
+    <title>NATS Agent Dashboard</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -132,7 +132,22 @@ export class Bridge {
 
   private async handleDiscover(): Promise<void> {
     try {
-      const discovered = await this.agents.discover();
+      let discovered: Agent[];
+      try {
+        discovered = await this.agents.discover();
+      } catch (err) {
+        // NoRespondersError on `$SRV.INFO.agents` means zero agents are
+        // registered — a normal empty state, not an error. The SDK already
+        // catches this internally, but a `file:`-linked install can produce
+        // two copies of `@nats-io/nats-core` whose `NoRespondersError`
+        // classes differ, so the SDK's `instanceof` check misses and the
+        // error escapes. Duck-type as a safety net.
+        if (isNoRespondersError(err)) {
+          discovered = [];
+        } else {
+          throw err;
+        }
+      }
       this.agentsByInstanceId.clear();
       const dto: DiscoveredAgentDTO[] = [];
       const seenIds = new Set<string>();
@@ -676,6 +691,13 @@ export class Bridge {
 
 function queryKey(promptId: string, queryId: string): string {
   return `${promptId}:${queryId}`;
+}
+
+function isNoRespondersError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { name?: unknown; message?: unknown };
+  if (e.name === "NoRespondersError") return true;
+  return typeof e.message === "string" && e.message.includes("no responders");
 }
 
 /**

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -13,6 +13,7 @@ import {
   AttachmentsNotSupportedError,
   PayloadTooLargeError,
   ServiceError,
+  StreamMaxWaitExceededError,
   StreamStalledError,
   type NatsConnection,
   type QueryEvent,
@@ -632,6 +633,10 @@ export class Bridge {
     }
     if (err instanceof StreamStalledError) {
       this.sendError(id, "stream_stalled", err.message, { timeoutMs: err.timeoutMs });
+      return;
+    }
+    if (err instanceof StreamMaxWaitExceededError) {
+      this.sendError(id, "stream_max_wait_exceeded", err.message, { maxWaitMs: err.maxWaitMs });
       return;
     }
     // AbortError from user-initiated cancel — surface as a neutral "stopped" status

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -696,7 +696,10 @@ function queryKey(promptId: string, queryId: string): string {
 function isNoRespondersError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const e = err as { name?: unknown; message?: unknown };
-  if (e.name === "NoRespondersError") return true;
+  // The class is `NoRespondersError` but the constructor sets
+  // `this.name = "NoResponders"` (no `Error` suffix) — match the actual
+  // runtime value, not the class name.
+  if (e.name === "NoResponders") return true;
   return typeof e.message === "string" && e.message.includes("no responders");
 }
 


### PR DESCRIPTION
## Summary

Three small fixes to the local-clone web test client at `examples/agent-web-ui`:

- **Browser tab title** — was the package id `nats-ai-testui`, now `NATS Agent Dashboard` (matches the in-app brand line in `ConnectionBar.vue`).
- **`StreamMaxWaitExceededError` → typed wire error** (commit `e3d9f29`) — the dashboard's bridge now maps SDK `StreamMaxWaitExceededError` to a typed `error` frame so the UI can surface it instead of falling through as a generic exception.
- **Silence the red `no responders: '$SRV.INFO.agents'` banner** when zero agents are connected. The SDK's `discoverAgents()` already catches `NoRespondersError` internally and returns `[]`, but with this example's `file:`-linked SDK install the dependency tree can resolve two distinct copies of `@nats-io/nats-core`, so `instanceof NoRespondersError` misses and the error escapes. The bridge now duck-types it (`err.name === "NoRespondersError"` or message contains `"no responders"`) and treats it as an empty discovery — matching the SDK's intent.

No protocol or wire-format changes; no SDK changes. Caller-only example polish.

## Test plan

- [x] `bun run typecheck` clean in `examples/agent-web-ui/`
- [x] `bun run build` clean (Vite + tsc)
- [x] Deployed to `agents.m64.io` and verified:
  - tab title reads "NATS Agent Dashboard"
  - with zero agents connected, no red banner appears (grid is just empty)
  - dashboard reconnects to NGS cleanly, `agent-dashboard.service` is `active (running)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)