### PR TITLE
examples/{pi,claude-code}-headless: verb-first subjects + agent token rename

### DIFF
--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -397,14 +397,27 @@ export class Bridge {
     id: string,
     controllerInstanceId: string,
     endpoint: "spawn" | "stop" | "list",
-    label: string = "pi-headless",
+    expectedAgent: "pi-headless" | "cc-headless" = "pi-headless",
   ): string | null {
     const agent = this.agentsByInstanceId.get(controllerInstanceId);
     if (!agent) {
       this.sendError(
         id,
         "agent_not_found",
-        `no ${label} controller with instance id ${controllerInstanceId} in last discovery result — click Refresh`,
+        `no ${expectedAgent} controller with instance id ${controllerInstanceId} in last discovery result — click Refresh`,
+      );
+      return null;
+    }
+    // Both pi-headless and cc-headless controllers carry `metadata.role
+    // = "controller"`, so the agent token is what disambiguates which
+    // handler this controller belongs under. Without this check, a
+    // mis-dispatched cc controller id into a pi handler would silently
+    // construct a `cc-headless` extension subject and call it.
+    if (agent.agent !== expectedAgent) {
+      this.sendError(
+        id,
+        "wrong_agent_token",
+        `instance ${controllerInstanceId} is agent="${agent.agent}", expected "${expectedAgent}"`,
       );
       return null;
     }
@@ -412,7 +425,7 @@ export class Bridge {
       this.sendError(
         id,
         "not_a_controller",
-        `instance ${controllerInstanceId} is not a ${label} controller`,
+        `instance ${controllerInstanceId} is not a ${expectedAgent} controller`,
       );
       return null;
     }
@@ -443,7 +456,7 @@ export class Bridge {
       id,
       controllerInstanceId,
       "spawn",
-      "claude-code-headless",
+      "cc-headless",
     );
     if (!subject) return;
     try {
@@ -474,7 +487,7 @@ export class Bridge {
       id,
       controllerInstanceId,
       "stop",
-      "claude-code-headless",
+      "cc-headless",
     );
     if (!subject) return;
     try {
@@ -518,7 +531,7 @@ export class Bridge {
       id,
       controllerInstanceId,
       "list",
-      "claude-code-headless",
+      "cc-headless",
     );
     if (!subject) return;
     try {

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -350,7 +350,8 @@ export class Bridge {
       // The session_id equals the 4th-token `name` of a pi-headless session.
       for (const [instanceId, agent] of this.agentsByInstanceId) {
         if (
-          agent.metadata["spawner"] === "pi-headless" &&
+          agent.agent === "pi-headless" &&
+          agent.metadata["role"] === "session" &&
           agent.name === sessionId
         ) {
           this.forgetAgent(instanceId);
@@ -396,7 +397,6 @@ export class Bridge {
     id: string,
     controllerInstanceId: string,
     endpoint: "spawn" | "stop" | "list",
-    role: string = "pi-headless-controller",
     label: string = "pi-headless",
   ): string | null {
     const agent = this.agentsByInstanceId.get(controllerInstanceId);
@@ -408,7 +408,7 @@ export class Bridge {
       );
       return null;
     }
-    if (agent.metadata["role"] !== role) {
+    if (agent.metadata["role"] !== "controller") {
       this.sendError(
         id,
         "not_a_controller",
@@ -416,24 +416,20 @@ export class Bridge {
       );
       return null;
     }
-    // The controller's custom endpoints (`spawn` / `stop` / `list`) live on the
-    // pre-v0.3-shape subject `agents.<token>.<owner>.<name>.<endpoint>`, NOT
-    // on the v0.3 verb-first prompt subject. Strip the `prompt` verb token
-    // out before appending the custom-endpoint suffix.
-    //
-    // prompt subject: `agents.prompt.<subjectToken>.<owner>.<name>` (5 tokens)
-    // custom subject: `agents.<subjectToken>.<owner>.<name>.<endpoint>` (5 tokens)
+    // Verb-first throughout: swap `prompt` for the extension verb in the
+    // controller's prompt subject.
+    //   prompt subject:    agents.prompt.<agent>.<owner>.<name>     (5 tokens)
+    //   extension subject: agents.<endpoint>.<agent>.<owner>.<name> (5 tokens)
     const tokens = agent.promptEndpoint.subject.split(".");
     if (tokens.length !== 5 || tokens[0] !== "agents" || tokens[1] !== "prompt") {
       this.sendError(
         id,
         "bad_prompt_subject",
-        `controller's prompt subject doesn't match v0.3 verb-first shape: ${agent.promptEndpoint.subject}`,
+        `controller's prompt subject doesn't match the verb-first shape: ${agent.promptEndpoint.subject}`,
       );
       return null;
     }
-    const customRoot = `${tokens[0]}.${tokens[2]}.${tokens[3]}.${tokens[4]}`;
-    return `${customRoot}.${endpoint}`;
+    return `${tokens[0]}.${endpoint}.${tokens[2]}.${tokens[3]}.${tokens[4]}`;
   }
 
   // ─── claude-code-headless control plane ───────────────────────────────────
@@ -447,7 +443,6 @@ export class Bridge {
       id,
       controllerInstanceId,
       "spawn",
-      "claude-code-headless-controller",
       "claude-code-headless",
     );
     if (!subject) return;
@@ -479,7 +474,6 @@ export class Bridge {
       id,
       controllerInstanceId,
       "stop",
-      "claude-code-headless-controller",
       "claude-code-headless",
     );
     if (!subject) return;
@@ -499,10 +493,11 @@ export class Bridge {
         return;
       }
       // Drop the stopped session from this bridge's agent map + UI eagerly.
-      // The session_id equals the 4th-token `name` of a claude-code-headless session.
+      // The session_id equals the 4th-token `name` of a cc-headless session.
       for (const [instanceId, agent] of this.agentsByInstanceId) {
         if (
-          agent.metadata["spawner"] === "claude-code-headless" &&
+          agent.agent === "cc-headless" &&
+          agent.metadata["role"] === "session" &&
           agent.name === sessionId
         ) {
           this.forgetAgent(instanceId);
@@ -523,7 +518,6 @@ export class Bridge {
       id,
       controllerInstanceId,
       "list",
-      "claude-code-headless-controller",
       "claude-code-headless",
     );
     if (!subject) return;

--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -193,17 +193,18 @@ const sessionState = computed<"alive" | "expired">(() => {
 });
 const isExpired = computed(() => sessionState.value === "expired");
 
-// Find the controller that spawned this session (matched by spawner role +
-// owner). Returns null if the controller has vanished — in which case the
-// stop button is shown disabled with a tooltip.
+// Find the controller that spawned this session (matched by agent token +
+// role + owner). Returns null if the controller has vanished — in which case
+// the stop button is shown disabled with a tooltip.
 const parentController = computed(() => {
   if (!isPiSession.value && !isCcSession.value) return null;
-  const role = isPiSession.value
-    ? "pi-headless-controller"
-    : "claude-code-headless-controller";
+  const agentToken = isPiSession.value ? "pi-headless" : "cc-headless";
   return (
     agentsState.list.find(
-      (a) => a.metadata?.["role"] === role && a.owner === props.agent.owner,
+      (a) =>
+        a.agent === agentToken &&
+        a.metadata?.["role"] === "controller" &&
+        a.owner === props.agent.owner,
     ) ?? null
   );
 });

--- a/examples/agent-web-ui/src/components/ChatPanel.vue
+++ b/examples/agent-web-ui/src/components/ChatPanel.vue
@@ -22,7 +22,9 @@ const bridge = useBridge();
 const error = ref<string | null>(null);
 
 const isCcSession = computed(
-  () => props.agent.metadata?.["spawner"] === "claude-code-headless",
+  () =>
+    props.agent.agent === "cc-headless" &&
+    props.agent.metadata?.["role"] === "session",
 );
 
 // Human label for the chat-header pill. Mirrors AgentCard's tagLabel

--- a/examples/agent-web-ui/src/components/RightPanel.vue
+++ b/examples/agent-web-ui/src/components/RightPanel.vue
@@ -18,12 +18,10 @@ const agent = computed(() => selectedAgent.value);
 const role = computed<"pi-controller" | "cc-controller" | "session" | "agent" | null>(() => {
   const a = agent.value;
   if (!a) return null;
-  if (a.metadata?.["role"] === "pi-headless-controller") return "pi-controller";
-  if (a.metadata?.["role"] === "claude-code-headless-controller") return "cc-controller";
-  if (
-    a.metadata?.["spawner"] === "pi-headless" ||
-    a.metadata?.["spawner"] === "claude-code-headless"
-  ) return "session";
+  const meta = a.metadata?.["role"];
+  if (a.agent === "pi-headless" && meta === "controller") return "pi-controller";
+  if (a.agent === "cc-headless" && meta === "controller") return "cc-controller";
+  if ((a.agent === "pi-headless" || a.agent === "cc-headless") && meta === "session") return "session";
   return "agent";
 });
 

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -62,24 +62,32 @@ export function sortAgents(list: DiscoveredAgentDTO[]): DiscoveredAgentDTO[] {
   });
 }
 
-/** Discovered pi-headless controllers (agents flagged via `metadata.role`). */
+/** Discovered pi-headless controllers (agent token + role). */
 export const piexecControllers = computed<DiscoveredAgentDTO[]>(() =>
-  agentsState.list.filter((a) => a.metadata?.["role"] === "pi-headless-controller"),
+  agentsState.list.filter(
+    (a) => a.agent === "pi-headless" && a.metadata?.["role"] === "controller",
+  ),
 );
 
-/** Discovered pi-headless sessions (spawned by a controller; identified via `metadata.spawner`). */
+/** Discovered pi-headless sessions (agent token + role). */
 export const piexecSessions = computed<DiscoveredAgentDTO[]>(() =>
-  agentsState.list.filter((a) => a.metadata?.["spawner"] === "pi-headless"),
+  agentsState.list.filter(
+    (a) => a.agent === "pi-headless" && a.metadata?.["role"] === "session",
+  ),
 );
 
-/** Discovered claude-code-headless controllers (agents flagged via `metadata.role`). */
+/** Discovered claude-code-headless controllers (agent token + role). */
 export const ccexecControllers = computed<DiscoveredAgentDTO[]>(() =>
-  agentsState.list.filter((a) => a.metadata?.["role"] === "claude-code-headless-controller"),
+  agentsState.list.filter(
+    (a) => a.agent === "cc-headless" && a.metadata?.["role"] === "controller",
+  ),
 );
 
-/** Discovered claude-code-headless sessions (spawned by a controller; identified via `metadata.spawner`). */
+/** Discovered claude-code-headless sessions (agent token + role). */
 export const ccexecSessions = computed<DiscoveredAgentDTO[]>(() =>
-  agentsState.list.filter((a) => a.metadata?.["spawner"] === "claude-code-headless"),
+  agentsState.list.filter(
+    (a) => a.agent === "cc-headless" && a.metadata?.["role"] === "session",
+  ),
 );
 
 /**
@@ -113,10 +121,8 @@ export const BUCKET_ORDER: Bucket[] = [
 ];
 
 export const BUCKET_LABELS: Record<Bucket, string> = {
-  // "Headless" matches the canonical protocol vocabulary used in
-  // metadata.role / metadata.spawner ("pi-headless-controller",
-  // "claude-code-headless"); aligning UI labels keeps users one term away
-  // from the docs they'll read next.
+  // Labels track the on-wire `agent` token + `metadata.role` so the UI
+  // vocabulary stays one term away from the docs.
   [BUCKETS.PI_EXEC_SESSION]: "PI Headless Sessions",
   [BUCKETS.PI_EXEC_CONTROL]: "PI Headless Controllers",
   [BUCKETS.CC_EXEC_SESSION]: "Claude Code Headless Sessions",
@@ -130,11 +136,12 @@ export const BUCKET_LABELS: Record<Bucket, string> = {
 
 export function bucketOf(agent: DiscoveredAgentDTO): Bucket {
   const role = agent.metadata?.["role"];
-  const spawner = agent.metadata?.["spawner"];
-  if (spawner === "pi-headless") return BUCKETS.PI_EXEC_SESSION;
-  if (spawner === "claude-code-headless") return BUCKETS.CC_EXEC_SESSION;
-  if (role === "pi-headless-controller") return BUCKETS.PI_EXEC_CONTROL;
-  if (role === "claude-code-headless-controller") return BUCKETS.CC_EXEC_CONTROL;
+  if (agent.agent === "pi-headless") {
+    return role === "controller" ? BUCKETS.PI_EXEC_CONTROL : BUCKETS.PI_EXEC_SESSION;
+  }
+  if (agent.agent === "cc-headless") {
+    return role === "controller" ? BUCKETS.CC_EXEC_CONTROL : BUCKETS.CC_EXEC_SESSION;
+  }
   // `agent.agent` carries the value of `metadata.agent` (per Appendix C of
   // the spec). Each runtime publishes its own canonical token — match the
   // actual values the runtimes set, plus the legacy short aliases that

--- a/examples/agent-web-ui/src/stores/ccexec.ts
+++ b/examples/agent-web-ui/src/stores/ccexec.ts
@@ -32,14 +32,15 @@ export const ccexecState = reactive<{
 
 /**
  * The currently selected claude-code-headless controller, or null when the
- * selected agent isn't a claude-code-headless-controller.
+ * selected agent isn't a claude-code-headless controller.
  */
 export const selectedCcController = computed(() => {
   const id = agentsState.selectedInstanceId;
   if (!id) return null;
   const agent = agentsState.list.find((a) => a.instanceId === id);
   if (!agent) return null;
-  if (agent.metadata?.["role"] !== "claude-code-headless-controller") return null;
+  if (agent.agent !== "cc-headless") return null;
+  if (agent.metadata?.["role"] !== "controller") return null;
   return agent;
 });
 

--- a/examples/agent-web-ui/src/stores/piexec.ts
+++ b/examples/agent-web-ui/src/stores/piexec.ts
@@ -47,14 +47,15 @@ export const piexecState = reactive<{
 
 /**
  * The currently selected pi-headless controller, or null when the selected
- * agent isn't a pi-headless-controller (or nothing is selected).
+ * agent isn't a pi-headless controller (or nothing is selected).
  */
 export const selectedController = computed(() => {
   const id = agentsState.selectedInstanceId;
   if (!id) return null;
   const agent = agentsState.list.find((a) => a.instanceId === id);
   if (!agent) return null;
-  if (agent.metadata?.["role"] !== "pi-headless-controller") return null;
+  if (agent.agent !== "pi-headless") return null;
+  if (agent.metadata?.["role"] !== "controller") return null;
   return agent;
 });
 

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -2,7 +2,7 @@
 
 A headless NATS agent host that spawns [Claude Code](https://docs.claude.com/en/docs/claude-code) sessions on demand via the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) and exposes each one as a first-class NATS Agent Protocol **v0.3** instance (verb-first subjects + `status` endpoint). Built on `@synadia-ai/agents` (caller-side primitives) and `@synadia-ai/agent-service` (host-side `ReferenceAgent`).
 
-Each spawned session registers as its own NATS agent under `agents.prompt.cc.<owner>.<session_id>` — discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.prompt.cc.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle — `spawn`, `stop`, `list` — alongside the protocol-required `prompt` endpoint (which returns help text) and a `status` endpoint that replies with the same payload as a heartbeat.
+Each spawned session registers as its own NATS agent under `agents.prompt.cc-headless.<owner>.<session_id>` — discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.prompt.cc-headless.<owner>.<name>` (default `name = "control"`) adds request/reply endpoints for session lifecycle — `spawn`, `stop`, `list` — alongside the protocol-required `prompt` endpoint (which returns help text) and a `status` endpoint that replies with the same payload as a heartbeat.
 
 In short: one process, many Claude Code sessions, all first-class NATS agents.
 
@@ -28,8 +28,8 @@ npx @synadia-ai/nats-claude-code-headless --context localhost
 and prints:
 
 ```
-claude-code-headless: controller listening on agents.prompt.cc.<you>.exec
-claude-code-headless: extra endpoints — …exec.spawn  …exec.stop  …exec.list
+claude-code-headless: controller listening on agents.prompt.cc-headless.<you>.control
+claude-code-headless: control endpoints — agents.spawn.cc-headless.<you>.control  …  agents.stop.…  agents.list.…
 ```
 
 For a permanent install:
@@ -88,7 +88,7 @@ Optional defaults live in `~/.claude-code-headless/config.json`:
 ```json
 {
   "context": "localhost",
-  "name": "exec",
+  "name": "control",
   "defaultModel": "claude-sonnet-4-6",
   "defaultPermissionMode": "dontAsk",
   "defaultAllowedTools": ["Read", "Glob", "Grep"],
@@ -103,7 +103,7 @@ Env overrides:
 | Variable | Overrides | Default |
 | --- | --- | --- |
 | `CLAUDE_CODE_HEADLESS_OWNER` | Owner subject token (3rd segment) | `$USER` |
-| `CLAUDE_CODE_HEADLESS_NAME` | Controller instance name (4th token) | `exec` |
+| `CLAUDE_CODE_HEADLESS_NAME` | Controller instance name (4th token) | `control` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_MODEL` | Default Claude model id for spawns | `claude-sonnet-4-6` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_PERMISSION_MODE` | Default permission mode for spawns | `dontAsk` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_ALLOWED_TOOLS` | Default tool allowlist (comma-separated) | `Read,Glob,Grep` |
@@ -149,36 +149,38 @@ The out-of-the-box defaults are deliberately conservative for a public reference
 
 ## Subject layout
 
-```
-agents.prompt.cc.<owner>.<name>             ← controller prompt endpoint (help text)
-agents.status.cc.<owner>.<name>             ← controller status (§8.7 (v0.3); replies with heartbeat-shaped payload)
-agents.hb.cc.<owner>.<name>                 ← controller heartbeat (§8.1 v0.3, 30 s)
-agents.cc.<owner>.<name>.spawn              ← POST JSON → session descriptor (custom; non-verb-first)
-agents.cc.<owner>.<name>.stop               ← POST { session_id } → { ok: true }    (custom)
-agents.cc.<owner>.<name>.list               ← (empty) → { sessions: [...] }          (custom)
+Verb-first throughout — protocol verbs and claude-code-headless extension verbs share the same `agents.<verb>.cc-headless.<owner>.<token>` shape, so a tracer or audit layer can subscribe to `agents.<verb>.>` and parse identity positionally.
 
-agents.prompt.cc.<owner>.<session_id>       ← spawned session prompt (§5/§6, v0.3)
-agents.status.cc.<owner>.<session_id>       ← spawned session status (§8.7 (v0.3))
-agents.hb.cc.<owner>.<session_id>           ← spawned session heartbeat (§8.1 v0.3, 30 s)
+```
+agents.prompt.cc-headless.<owner>.<name>      ← controller prompt endpoint (help text)
+agents.status.cc-headless.<owner>.<name>      ← controller status (replies with heartbeat-shaped payload)
+agents.hb.cc-headless.<owner>.<name>          ← controller heartbeat (30 s)
+agents.spawn.cc-headless.<owner>.<name>       ← POST JSON → session descriptor
+agents.stop.cc-headless.<owner>.<name>        ← POST { session_id } → { ok: true }
+agents.list.cc-headless.<owner>.<name>        ← (empty) → { sessions: [...] }
+
+agents.prompt.cc-headless.<owner>.<session_id>  ← spawned session prompt
+agents.status.cc-headless.<owner>.<session_id>  ← spawned session status
+agents.hb.cc-headless.<owner>.<session_id>      ← spawned session heartbeat (30 s)
 ```
 
-The `cc` token is shared with [`agents/claude-code/`](../../agents/claude-code), which speaks the inverse direction (Claude Code as MCP-driven NATS *client*). They co-exist because the controller name and per-session ids disambiguate the 4th subject token.
+The `cc-headless` token disambiguates this controller (and its spawned sessions) from the regular Claude Code agent at [`agents/claude-code/`](../../agents/claude-code), which uses the `cc` token for the opposite direction (Claude Code as MCP-driven NATS *client*).
 
 ## Wire examples
 
 ### Spawn
 
 ```bash
-nats req agents.cc.$USER.exec.spawn \
+nats req agents.spawn.cc-headless.$USER.control \
   '{"cwd":"/tmp/cc-sandbox","model":"claude-sonnet-4-6","allowed_tools":["Read","Glob","Grep","Edit"],"permission_mode":"acceptEdits","max_lifetime_s":900}' \
   --timeout=15s
-# → { "session_id":"sess-a1b2c3d4", "subject":"agents.prompt.cc.$USER.sess-a1b2c3d4", "status_subject":"agents.status.cc.$USER.sess-a1b2c3d4", ... }
+# → { "session_id":"sess-a1b2c3d4", "subject":"agents.prompt.cc-headless.$USER.sess-a1b2c3d4", "status_subject":"agents.status.cc-headless.$USER.sess-a1b2c3d4", ... }
 ```
 
 ### Prompt (protocol-standard — no custom format)
 
 ```bash
-nats req agents.prompt.cc.$USER.sess-a1b2c3d4 \
+nats req agents.prompt.cc-headless.$USER.sess-a1b2c3d4 \
   'list the files here and summarise what you see' --replies=0 --timeout=120s
 # → {"type":"status","data":"ack"}
 # → {"type":"response","data":"There are three files: …"}
@@ -207,14 +209,14 @@ await nc.close();
 ### Stop
 
 ```bash
-nats req agents.cc.$USER.exec.stop '{"session_id":"sess-a1b2c3d4"}'
+nats req agents.stop.cc-headless.$USER.control '{"session_id":"sess-a1b2c3d4"}'
 # → { "ok": true, "session_id":"sess-a1b2c3d4" }
 ```
 
 ### List
 
 ```bash
-nats req agents.cc.$USER.exec.list ''
+nats req agents.list.cc-headless.$USER.control ''
 # → { "sessions": [ { "session_id":"sess-a1b2c3d4", "cwd":"/tmp/cc-sandbox", "remaining_lifetime_s": 867, ... } ] }
 ```
 
@@ -238,9 +240,9 @@ Session prompt endpoints follow protocol §9.
 
 ## Notes
 
-- **Session identity.** The 4th subject token is the session id; `metadata.session` echoes it. Controllers use `name = "exec"` by default.
-- **Metadata marker.** The controller carries `metadata.role = "claude-code-headless-controller"` so clients can tell it apart from other `cc` agents.
-- **One controller per `(owner, name)`.** The custom `spawn` / `stop` / `list` endpoints are NATS micro-service endpoints, which load-balance across all instances sharing the same subject. If you need multiple controllers side-by-side, give each one a distinct `--name` (e.g. `--name exec-a`, `--name exec-b`).
+- **Session identity.** The 4th subject token is the session id; `metadata.session` echoes it. Controllers use `name = "control"` by default and sessions carry `metadata.role = "session"`.
+- **Metadata marker.** The controller carries `metadata.role = "controller"` so clients can tell it apart from sessions. The shared `agent: "cc-headless"` token already disambiguates this from the regular `agent: "cc"` (Claude Code as MCP-driven NATS client).
+- **Multiple controllers per host.** On startup the controller probes `$SRV.INFO.agents` and, if its target prompt subject is already claimed, picks the next free `<name>-2`, `<name>-3`, … suffix automatically. So booting a second claude-code-headless with default settings leaves the first as `control` and the second as `control-2` without explicit `--name` flags. (For deterministic naming or two stable controllers side-by-side, still pass `--name` explicitly.)
 - **Serial drain per session.** Per session, prompts are queued and processed one at a time; the Claude Agent SDK's `query()` is one full multi-turn round-trip per call, and concurrent re-entry into the same session would interleave context.
 - **Session resumption.** Each prompt after the first is sent to the SDK with `resume: <sdkSessionId>` so context carries forward within a session for its full lifetime.
 - **Lifetime & pruning.** `max_lifetime_s` bounds a session's wall-clock life; pending requests older than 30 min are evicted (active requests are never evicted).

--- a/examples/claude-code-headless/package.json
+++ b/examples/claude-code-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synadia-ai/nats-claude-code-headless",
   "version": "0.4.2",
-  "description": "Headless NATS agent host that spawns, prompts, and stops Claude Code sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.cc.<owner>.<session_id>; a small controller service adds spawn/stop/list custom endpoints.",
+  "description": "Headless NATS agent host that spawns, prompts, and stops Claude Code sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.cc-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",
     "agents",

--- a/examples/claude-code-headless/scripts/_common.ts
+++ b/examples/claude-code-headless/scripts/_common.ts
@@ -9,7 +9,7 @@ export interface CliArgs {
   readonly context?: string;
   readonly natsUrl?: string;
   readonly owner?: string;
-  readonly name?: string; // controller name, default "exec"
+  readonly name?: string; // controller name, default "control"
   readonly rest: ReadonlyMap<string, string>;
   readonly positional: ReadonlyArray<string>;
 }
@@ -91,7 +91,7 @@ export function ownerFilter(args: CliArgs): string {
 }
 
 export function nameFilter(args: CliArgs): string {
-  return args.name ?? "exec";
+  return args.name ?? "control";
 }
 
 export async function findController(agents: Agents, args: CliArgs): Promise<Agent> {
@@ -99,8 +99,8 @@ export async function findController(agents: Agents, args: CliArgs): Promise<Age
   const owner = ownerFilter(args);
   const name = nameFilter(args);
   const candidates = found.filter((a) => {
-    if (a.agent !== "cc") return false;
-    if (a.metadata["role"] !== "claude-code-headless-controller") return false;
+    if (a.agent !== "cc-headless") return false;
+    if (a.metadata["role"] !== "controller") return false;
     if (owner && a.owner !== owner) return false;
     if (name && a.name !== name) return false;
     return true;

--- a/examples/claude-code-headless/scripts/list.ts
+++ b/examples/claude-code-headless/scripts/list.ts
@@ -1,12 +1,13 @@
 // CLI helper: list active claude-code-headless sessions on every reachable controller.
 //
 // Usage:
-//   bun run scripts/list.ts [--owner USER] [--name exec]
+//   bun run scripts/list.ts [--owner USER] [--name control]
 //                           [--context demo | --url nats://...]
 
 import process from "node:process";
 
 import { openCliClient, parseArgs, ownerFilter, nameFilter } from "./_common.js";
+import { controllerListSubject } from "../src/subjects.js";
 
 interface SessionSummary {
   session_id: string;
@@ -29,8 +30,8 @@ async function main(): Promise<void> {
     const name = nameFilter(args);
     const controllers = agents.filter(
       (a) =>
-        a.agent === "cc" &&
-        a.metadata["role"] === "claude-code-headless-controller" &&
+        a.agent === "cc-headless" &&
+        a.metadata["role"] === "controller" &&
         (!owner || a.owner === owner) &&
         (!name || a.name === name),
     );
@@ -39,7 +40,7 @@ async function main(): Promise<void> {
       process.exit(0);
     }
     for (const controller of controllers) {
-      const listSubject = `${controller.promptEndpoint.subject}.list`;
+      const listSubject = controllerListSubject(controller.owner, controller.name);
       const rep = await cli.nc.request(listSubject, "", { timeout: 5_000 });
       const body = JSON.parse(rep.string()) as { sessions: SessionSummary[] };
       process.stdout.write(

--- a/examples/claude-code-headless/scripts/spawn.ts
+++ b/examples/claude-code-headless/scripts/spawn.ts
@@ -12,6 +12,7 @@
 import process from "node:process";
 
 import { openCliClient, findController, parseArgs, waitForSession } from "./_common.js";
+import { controllerSpawnSubject, controllerStopSubject } from "../src/subjects.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -43,7 +44,7 @@ async function main(): Promise<void> {
   const cli = await openCliClient(args);
   try {
     const controller = await findController(cli.agents, args);
-    const spawnSubject = `${controller.promptEndpoint.subject}.spawn`;
+    const spawnSubject = controllerSpawnSubject(controller.owner, controller.name);
     process.stderr.write(`claude-code-headless-cli: calling ${spawnSubject}\n`);
 
     const rep = await cli.nc.request(spawnSubject, JSON.stringify(spec), { timeout: 15_000 });
@@ -79,7 +80,7 @@ async function main(): Promise<void> {
       process.stdout.write("\n");
 
       if (stopAfter) {
-        const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+        const stopSubject = controllerStopSubject(controller.owner, controller.name);
         await cli.nc.request(
           stopSubject,
           JSON.stringify({ session_id: descriptor.session_id }),

--- a/examples/claude-code-headless/scripts/stop.ts
+++ b/examples/claude-code-headless/scripts/stop.ts
@@ -1,12 +1,13 @@
 // CLI helper: stop a claude-code-headless session.
 //
 // Usage:
-//   bun run scripts/stop.ts SESSION_ID [--owner USER] [--name exec]
+//   bun run scripts/stop.ts SESSION_ID [--owner USER] [--name control]
 //                                      [--context demo | --url nats://...]
 
 import process from "node:process";
 
 import { openCliClient, findController, parseArgs } from "./_common.js";
+import { controllerStopSubject } from "../src/subjects.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -19,7 +20,7 @@ async function main(): Promise<void> {
   const cli = await openCliClient(args);
   try {
     const controller = await findController(cli.agents, args);
-    const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+    const stopSubject = controllerStopSubject(controller.owner, controller.name);
     const rep = await cli.nc.request(
       stopSubject,
       JSON.stringify({ session_id: sessionId }),

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -45,7 +45,7 @@ export interface ClaudeCodeHeadlessConfig {
 const CONFIG_FILE = join(homedir(), ".claude-code-headless", "config.json");
 
 const BUILT_IN_DEFAULTS = {
-  name: "exec",
+  name: "control",
   // Sonnet is the right cost/quality default for a per-request spawner;
   // callers can override per-spawn or via config.json.
   defaultModel: "claude-sonnet-4-6",

--- a/examples/claude-code-headless/src/controller.ts
+++ b/examples/claude-code-headless/src/controller.ts
@@ -1,17 +1,18 @@
 // claude-code-headless controller service.
 //
-// One protocol-compliant NATS agent that uses the 3rd subject token `cc`
-// (the verb `prompt` lives at token 2 per §2 v0.3) and exposes endpoints:
+// One protocol-compliant NATS agent that registers under the agent token
+// `cc-headless` (3rd subject token, see subjects.ts for the full layout)
+// and exposes endpoints:
 //
 //   - `prompt`  (§5/§6-compliant)  — returns a help-text response, so the
 //                                    controller is usable with `nats req`.
-//   - `status`  (§8.7 (v0.3))       — replies with a heartbeat-shaped payload.
+//   - `status`                     — replies with a heartbeat-shaped payload.
 //   - `spawn`   (request/reply)    — creates a new Claude Code session,
 //                                    registers it as its own NATS agent.
 //   - `stop`    (request/reply)    — disposes a session.
 //   - `list`    (request/reply)    — returns an array of session summaries.
 //
-// Heartbeats go to `agents.hb.cc.<owner>.<name>` every 30s (§8.1 v0.3).
+// Heartbeats go to `agents.hb.cc-headless.<owner>.<name>` every 30s.
 
 import type { NatsConnection } from "@nats-io/nats-core";
 import { Svcm, type Service, type ServiceMsg } from "@nats-io/services";
@@ -58,7 +59,7 @@ const helpText = (
     "",
     "This is a control-plane agent. It spawns, stops, and lists Claude Code",
     "sessions backed by @anthropic-ai/claude-agent-sdk. Each spawned session",
-    "registers as its OWN NATS agent at `agents.prompt.cc.<owner>.<session_id>`",
+    "registers as its OWN NATS agent at `agents.prompt.cc-headless.<owner>.<session_id>`",
     "and speaks the standard NATS Agent Protocol v0.3 — discover it via",
     "$SRV.INFO.agents and prompt it like any agent.",
     "",
@@ -107,10 +108,10 @@ export class Controller {
     const svcm = new Svcm(this.opts.nc);
 
     const metadata: Record<string, string> = {
-      agent: "cc",
+      agent: "cc-headless",
       owner: this.opts.owner,
       protocol_version: `${SDK_PROTOCOL_VERSION.major}.${SDK_PROTOCOL_VERSION.minor}`,
-      role: "claude-code-headless-controller",
+      role: "controller",
     };
 
     this.service = await svcm.add({
@@ -134,7 +135,7 @@ export class Controller {
       },
     });
 
-    // §8.7 (v0.3) status endpoint — replies with a heartbeat-shaped payload.
+    // Status endpoint — replies with a heartbeat-shaped payload.
     this.service.addEndpoint(STATUS_ENDPOINT_NAME, {
       subject: this.statusSubject,
       queue: STATUS_QUEUE_GROUP,
@@ -144,7 +145,7 @@ export class Controller {
       },
     });
 
-    // Custom control endpoints — not protocol-standard, but allowed.
+    // Extension endpoints (verb-first, agents.<verb>.cc-headless.<owner>.<name>).
     this.service.addEndpoint("spawn", {
       subject: controllerSpawnSubject(this.opts.owner, this.opts.name),
       handler: (err, msg) => {
@@ -172,7 +173,7 @@ export class Controller {
     this.startHeartbeats();
     this.log(`claude-code-headless: controller listening on ${this.promptSubject}`);
     this.log(
-      `claude-code-headless: extra endpoints — ${controllerSpawnSubject(this.opts.owner, this.opts.name)}, ${controllerStopSubject(this.opts.owner, this.opts.name)}, ${controllerListSubject(this.opts.owner, this.opts.name)}`,
+      `claude-code-headless: control endpoints — ${controllerSpawnSubject(this.opts.owner, this.opts.name)}, ${controllerStopSubject(this.opts.owner, this.opts.name)}, ${controllerListSubject(this.opts.owner, this.opts.name)}`,
     );
   }
 
@@ -219,7 +220,7 @@ export class Controller {
     if (!this.service) return;
     const intervalS = this.opts.heartbeatIntervalS ?? DEFAULT_HEARTBEAT_INTERVAL_S;
     const payload = {
-      agent: "cc",
+      agent: "cc-headless",
       owner: this.opts.owner,
       instance_id: this.service.info().id,
       ts: new Date().toISOString(),
@@ -304,7 +305,7 @@ export class Controller {
     const publish = (): void => {
       if (!this.service) return;
       const payload = {
-        agent: "cc",
+        agent: "cc-headless",
         owner: this.opts.owner,
         instance_id: this.service.info().id,
         ts: new Date().toISOString(),

--- a/examples/claude-code-headless/src/index.ts
+++ b/examples/claude-code-headless/src/index.ts
@@ -16,6 +16,7 @@ import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 import { ClaudeSessionManager } from "./claude-session-manager.js";
 import { Controller } from "./controller.js";
 import { loadConfig, parseCliOverrides } from "./config.js";
+import { resolveControllerName } from "./subjects.js";
 
 const log = (line: string): void => {
   process.stderr.write(`${line}\n`);
@@ -81,10 +82,18 @@ async function main(): Promise<void> {
   });
   await manager.start();
 
+  // Probe for an unclaimed controller name. With the default `control`,
+  // a second claude-code-headless on the same NATS lands on `control-2`,
+  // a third on `control-3`, and so on.
+  const resolvedName = await resolveControllerName(nc, config.name, config.owner);
+  if (resolvedName !== config.name) {
+    log(`claude-code-headless: name "${config.name}" is taken; using "${resolvedName}"`);
+  }
+
   const controller = new Controller({
     nc,
     owner: config.owner,
-    name: config.name,
+    name: resolvedName,
     manager,
   });
   await controller.start();

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -130,7 +130,7 @@ export class ManagedSession {
     this.statusSubject = sessionStatusSubject(this.owner, this.sessionId);
 
     const extraMetadata: Record<string, string> = {
-      spawner: "claude-code-headless",
+      role: "session",
       cwd: this.cwd,
       model: this.model,
       permission_mode: this.permissionMode,
@@ -141,7 +141,7 @@ export class ManagedSession {
 
     this.refAgent = new ReferenceAgent({
       nc: this.nc,
-      agent: "cc",
+      agent: "cc-headless",
       owner: this.owner,
       name: this.sessionId,
       session: this.sessionId,

--- a/examples/claude-code-headless/src/subjects.ts
+++ b/examples/claude-code-headless/src/subjects.ts
@@ -1,63 +1,69 @@
 // Subject builders + session-id sanitizer for claude-code-headless.
 //
-// Wire layout (v0.3 — verb-first per spec §2):
-//   agents.prompt.cc.<owner>.<name>     → controller's prompt endpoint
-//   agents.hb.cc.<owner>.<name>         → controller heartbeat
-//   agents.status.cc.<owner>.<name>     → controller status (§8.7 (v0.3))
-//   agents.prompt.cc.<owner>.<session>  → spawned session's prompt endpoint
-//   agents.hb.cc.<owner>.<session>      → spawned session heartbeat
-//   agents.status.cc.<owner>.<session>  → spawned session status
+// Wire layout (verb-first throughout):
 //
-// Custom endpoints stay on a non-verb-first form so they're clearly
-// application extensions (not protocol endpoints):
-//   agents.cc.<owner>.<name>.spawn      → POST JSON → session descriptor
-//   agents.cc.<owner>.<name>.stop       → POST {session_id} → ok
-//   agents.cc.<owner>.<name>.list       → (empty) → {sessions:[...]}
+//   agents.prompt.cc-headless.<owner>.<name>     → controller's prompt endpoint
+//   agents.hb.cc-headless.<owner>.<name>         → controller heartbeat
+//   agents.status.cc-headless.<owner>.<name>     → controller status
+//   agents.spawn.cc-headless.<owner>.<name>      → controller spawn endpoint
+//   agents.stop.cc-headless.<owner>.<name>       → controller stop endpoint
+//   agents.list.cc-headless.<owner>.<name>       → controller list endpoint
+//   agents.prompt.cc-headless.<owner>.<session>  → spawned session prompt
+//   agents.hb.cc-headless.<owner>.<session>      → spawned session heartbeat
+//   agents.status.cc-headless.<owner>.<session>  → spawned session status
 //
-// The `cc` token is shared with `agents/claude-code/` (Claude Code as
-// MCP-driven NATS client). They co-exist because the controller name
-// and per-session ids disambiguate the trailing subject tokens.
+// `cc-headless` distinguishes this controller (and its spawned sessions) from
+// the regular Claude Code agent at `agents/claude-code/` (which uses the
+// `cc` token). The wire layout is verb-first for every endpoint — the
+// protocol-mandated verbs (`prompt`, `hb`, `status`) share the same
+// `agents.<verb>.<agent>.<owner>.<name>` shape as the extension verbs
+// (`spawn`, `stop`, `list`), so any tracer or audit layer can subscribe to
+// `agents.<verb>.>` and parse identity positionally.
 
-export const AGENT_TOKEN = "cc";
+import type { NatsConnection } from "@nats-io/nats-core";
+import { Svcm } from "@nats-io/services";
+import { SERVICE_NAME } from "@synadia-ai/agents";
+
+export const AGENT_TOKEN = "cc-headless";
+
+function subject(verb: string, owner: string, name: string): string {
+  return `agents.${verb}.${AGENT_TOKEN}.${owner}.${name}`;
+}
 
 export function controllerPromptSubject(owner: string, name: string): string {
-  return `agents.prompt.${AGENT_TOKEN}.${owner}.${name}`;
+  return subject("prompt", owner, name);
 }
 
 export function controllerHeartbeatSubject(owner: string, name: string): string {
-  return `agents.hb.${AGENT_TOKEN}.${owner}.${name}`;
+  return subject("hb", owner, name);
 }
 
 export function controllerStatusSubject(owner: string, name: string): string {
-  return `agents.status.${AGENT_TOKEN}.${owner}.${name}`;
+  return subject("status", owner, name);
 }
 
-/** Custom endpoints — application-specific, NOT part of the v0.3 verb-first scheme. */
-const customSubjectRoot = (owner: string, name: string): string =>
-  `agents.${AGENT_TOKEN}.${owner}.${name}`;
-
 export function controllerSpawnSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.spawn`;
+  return subject("spawn", owner, name);
 }
 
 export function controllerStopSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.stop`;
+  return subject("stop", owner, name);
 }
 
 export function controllerListSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.list`;
+  return subject("list", owner, name);
 }
 
 export function sessionPromptSubject(owner: string, sessionId: string): string {
-  return `agents.prompt.${AGENT_TOKEN}.${owner}.${sessionId}`;
+  return subject("prompt", owner, sessionId);
 }
 
 export function sessionHeartbeatSubject(owner: string, sessionId: string): string {
-  return `agents.hb.${AGENT_TOKEN}.${owner}.${sessionId}`;
+  return subject("hb", owner, sessionId);
 }
 
 export function sessionStatusSubject(owner: string, sessionId: string): string {
-  return `agents.status.${AGENT_TOKEN}.${owner}.${sessionId}`;
+  return subject("status", owner, sessionId);
 }
 
 // Tokens MUST follow §2.2: [a-z0-9_-], not starting with $, 1..63 chars.
@@ -99,4 +105,40 @@ export function generateSessionId(): string {
   globalThis.crypto.getRandomValues(bytes);
   const rand = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `sess-${rand}`;
+}
+
+/**
+ * Probe `$SRV.INFO.agents` and pick the first controller name whose prompt
+ * subject is unclaimed. Auto-suffixes `-2`, `-3`, … until a free slot is
+ * found, so two claude-code-headless processes booted with the default
+ * `control` land on `control` and `control-2` respectively. The probe is
+ * best-effort (a small race window remains between discovery and svcm.add)
+ * — the trade-off is acceptable for a developer convenience.
+ */
+export async function resolveControllerName(
+  nc: NatsConnection,
+  base: string,
+  owner: string,
+): Promise<string> {
+  const svcm = new Svcm(nc);
+  const client = svcm.client({ strategy: "stall", maxWait: 1000, maxMessages: 50 });
+
+  const taken = new Set<string>();
+  try {
+    const iter = await client.info(SERVICE_NAME);
+    for await (const si of iter) {
+      for (const ep of si.endpoints ?? []) {
+        taken.add(ep.subject);
+      }
+    }
+  } catch {
+    // No existing services or timeout — fine.
+  }
+
+  let candidate = base;
+  let suffix = 2;
+  while (taken.has(controllerPromptSubject(owner, candidate))) {
+    candidate = `${base}-${suffix++}`;
+  }
+  return candidate;
 }

--- a/examples/claude-code-headless/src/subjects.ts
+++ b/examples/claude-code-headless/src/subjects.ts
@@ -107,6 +107,20 @@ export function generateSessionId(): string {
   return `sess-${rand}`;
 }
 
+// `maxWait: 200` caps cold-boot latency at 200 ms; on a local NATS all
+// responses arrive in <5 ms, and 200 ms is well above any sane WAN RTT
+// to NGS. (The @nats-io/nats-core stall timer is hardcoded at 300 ms for
+// `strategy: "stall"`, so anything under 300 ms means maxWait wins —
+// which is what we want here.)
+const SRV_INFO_MAX_WAIT_MS = 200;
+const SRV_INFO_MAX_MESSAGES = 50;
+
+// Hard cap on auto-suffix attempts. Bounded implicitly by `maxMessages`
+// above, but an explicit guard makes failure visible rather than letting
+// the loop spin indefinitely if the wire ever returns more responses
+// than expected.
+const MAX_SUFFIX_ATTEMPTS = 100;
+
 /**
  * Probe `$SRV.INFO.agents` and pick the first controller name whose prompt
  * subject is unclaimed. Auto-suffixes `-2`, `-3`, … until a free slot is
@@ -121,14 +135,25 @@ export async function resolveControllerName(
   owner: string,
 ): Promise<string> {
   const svcm = new Svcm(nc);
-  const client = svcm.client({ strategy: "stall", maxWait: 1000, maxMessages: 50 });
+  const client = svcm.client({
+    strategy: "stall",
+    maxWait: SRV_INFO_MAX_WAIT_MS,
+    maxMessages: SRV_INFO_MAX_MESSAGES,
+  });
 
-  const taken = new Set<string>();
+  // Collect only `agents.prompt.<AGENT_TOKEN>.*` subjects — those are the
+  // only ones the suffix loop ever checks. Filtering at collection time
+  // makes the intent self-documenting and skips bookkeeping for the
+  // status/hb/spawn/stop/list/etc subjects we don't care about here.
+  const promptPrefix = `agents.prompt.${AGENT_TOKEN}.`;
+  const takenPromptSubjects = new Set<string>();
   try {
     const iter = await client.info(SERVICE_NAME);
     for await (const si of iter) {
       for (const ep of si.endpoints ?? []) {
-        taken.add(ep.subject);
+        if (ep.subject.startsWith(promptPrefix)) {
+          takenPromptSubjects.add(ep.subject);
+        }
       }
     }
   } catch {
@@ -136,9 +161,14 @@ export async function resolveControllerName(
   }
 
   let candidate = base;
-  let suffix = 2;
-  while (taken.has(controllerPromptSubject(owner, candidate))) {
-    candidate = `${base}-${suffix++}`;
+  for (let attempt = 0; attempt < MAX_SUFFIX_ATTEMPTS; attempt++) {
+    if (!takenPromptSubjects.has(controllerPromptSubject(owner, candidate))) {
+      return candidate;
+    }
+    candidate = `${base}-${attempt + 2}`;
   }
-  return candidate;
+  throw new Error(
+    `claude-code-headless: could not find a free controller name after ${MAX_SUFFIX_ATTEMPTS} attempts ` +
+      `(base="${base}", owner="${owner}"). Pass an explicit --name to override.`,
+  );
 }

--- a/examples/pi-headless/README.md
+++ b/examples/pi-headless/README.md
@@ -2,7 +2,7 @@
 
 A headless NATS agent host for the [PI coding agent](https://github.com/badlogic/pi-mono), built on `@synadia-ai/agents` (caller-side primitives) and `@synadia-ai/agent-service` (host-side `ReferenceAgent`) and conforming to the NATS Agent Protocol **v0.3** (verb-first subjects + `status` endpoint).
 
-Each spawned PI session registers as its own NATS agent instance under `agents.prompt.pi.<owner>.<session_id>` - discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.prompt.pi.<owner>.<name>` (default `name = "exec"`) adds request/reply endpoints for session lifecycle - `spawn`, `stop`, `list` - alongside the protocol-required `prompt` endpoint (which returns help text) and a `status` endpoint that replies with the same payload as a heartbeat.
+Each spawned PI session registers as its own NATS agent instance under `agents.prompt.pi-headless.<owner>.<session_id>` - discoverable via `$SRV.INFO.agents` and promptable with any protocol-compliant client, including the `@synadia-ai/agents` SDK. A small **controller** service at `agents.prompt.pi-headless.<owner>.<name>` (default `name = "control"`) adds request/reply endpoints for session lifecycle - `spawn`, `stop`, `list` - alongside the protocol-required `prompt` endpoint (which returns help text) and a `status` endpoint that replies with the same payload as a heartbeat.
 
 In short: one process, many PI sessions, all first-class NATS agents.
 
@@ -26,8 +26,8 @@ npx @synadia-ai/nats-pi-headless --context localhost
 and prints:
 
 ```
-pi-headless: controller listening on agents.prompt.pi.<you>.exec
-pi-headless: extra endpoints — …exec.spawn  …exec.stop  …exec.list
+pi-headless: controller listening on agents.prompt.pi-headless.<you>.control
+pi-headless: control endpoints — agents.spawn.pi-headless.<you>.control  …  agents.stop.…  agents.list.…
 ```
 
 For a permanent install:
@@ -82,7 +82,7 @@ Optional defaults live in `~/.pi-headless/config.json`:
 ```json
 {
   "context": "localhost",
-  "name": "exec",
+  "name": "control",
   "defaultModel": "anthropic/claude-sonnet-4-5",
   "defaultThinkingLevel": "off",
   "defaultMaxLifetimeS": 1800
@@ -94,7 +94,7 @@ Env overrides:
 | Variable | Overrides | Default |
 | --- | --- | --- |
 | `PI_HEADLESS_OWNER` | Owner subject token (3rd segment) | `$USER` |
-| `PI_HEADLESS_NAME` | Controller instance name (4th token) | `exec` |
+| `PI_HEADLESS_NAME` | Controller instance name (4th token) | `control` |
 | `PI_HEADLESS_DEFAULT_MODEL` | Default model spec for spawns | (none — caller must set, or PI picks) |
 | `PI_HEADLESS_DEFAULT_THINKING_LEVEL` | Default thinking level for spawns | (none) |
 | `PI_HEADLESS_DEFAULT_MAX_LIFETIME` | Default session lifetime, in seconds | `1800` |
@@ -105,17 +105,19 @@ PI auth / model registry comes from `~/.pi/agent/auth.json` (the same location `
 
 ## Subject layout
 
-```
-agents.prompt.pi.<owner>.<name>             ← controller prompt endpoint (help text)
-agents.status.pi.<owner>.<name>             ← controller status (§8.7 (v0.3); replies with heartbeat-shaped payload)
-agents.hb.pi.<owner>.<name>                 ← controller heartbeat (§8.1 v0.3, 30 s)
-agents.pi.<owner>.<name>.spawn              ← POST JSON → session descriptor (custom; non-verb-first)
-agents.pi.<owner>.<name>.stop               ← POST { session_id } → { ok: true }    (custom)
-agents.pi.<owner>.<name>.list               ← (empty) → { sessions: [...] }          (custom)
+Verb-first throughout — protocol verbs and pi-headless extension verbs share the same `agents.<verb>.pi-headless.<owner>.<token>` shape, so a tracer or audit layer can subscribe to `agents.<verb>.>` and parse identity positionally.
 
-agents.prompt.pi.<owner>.<session_id>       ← spawned session prompt (§5/§6, v0.3)
-agents.status.pi.<owner>.<session_id>       ← spawned session status (§8.7 (v0.3))
-agents.hb.pi.<owner>.<session_id>           ← spawned session heartbeat (§8.1 v0.3, 30 s)
+```
+agents.prompt.pi-headless.<owner>.<name>      ← controller prompt endpoint (help text)
+agents.status.pi-headless.<owner>.<name>      ← controller status (replies with heartbeat-shaped payload)
+agents.hb.pi-headless.<owner>.<name>          ← controller heartbeat (30 s)
+agents.spawn.pi-headless.<owner>.<name>       ← POST JSON → session descriptor
+agents.stop.pi-headless.<owner>.<name>        ← POST { session_id } → { ok: true }
+agents.list.pi-headless.<owner>.<name>        ← (empty) → { sessions: [...] }
+
+agents.prompt.pi-headless.<owner>.<session_id>  ← spawned session prompt
+agents.status.pi-headless.<owner>.<session_id>  ← spawned session status
+agents.hb.pi-headless.<owner>.<session_id>      ← spawned session heartbeat (30 s)
 ```
 
 ## Wire examples
@@ -123,16 +125,16 @@ agents.hb.pi.<owner>.<session_id>           ← spawned session heartbeat (§8.1
 ### Spawn
 
 ```bash
-nats req agents.pi.$USER.exec.spawn \
+nats req agents.spawn.pi-headless.$USER.control \
   '{"cwd":"/tmp/pi-sandbox","model":"anthropic/claude-sonnet-4-5","max_lifetime_s":900}' \
   --timeout=10s
-# → { "session_id":"sess-a1b2c3d4", "subject":"agents.prompt.pi.$USER.sess-a1b2c3d4", "status_subject":"agents.status.pi.$USER.sess-a1b2c3d4", ... }
+# → { "session_id":"sess-a1b2c3d4", "subject":"agents.prompt.pi-headless.$USER.sess-a1b2c3d4", "status_subject":"agents.status.pi-headless.$USER.sess-a1b2c3d4", ... }
 ```
 
 ### Prompt (protocol-standard - no custom format)
 
 ```bash
-nats req agents.prompt.pi.$USER.sess-a1b2c3d4 \
+nats req agents.prompt.pi-headless.$USER.sess-a1b2c3d4 \
   'summarise the files in this directory' --replies=0 --timeout=60s
 # → {"type":"status","data":"ack"}
 # → {"type":"response","data":"There are three files: …"}
@@ -161,14 +163,14 @@ await nc.close();
 ### Stop
 
 ```bash
-nats req agents.pi.$USER.exec.stop '{"session_id":"sess-a1b2c3d4"}'
+nats req agents.stop.pi-headless.$USER.control '{"session_id":"sess-a1b2c3d4"}'
 # → { "ok": true, "session_id":"sess-a1b2c3d4" }
 ```
 
 ### List
 
 ```bash
-nats req agents.pi.$USER.exec.list ''
+nats req agents.list.pi-headless.$USER.control ''
 # → { "sessions": [ { "session_id":"sess-a1b2c3d4", "cwd":"/tmp/pi-sandbox", "remaining_lifetime_s": 867, ... } ] }
 ```
 
@@ -192,9 +194,9 @@ Session prompt endpoints follow protocol §9.
 
 ## Notes
 
-- **Session identity.** The 4th subject token is the session id; `metadata.session` echoes it. Controllers use `name = "exec"` by default.
-- **Metadata marker.** The controller carries `metadata.role = "pi-headless-controller"` so clients can tell it apart from other pi agents.
-- **One controller per `(owner, name)`.** The custom `spawn` / `stop` / `list` endpoints are NATS micro-service endpoints, which load-balance across all instances sharing the same subject. If you need multiple controllers side-by-side, give each one a distinct `--name` (e.g. `--name exec-a`, `--name exec-b`) so they advertise on different subjects and don't cross-steal each other's control requests.
+- **Session identity.** The 4th subject token is the session id; `metadata.session` echoes it. Controllers use `name = "control"` by default and sessions carry `metadata.role = "session"`.
+- **Metadata marker.** The controller carries `metadata.role = "controller"` so clients can tell it apart from sessions. The shared `agent: "pi-headless"` token already disambiguates this from the regular `agent: "pi"` runtime.
+- **Multiple controllers per host.** On startup the controller probes `$SRV.INFO.agents` and, if its target prompt subject is already claimed, picks the next free `<name>-2`, `<name>-3`, … suffix automatically. So booting a second pi-headless with default settings leaves the first as `control` and the second as `control-2` without explicit `--name` flags. (For deterministic naming or two stable controllers side-by-side, still pass `--name` explicitly.)
 - **Serial drain.** Per session, prompts are queued and processed one at a time.
 - **Lifetime & pruning.** `max_lifetime_s` bounds a session's wall-clock life; pending requests older than 30 min are evicted (active requests are never evicted).
 - **Attachments.** Base64 attachments are decoded to `~/.pi-headless/attachments/<session_id>/<uuid>/` and their absolute paths are prepended to the prompt text, matching the `agents/pi/` staging pattern.

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synadia-ai/nats-pi-headless",
   "version": "0.4.1",
-  "description": "Headless NATS agent host that spawns, prompts, and stops PI coding-agent sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.pi.<owner>.<session_id>; a small controller service adds spawn/stop/list custom endpoints.",
+  "description": "Headless NATS agent host that spawns, prompts, and stops PI coding-agent sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.pi-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",
     "agents",

--- a/examples/pi-headless/scripts/_common.ts
+++ b/examples/pi-headless/scripts/_common.ts
@@ -9,7 +9,7 @@ export interface CliArgs {
   readonly context?: string;
   readonly natsUrl?: string;
   readonly owner?: string;
-  readonly name?: string; // controller name, default "exec"
+  readonly name?: string; // controller name, default "control"
   readonly rest: ReadonlyMap<string, string>;
   readonly positional: ReadonlyArray<string>;
 }
@@ -91,7 +91,7 @@ export function ownerFilter(args: CliArgs): string {
 }
 
 export function nameFilter(args: CliArgs): string {
-  return args.name ?? "exec";
+  return args.name ?? "control";
 }
 
 export async function findController(
@@ -102,8 +102,8 @@ export async function findController(
   const owner = ownerFilter(args);
   const name = nameFilter(args);
   const candidates = found.filter((a) => {
-    if (a.agent !== "pi") return false;
-    if (a.metadata["role"] !== "pi-headless-controller") return false;
+    if (a.agent !== "pi-headless") return false;
+    if (a.metadata["role"] !== "controller") return false;
     if (owner && a.owner !== owner) return false;
     if (name && a.name !== name) return false;
     return true;

--- a/examples/pi-headless/scripts/list.ts
+++ b/examples/pi-headless/scripts/list.ts
@@ -1,12 +1,13 @@
 // CLI helper: list active pi-headless sessions on every reachable controller.
 //
 // Usage:
-//   bun run scripts/list.ts [--owner USER] [--name exec]
+//   bun run scripts/list.ts [--owner USER] [--name control]
 //                           [--context demo | --url nats://...]
 
 import process from "node:process";
 
 import { openCliClient, parseArgs, ownerFilter, nameFilter } from "./_common.js";
+import { controllerListSubject } from "../src/subjects.js";
 
 interface SessionSummary {
   session_id: string;
@@ -29,8 +30,8 @@ async function main(): Promise<void> {
     const name = nameFilter(args);
     const controllers = agents.filter(
       (a) =>
-        a.agent === "pi" &&
-        a.metadata["role"] === "pi-headless-controller" &&
+        a.agent === "pi-headless" &&
+        a.metadata["role"] === "controller" &&
         (!owner || a.owner === owner) &&
         (!name || a.name === name),
     );
@@ -39,7 +40,7 @@ async function main(): Promise<void> {
       process.exit(0);
     }
     for (const controller of controllers) {
-      const listSubject = `${controller.promptEndpoint.subject}.list`;
+      const listSubject = controllerListSubject(controller.owner, controller.name);
       const rep = await cli.nc.request(listSubject, "", { timeout: 5_000 });
       const body = JSON.parse(rep.string()) as { sessions: SessionSummary[] };
       process.stdout.write(

--- a/examples/pi-headless/scripts/spawn.ts
+++ b/examples/pi-headless/scripts/spawn.ts
@@ -10,6 +10,7 @@
 import process from "node:process";
 
 import { openCliClient, findController, parseArgs, waitForSession } from "./_common.js";
+import { controllerSpawnSubject, controllerStopSubject } from "../src/subjects.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -35,7 +36,7 @@ async function main(): Promise<void> {
   const cli = await openCliClient(args);
   try {
     const controller = await findController(cli.agents, args);
-    const spawnSubject = `${controller.promptEndpoint.subject}.spawn`;
+    const spawnSubject = controllerSpawnSubject(controller.owner, controller.name);
     process.stderr.write(`pi-headless-cli: calling ${spawnSubject}\n`);
 
     const rep = await cli.nc.request(spawnSubject, JSON.stringify(spec), { timeout: 15_000 });
@@ -67,7 +68,7 @@ async function main(): Promise<void> {
       process.stdout.write("\n");
 
       if (stopAfter) {
-        const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+        const stopSubject = controllerStopSubject(controller.owner, controller.name);
         await cli.nc.request(
           stopSubject,
           JSON.stringify({ session_id: descriptor.session_id }),

--- a/examples/pi-headless/scripts/stop.ts
+++ b/examples/pi-headless/scripts/stop.ts
@@ -1,12 +1,13 @@
 // CLI helper: stop a pi-headless session.
 //
 // Usage:
-//   bun run scripts/stop.ts SESSION_ID [--owner USER] [--name exec]
+//   bun run scripts/stop.ts SESSION_ID [--owner USER] [--name control]
 //                                      [--context demo | --url nats://...]
 
 import process from "node:process";
 
 import { openCliClient, findController, parseArgs } from "./_common.js";
+import { controllerStopSubject } from "../src/subjects.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -19,7 +20,7 @@ async function main(): Promise<void> {
   const cli = await openCliClient(args);
   try {
     const controller = await findController(cli.agents, args);
-    const stopSubject = `${controller.promptEndpoint.subject}.stop`;
+    const stopSubject = controllerStopSubject(controller.owner, controller.name);
     const rep = await cli.nc.request(
       stopSubject,
       JSON.stringify({ session_id: sessionId }),

--- a/examples/pi-headless/src/config.ts
+++ b/examples/pi-headless/src/config.ts
@@ -33,7 +33,7 @@ export interface PiHeadlessConfig {
 const CONFIG_FILE = join(homedir(), ".pi-headless", "config.json");
 
 const BUILT_IN_DEFAULTS = {
-  name: "exec",
+  name: "control",
   defaultMaxLifetimeS: 1800,
 } as const;
 

--- a/examples/pi-headless/src/controller.ts
+++ b/examples/pi-headless/src/controller.ts
@@ -1,17 +1,18 @@
 // pi-headless controller service.
 //
-// One protocol-compliant NATS agent that uses the 3rd subject token `pi`
-// (the verb `prompt` lives at token 2 per §2 v0.3) and exposes endpoints:
+// One protocol-compliant NATS agent that registers under the agent token
+// `pi-headless` (3rd subject token, see subjects.ts for the full layout)
+// and exposes endpoints:
 //
 //   - `prompt`  (§5/§6-compliant)  — returns a help-text response, so the
 //                                    controller is usable with `nats req`.
-//   - `status`  (§8.7 (v0.3))       — replies with a heartbeat-shaped payload.
+//   - `status`                     — replies with a heartbeat-shaped payload.
 //   - `spawn`   (request/reply)    — creates a new PI session, registers it
 //                                    as its own NATS agent instance.
 //   - `stop`    (request/reply)    — disposes a session.
 //   - `list`    (request/reply)    — returns an array of session summaries.
 //
-// Heartbeats go to `agents.hb.pi.<owner>.<name>` every 30s (§8.1 v0.3).
+// Heartbeats go to `agents.hb.pi-headless.<owner>.<name>` every 30s.
 
 import type { NatsConnection } from "@nats-io/nats-core";
 import { Svcm, type Service, type ServiceMsg } from "@nats-io/services";
@@ -57,8 +58,8 @@ const helpText = (
     "",
     "This is a control-plane agent. It spawns, stops, and lists PI coding-agent",
     "sessions. Each spawned session registers as its OWN NATS agent at",
-    "`agents.prompt.pi.<owner>.<session_id>` and speaks the standard NATS Agent",
-    "Protocol v0.3 — discover it via $SRV.INFO.agents and prompt it like any agent.",
+    "`agents.prompt.pi-headless.<owner>.<session_id>` and speaks the standard NATS",
+    "Agent Protocol v0.3 — discover it via $SRV.INFO.agents and prompt it like any agent.",
     "",
     "Custom endpoints on this controller:",
     `  spawn : ${spawnSubject}`,
@@ -103,10 +104,10 @@ export class Controller {
     const svcm = new Svcm(this.opts.nc);
 
     const metadata: Record<string, string> = {
-      agent: "pi",
+      agent: "pi-headless",
       owner: this.opts.owner,
       protocol_version: `${SDK_PROTOCOL_VERSION.major}.${SDK_PROTOCOL_VERSION.minor}`,
-      role: "pi-headless-controller",
+      role: "controller",
     };
 
     this.service = await svcm.add({
@@ -130,7 +131,7 @@ export class Controller {
       },
     });
 
-    // §8.7 (v0.3) status endpoint — replies with a heartbeat-shaped payload.
+    // Status endpoint — replies with a heartbeat-shaped payload.
     this.service.addEndpoint(STATUS_ENDPOINT_NAME, {
       subject: this.statusSubject,
       queue: STATUS_QUEUE_GROUP,
@@ -140,7 +141,7 @@ export class Controller {
       },
     });
 
-    // Custom control endpoints — not protocol-standard, but allowed.
+    // Extension endpoints (verb-first, agents.<verb>.pi-headless.<owner>.<name>).
     this.service.addEndpoint("spawn", {
       subject: controllerSpawnSubject(this.opts.owner, this.opts.name),
       handler: (err, msg) => {
@@ -168,7 +169,7 @@ export class Controller {
     this.startHeartbeats();
     this.log(`pi-headless: controller listening on ${this.promptSubject}`);
     this.log(
-      `pi-headless: extra endpoints — ${controllerSpawnSubject(this.opts.owner, this.opts.name)}, ${controllerStopSubject(this.opts.owner, this.opts.name)}, ${controllerListSubject(this.opts.owner, this.opts.name)}`,
+      `pi-headless: control endpoints — ${controllerSpawnSubject(this.opts.owner, this.opts.name)}, ${controllerStopSubject(this.opts.owner, this.opts.name)}, ${controllerListSubject(this.opts.owner, this.opts.name)}`,
     );
   }
 
@@ -216,7 +217,7 @@ export class Controller {
     if (!this.service) return;
     const intervalS = this.opts.heartbeatIntervalS ?? DEFAULT_HEARTBEAT_INTERVAL_S;
     const payload = {
-      agent: "pi",
+      agent: "pi-headless",
       owner: this.opts.owner,
       instance_id: this.service.info().id,
       ts: new Date().toISOString(),
@@ -301,7 +302,7 @@ export class Controller {
     const publish = (): void => {
       if (!this.service) return;
       const payload = {
-        agent: "pi",
+        agent: "pi-headless",
         owner: this.opts.owner,
         instance_id: this.service.info().id,
         ts: new Date().toISOString(),

--- a/examples/pi-headless/src/index.ts
+++ b/examples/pi-headless/src/index.ts
@@ -14,6 +14,7 @@ import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 import { Controller } from "./controller.js";
 import { loadConfig, parseCliOverrides } from "./config.js";
 import { PiSessionManager } from "./pi-session-manager.js";
+import { resolveControllerName } from "./subjects.js";
 
 const log = (line: string): void => {
   process.stderr.write(`${line}\n`);
@@ -56,10 +57,18 @@ async function main(): Promise<void> {
   });
   await manager.start();
 
+  // Probe for an unclaimed controller name. With the default `control`,
+  // a second pi-headless on the same NATS lands on `control-2`, a third
+  // on `control-3`, and so on.
+  const resolvedName = await resolveControllerName(nc, config.name, config.owner);
+  if (resolvedName !== config.name) {
+    log(`pi-headless: name "${config.name}" is taken; using "${resolvedName}"`);
+  }
+
   const controller = new Controller({
     nc,
     owner: config.owner,
-    name: config.name,
+    name: resolvedName,
     manager,
   });
   await controller.start();

--- a/examples/pi-headless/src/managed-session.ts
+++ b/examples/pi-headless/src/managed-session.ts
@@ -96,7 +96,7 @@ export class ManagedSession {
     this.statusSubject = sessionStatusSubject(this.owner, this.sessionId);
 
     const extraMetadata: Record<string, string> = {
-      spawner: "pi-headless",
+      role: "session",
       cwd: this.cwd,
       max_lifetime_s: String(this.maxLifetimeS),
     };
@@ -105,7 +105,7 @@ export class ManagedSession {
 
     this.refAgent = new ReferenceAgent({
       nc: this.nc,
-      agent: "pi",
+      agent: "pi-headless",
       owner: this.owner,
       name: this.sessionId,
       session: this.sessionId,

--- a/examples/pi-headless/src/subjects.ts
+++ b/examples/pi-headless/src/subjects.ts
@@ -1,65 +1,68 @@
 // Subject builders + session-id sanitizer for pi-headless.
 //
-// The protocol subjects (`agents.{verb}.pi.<owner>.<token>`) are built via
-// the SDK's `AgentSubject` so the wire layout has one source of truth across
-// the SDK, agent harnesses, and examples. The `pi` subject token equals
-// `metadata.agent` here (Appendix C: `pi` is both the canonical id and the
-// conventional abbreviation), so `AgentSubject.new(...)` without a
-// `subjectToken` override produces the right wire shape.
+// Wire layout (verb-first throughout):
 //
-// Custom endpoints (spawn / stop / list) stay on a non-verb-first form so
-// they're clearly application extensions, not protocol endpoints.
+//   agents.prompt.pi-headless.<owner>.<name>     → controller's prompt endpoint
+//   agents.hb.pi-headless.<owner>.<name>         → controller heartbeat
+//   agents.status.pi-headless.<owner>.<name>     → controller status
+//   agents.spawn.pi-headless.<owner>.<name>      → controller spawn endpoint
+//   agents.stop.pi-headless.<owner>.<name>       → controller stop endpoint
+//   agents.list.pi-headless.<owner>.<name>       → controller list endpoint
+//   agents.prompt.pi-headless.<owner>.<session>  → spawned session prompt
+//   agents.hb.pi-headless.<owner>.<session>      → spawned session heartbeat
+//   agents.status.pi-headless.<owner>.<session>  → spawned session status
+//
+// `pi-headless` distinguishes this controller (and its spawned sessions) from
+// the regular `pi` agent at `agents/pi/`. The wire layout is verb-first for
+// every endpoint — the protocol-mandated verbs (`prompt`, `hb`, `status`)
+// share the same `agents.<verb>.<agent>.<owner>.<name>` shape as the
+// extension verbs (`spawn`, `stop`, `list`), so any tracer or audit layer
+// can subscribe to `agents.<verb>.>` and parse identity positionally.
 
-import { AgentSubject } from "@synadia-ai/agents";
+import type { NatsConnection } from "@nats-io/nats-core";
+import { Svcm } from "@nats-io/services";
+import { SERVICE_NAME } from "@synadia-ai/agents";
 
-export const AGENT_TOKEN = "pi";
+export const AGENT_TOKEN = "pi-headless";
 
-function controllerSubject(owner: string, name: string): AgentSubject {
-  return AgentSubject.new(AGENT_TOKEN, owner, name);
+function subject(verb: string, owner: string, name: string): string {
+  return `agents.${verb}.${AGENT_TOKEN}.${owner}.${name}`;
 }
 
 export function controllerPromptSubject(owner: string, name: string): string {
-  return controllerSubject(owner, name).prompt;
+  return subject("prompt", owner, name);
 }
 
 export function controllerHeartbeatSubject(owner: string, name: string): string {
-  return controllerSubject(owner, name).heartbeat;
+  return subject("hb", owner, name);
 }
 
 export function controllerStatusSubject(owner: string, name: string): string {
-  return controllerSubject(owner, name).status;
+  return subject("status", owner, name);
 }
 
-/** Custom endpoints — application-specific, NOT part of the v0.3 verb-first scheme. */
-const customSubjectRoot = (owner: string, name: string): string =>
-  `agents.${AGENT_TOKEN}.${owner}.${name}`;
-
 export function controllerSpawnSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.spawn`;
+  return subject("spawn", owner, name);
 }
 
 export function controllerStopSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.stop`;
+  return subject("stop", owner, name);
 }
 
 export function controllerListSubject(owner: string, name: string): string {
-  return `${customSubjectRoot(owner, name)}.list`;
-}
-
-function sessionSubject(owner: string, sessionId: string): AgentSubject {
-  return AgentSubject.new(AGENT_TOKEN, owner, sessionId);
+  return subject("list", owner, name);
 }
 
 export function sessionPromptSubject(owner: string, sessionId: string): string {
-  return sessionSubject(owner, sessionId).prompt;
+  return subject("prompt", owner, sessionId);
 }
 
 export function sessionHeartbeatSubject(owner: string, sessionId: string): string {
-  return sessionSubject(owner, sessionId).heartbeat;
+  return subject("hb", owner, sessionId);
 }
 
 export function sessionStatusSubject(owner: string, sessionId: string): string {
-  return sessionSubject(owner, sessionId).status;
+  return subject("status", owner, sessionId);
 }
 
 // Tokens MUST follow §2.2: [a-z0-9_-], not starting with $, 1..63 chars.
@@ -98,4 +101,40 @@ export function generateSessionId(): string {
   globalThis.crypto.getRandomValues(bytes);
   const rand = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
   return `sess-${rand}`;
+}
+
+/**
+ * Probe `$SRV.INFO.agents` and pick the first controller name whose prompt
+ * subject is unclaimed. Auto-suffixes `-2`, `-3`, … until a free slot is
+ * found, so two pi-headless processes booted with the default `control`
+ * land on `control` and `control-2` respectively. The probe is best-effort
+ * (a small race window remains between discovery and svcm.add) — the
+ * trade-off is acceptable for a developer convenience.
+ */
+export async function resolveControllerName(
+  nc: NatsConnection,
+  base: string,
+  owner: string,
+): Promise<string> {
+  const svcm = new Svcm(nc);
+  const client = svcm.client({ strategy: "stall", maxWait: 1000, maxMessages: 50 });
+
+  const taken = new Set<string>();
+  try {
+    const iter = await client.info(SERVICE_NAME);
+    for await (const si of iter) {
+      for (const ep of si.endpoints ?? []) {
+        taken.add(ep.subject);
+      }
+    }
+  } catch {
+    // No existing services or timeout — fine.
+  }
+
+  let candidate = base;
+  let suffix = 2;
+  while (taken.has(controllerPromptSubject(owner, candidate))) {
+    candidate = `${base}-${suffix++}`;
+  }
+  return candidate;
 }

--- a/examples/pi-headless/src/subjects.ts
+++ b/examples/pi-headless/src/subjects.ts
@@ -103,6 +103,20 @@ export function generateSessionId(): string {
   return `sess-${rand}`;
 }
 
+// `maxWait: 200` caps cold-boot latency at 200 ms; on a local NATS all
+// responses arrive in <5 ms, and 200 ms is well above any sane WAN RTT
+// to NGS. (The @nats-io/nats-core stall timer is hardcoded at 300 ms for
+// `strategy: "stall"`, so anything under 300 ms means maxWait wins —
+// which is what we want here.)
+const SRV_INFO_MAX_WAIT_MS = 200;
+const SRV_INFO_MAX_MESSAGES = 50;
+
+// Hard cap on auto-suffix attempts. Bounded implicitly by `maxMessages`
+// above, but an explicit guard makes failure visible rather than letting
+// the loop spin indefinitely if the wire ever returns more responses
+// than expected.
+const MAX_SUFFIX_ATTEMPTS = 100;
+
 /**
  * Probe `$SRV.INFO.agents` and pick the first controller name whose prompt
  * subject is unclaimed. Auto-suffixes `-2`, `-3`, … until a free slot is
@@ -117,14 +131,25 @@ export async function resolveControllerName(
   owner: string,
 ): Promise<string> {
   const svcm = new Svcm(nc);
-  const client = svcm.client({ strategy: "stall", maxWait: 1000, maxMessages: 50 });
+  const client = svcm.client({
+    strategy: "stall",
+    maxWait: SRV_INFO_MAX_WAIT_MS,
+    maxMessages: SRV_INFO_MAX_MESSAGES,
+  });
 
-  const taken = new Set<string>();
+  // Collect only `agents.prompt.<AGENT_TOKEN>.*` subjects — those are the
+  // only ones the suffix loop ever checks. Filtering at collection time
+  // makes the intent self-documenting and skips bookkeeping for the
+  // status/hb/spawn/stop/list/etc subjects we don't care about here.
+  const promptPrefix = `agents.prompt.${AGENT_TOKEN}.`;
+  const takenPromptSubjects = new Set<string>();
   try {
     const iter = await client.info(SERVICE_NAME);
     for await (const si of iter) {
       for (const ep of si.endpoints ?? []) {
-        taken.add(ep.subject);
+        if (ep.subject.startsWith(promptPrefix)) {
+          takenPromptSubjects.add(ep.subject);
+        }
       }
     }
   } catch {
@@ -132,9 +157,14 @@ export async function resolveControllerName(
   }
 
   let candidate = base;
-  let suffix = 2;
-  while (taken.has(controllerPromptSubject(owner, candidate))) {
-    candidate = `${base}-${suffix++}`;
+  for (let attempt = 0; attempt < MAX_SUFFIX_ATTEMPTS; attempt++) {
+    if (!takenPromptSubjects.has(controllerPromptSubject(owner, candidate))) {
+      return candidate;
+    }
+    candidate = `${base}-${attempt + 2}`;
   }
-  return candidate;
+  throw new Error(
+    `pi-headless: could not find a free controller name after ${MAX_SUFFIX_ATTEMPTS} attempts ` +
+      `(base="${base}", owner="${owner}"). Pass an explicit --name to override.`,
+  );
 }


### PR DESCRIPTION
## Summary

Restructures the on-the-wire subject layout for the two headless controller examples (`examples/pi-headless`, `examples/claude-code-headless`), and follows the rename in the dashboard. Three bundled commits: pi-headless, cc-headless, agent-web-ui.

### What changes on the wire

**Verb-first throughout.** Today the protocol verbs (`prompt`/`hb`/`status`) sit at token 2 of `agents.<verb>.<agent>.<owner>.<name>`, but the headless extension verbs (`spawn`/`stop`/`list`) hung off the tail at `agents.<agent>.<owner>.<name>.<verb>`. They now share the same shape, so any tracer or audit layer can subscribe to `agents.<verb>.>` (or `agents.<verb>.pi-headless.>`, etc) and parse identity positionally — same code path for protocol traffic and extensions. This was the actual audit gap behind the boss's "they aren't using the _INBOX format we want to be able to audit" comment: the control plane simply wasn't on a subject the tracer at `synadia-ai/tracer` was subscribed to.

**Agent token rename.** `metadata.agent` and the 3rd subject token go from `pi` / `cc` to `pi-headless` / `cc-headless` for both the controllers and their spawned sessions. This separates the headless example agents from the standalone `agents/pi/` (still `pi`) and `agents/claude-code/` (still `cc`) on `$SRV.INFO.agents`, so discovery / dashboards / auditors can tell them apart at a glance.

### Subject map

| pi-headless | claude-code-headless |
|---|---|
| `agents.prompt.pi-headless.<owner>.<name>` | `agents.prompt.cc-headless.<owner>.<name>` |
| `agents.hb.pi-headless.<owner>.<name>` | `agents.hb.cc-headless.<owner>.<name>` |
| `agents.status.pi-headless.<owner>.<name>` | `agents.status.cc-headless.<owner>.<name>` |
| `agents.spawn.pi-headless.<owner>.<name>` | `agents.spawn.cc-headless.<owner>.<name>` |
| `agents.stop.pi-headless.<owner>.<name>` | `agents.stop.cc-headless.<owner>.<name>` |
| `agents.list.pi-headless.<owner>.<name>` | `agents.list.cc-headless.<owner>.<name>` |
| `agents.prompt.pi-headless.<owner>.<session_id>` | `agents.prompt.cc-headless.<owner>.<session_id>` |
| `agents.hb.pi-headless.<owner>.<session_id>` | `agents.hb.cc-headless.<owner>.<session_id>` |
| `agents.status.pi-headless.<owner>.<session_id>` | `agents.status.cc-headless.<owner>.<session_id>` |

### Other changes

- **Controller name default** flips from `exec` to `control`. On startup the controller probes `$SRV.INFO.agents` and picks the next free `<name>-N` if its target prompt subject is already claimed — so booting two pi-headless processes with the default settings yields `control` and `control-2` automatically, no `--name` juggling needed.
- **Metadata simplification.** `metadata.role = "pi-headless-controller"` becomes `metadata.role = "controller"`; sessions now carry `metadata.role = "session"`. The redundant `metadata.spawner` field is dropped — the new `agent` token already disambiguates from the standalone runtimes.
- **CLI helper scripts** (`spawn.ts` / `stop.ts` / `list.ts` for both examples) build subjects from the typed `controllerSpawnSubject` / `controllerStopSubject` / `controllerListSubject` helpers in `subjects.ts` rather than hand-concatenating from the prompt subject.
- **Dashboard** (`examples/agent-web-ui`) follows the new tokens + role values, and `bridge.ts:resolveControllerSubject` simplifies to a verb-token swap. Internal WS message kinds (`piexec-*` / `ccexec-*` between the dashboard server and the browser) are unchanged — those don't appear on the NATS wire.

### Caveats / migration

- **Breaking wire change** for both headless examples. Callers that hard-code the old `agents.pi.<owner>.<name>.spawn` shape need to flip to `agents.spawn.pi-headless.<owner>.<name>` (and the same for stop/list and for cc-headless).
- **Agent harnesses untouched.** The headless examples don't use `agents/pi/` or `agents/claude-code/` source — sessions are spawned via `@mariozechner/pi-coding-agent` / `@anthropic-ai/claude-agent-sdk` directly, registered through `ReferenceAgent` from `@synadia-ai/agent-service/testing`. The standalone `pi` and `cc` agent harnesses keep their existing tokens and subject layouts.
- **Tracer follow-up.** With the extension verbs on `agents.<verb>.>` like protocol traffic, the tracer at `synadia-ai/tracer` just needs `agents.spawn.>` / `agents.stop.>` / `agents.list.>` added to its subscription set (or a single `agents.>` minus the protocol verbs). Separate one-line change in the tracer repo, not in this PR.

## Test plan

- [x] `bun run typecheck` clean in `examples/pi-headless`
- [x] `bun run typecheck` clean in `examples/claude-code-headless`
- [x] `bun run typecheck` clean in `examples/agent-web-ui`
- [x] `bun run build` clean in `examples/agent-web-ui` (Vite)
- [ ] End-to-end smoke against a local NATS: spawn a session via `nats req agents.spawn.pi-headless.$USER.control` and confirm the session shows up at `agents.prompt.pi-headless.$USER.<sessionId>`.
- [ ] Boot a second pi-headless on the same NATS and confirm the second one logs `name "control" is taken; using "control-2"`.
- [ ] Web UI: confirm controllers + sessions still group correctly into "PI Headless Controllers" / "PI Headless Sessions" buckets and the spawn/stop/list dashboard actions still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)