### PR TITLE
Release(client-sdk/typescript): 0.5.0

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,9 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-> **Release-tag note:** the `replySubject` removal under "Removed" below
-> is a breaking public API change (the getter was listed in the 0.4.0
-> public surface). Cut this as **0.5.0**, not a 0.4.x patch.
+## [0.5.0] - 2026-05-04
+
+> Breaking: removes the `PromptStream.replySubject` getter from the
+> 0.4.0 public surface. See "Removed" below.
 
 ### Changed
 

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/agents",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for the NATS Agent Protocol — discover, prompt, and stream from AI agents over NATS.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Cuts `@synadia-ai/agents` 0.5.0. Pure release prep — moves the [Unreleased] section to a [0.5.0] heading and bumps the package version. No source code changes.

### What's in 0.5.0

Accumulated on main since 0.4.0:

- **#66** (Derek) — PromptStream now drives the response with `nc.requestMany` + `sentinel` strategy, dropping the per-stream `_INBOX.agents.>` subscribe/flush/publish dance. Wire shape unchanged. Adds `PromptOptions.maxWaitMs` (default `DEFAULT_PROMPT_MAX_WAIT_MS = 600_000`) and `StreamMaxWaitExceededError` for the new failure mode. **Removes the `PromptStream.replySubject` getter** — that's the one breaking-API-on-the-public-surface item, hence the 0.5.0 minor bump rather than a 0.4.x patch. The getter was documented as a debugging aid and isn't used by any tests or examples in-tree.

### After merge

- Run `npm publish` from `client-sdk/typescript/` on a machine logged in as `mschallner` (per the project's npm publish identity convention). I won't run it.
- Once published, the next PR ladder rung is `@synadia-ai/agent-service` 0.5.0 (lockstep) — agent-sdk has no source changes since 0.4.0, but its `dependencies."@synadia-ai/agents"` pin needs to be `^0.5.0` for consumers to install both cleanly.

## Test plan

- [x] `bun run typecheck` clean in `client-sdk/typescript`
- [x] `bun run build` clean (tsup, ESM + CJS + DTS)
- [x] `bun run test:unit` — 239/239 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)