### PR TITLE
Fix(python): restore `session` on $SRV.INFO metadata + §8.3/§8.7 payloads (#73)

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -6,6 +6,37 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
+## [0.3.0] - 2026-05-04
+
+Restores wire-shape parity with the spec and TS SDK after the
+2026-04-28 session-name collapse mistakenly dropped `session` from
+service metadata and §8.3 / §8.7 payloads. Reported as
+[issue #73](https://github.com/synadia-ai/synadia-agents/issues/73).
+
+### Fixed
+
+- **`metadata.session` (§3.2)** — `AgentService.start()` now advertises
+  `metadata.session = session_name` alongside the existing
+  `{agent, owner, protocol_version}` triple. Per §3.2 a session-less
+  harness MAY omit the field OR set it to `"default"`; since the
+  Python constructor takes a required `session_name` (callers pass
+  `"default"` when session-less), we always emit it for a uniform
+  shape across both styles.
+- **`HeartbeatPayload.session` (§8.3)** — `build_heartbeat_payload`
+  now populates `session=subject.session_name`, so periodic
+  heartbeats published on `agents.hb.{a}.{o}.{session_name}` mirror
+  `metadata.session` per §8.3 / appendix B.11.
+- **Status reply `session` (§8.7)** — the same builder feeds the
+  `agents.status.{a}.{o}.{session_name}` request/reply endpoint, so
+  a §8.7 status reply carries `session` matching the heartbeat. §8.7
+  + appendix B.11a explicitly require the same §8.3 schema.
+
+### Changed
+
+- **Dependency floor bumped to `synadia-ai-agents>=0.7`** so the
+  shared `HeartbeatPayload` model has the `session` field — needed
+  for the publisher and status handler to populate it.
+
 ## [0.2.0] - 2026-05-03
 
 ### Changed

--- a/agent-sdk/python/CLAUDE.md
+++ b/agent-sdk/python/CLAUDE.md
@@ -158,11 +158,14 @@ deferred to a follow-up. All shapes are imported from
   wants to host N sessions registers N services. The agent-sdk picks
   the session names; the client filters on them.
 - **Service registration** (§3): every agent registers as a NATS micro
-  service named `agents` with `metadata = {agent, owner,
-  protocol_version = "0.3"}` — exactly three fields under v0.3. The
-  `prompt` endpoint MUST be registered with queue group `"agents"`
-  (§3.3); ditto the `status` endpoint. The framework default differs
-  between SDKs, so we pin the spec value explicitly.
+  service named `agents` with `metadata = {agent, owner, session,
+  protocol_version = "0.3"}`. `session` mirrors the 5th subject token
+  per §3.2 — session-less harnesses MAY omit it or set it to
+  `"default"`; this SDK takes a required `session_name` constructor
+  arg and always advertises the value, defaulting callers pass
+  `"default"`. The `prompt` endpoint MUST be registered with queue
+  group `"agents"` (§3.3); ditto the `status` endpoint. The framework
+  default differs between SDKs, so we pin the spec value explicitly.
 - **Request envelope** (§5.1): `{prompt: str, attachments?:
   [{filename, content: <base64>}]}`. Plain-text request payloads are
   promoted to `{"prompt": <text>}` (§5.3). The agent-sdk decodes
@@ -176,10 +179,14 @@ deferred to a follow-up. All shapes are imported from
   the agent's response handler via the API equivalent of TS's
   `PromptStream.ask`. Caller replies via `Query.reply`. The agent-sdk
   owns the *initiation* path; reply decoding is shared.
-- **Heartbeat** (§8.3): `{agent, owner, instance_id, ts, interval_s}`
-  on `agents.hb.{a}.{o}.{session_name}`. The publisher loop lives
-  here; the wire model `HeartbeatPayload` is imported from
-  `synadia_ai.agents`.
+- **Heartbeat** (§8.3): `{agent, owner, session, instance_id, ts,
+  interval_s}` on `agents.hb.{a}.{o}.{session_name}`. `session`
+  mirrors `metadata.session` per §8.3 ("present iff metadata field
+  is set"); this SDK always populates it from `subject.session_name`
+  on emission, and the shared `HeartbeatPayload` decoder accepts its
+  absence so we interop with spec-compliant session-less peers. The
+  publisher loop lives here; the wire model `HeartbeatPayload` is
+  imported from `synadia_ai.agents`.
 - **Status** (v0.3 §-TBD): request/response on
   `agents.status.{a}.{o}.{session_name}` returns the same payload
   shape as a heartbeat, freshly built per request. Handler lives
@@ -291,7 +298,7 @@ The session-scoped `nats-server` log sits alongside at
 `tests/_evidence/_nats-server-logs/`. Read these when a test fails or
 when verifying protocol compliance by eye — for an agent-side test,
 `srv-info.json` is the load-bearing artifact (does it advertise the
-right `metadata = {agent, owner, protocol_version}`? does the
+right `metadata = {agent, owner, session, protocol_version}`? does the
 `prompt` endpoint carry queue group `"agents"`?).
 
 ## Testing — no-bullshit, concrete evidence

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agent-service"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python agent-host SDK for the NATS Agent Protocol — register and serve spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "nats-py>=2.7",
     "pydantic>=2.5",
-    "synadia-ai-agents>=0.6",
+    "synadia-ai-agents>=0.7",
 ]
 
 [project.urls]
@@ -37,7 +37,7 @@ Issues = "https://github.com/synadia-ai/synadia-agents/issues"
 # `uv sync`. This affects monorepo developers only — it is dev-time
 # config and is NOT persisted into the built wheel's METADATA, so an
 # external user installing `synadia-ai-agent-service` from PyPI gets
-# the declared dep (`synadia-ai-agents>=0.6`) from PyPI as normal.
+# the declared dep (`synadia-ai-agents>=0.7`) from PyPI as normal.
 synadia-ai-agents = { path = "../../client-sdk/python", editable = true }
 
 [dependency-groups]

--- a/agent-sdk/python/src/synadia_ai/agent_service/heartbeat.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/heartbeat.py
@@ -43,6 +43,7 @@ def build_heartbeat_payload(
     return HeartbeatPayload(
         agent=subject.agent,
         owner=subject.owner,
+        session=subject.session_name,
         instance_id=instance_id,
         ts=now_iso(),
         interval_s=interval_s,

--- a/agent-sdk/python/src/synadia_ai/agent_service/service.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/service.py
@@ -295,9 +295,16 @@ class AgentService:
         # limit (§2.1). See ``_effective_max_payload`` for the rule.
         max_payload_str = self._effective_max_payload()
 
+        # §3.2: metadata.session matches the 5th subject token. For session-
+        # less harnesses (e.g. openclaw) the spec allows omitting the field
+        # OR setting it to "default"; the Python constructor takes a required
+        # `session_name` (defaulting callers pass "default"), so we always
+        # advertise it. Callers that filter on metadata.session see a
+        # consistent shape across session-aware and session-less agents.
         metadata: dict[str, str] = {
             "agent": self.subject.agent,
             "owner": self.subject.owner,
+            "session": self.subject.session_name,
             "protocol_version": _PROTOCOL_VERSION,
         }
         config = ServiceConfig(

--- a/agent-sdk/python/tests/test_echo_e2e.py
+++ b/agent-sdk/python/tests/test_echo_e2e.py
@@ -75,19 +75,22 @@ async def test_echo_agent_roundtrip(  # noqa: PLR0915 — integration test inten
         assert srv_info_parsed["metadata"]["agent"] == AGENT
         assert srv_info_parsed["metadata"]["owner"] == OWNER
         assert srv_info_parsed["metadata"]["protocol_version"] == "0.3"
-        # Spec §3.2 forbids echoing the session/instance name into metadata.
+        # §3.2: metadata.session matches the 5th subject token. The Python
+        # SDK always advertises it (defaulting to "default" for session-less
+        # callers), per §3.2's "MAY be omitted or set to default" allowance.
+        assert srv_info_parsed["metadata"]["session"] == SESSION_NAME
+        # Spec §3.2 forbids echoing the instance name into metadata under
+        # any other key.
         assert "name" not in srv_info_parsed["metadata"]
-        # v0.3 collapsed name + session into the subject — `session` is no
-        # longer carried in metadata. Regression guard against re-introducing it.
-        assert "session" not in srv_info_parsed["metadata"]
         # And the removed v0.0.1-era keys MUST be gone.
         assert "type" not in srv_info_parsed["metadata"]
         assert "platform" not in srv_info_parsed["metadata"]
         assert "protocol" not in srv_info_parsed["metadata"]
-        # Metadata is now exactly three fields under v0.3.
+        # Metadata is exactly four fields under v0.3 (§3.2).
         assert set(srv_info_parsed["metadata"].keys()) == {
             "agent",
             "owner",
+            "session",
             "protocol_version",
         }
 
@@ -162,6 +165,8 @@ async def test_echo_agent_roundtrip(  # noqa: PLR0915 — integration test inten
             evidence.write_json("heartbeat.json", json.loads(hb_payload.model_dump_json()))
             assert hb_payload.agent == AGENT
             assert hb_payload.owner == OWNER
+            # §8.3: payload.session mirrors metadata.session (== subject token 5).
+            assert hb_payload.session == SESSION_NAME
             assert hb_payload.instance_id, "heartbeat MUST carry instance_id (§8.3)"
             assert hb_payload.interval_s == HEARTBEAT_INTERVAL_S
 
@@ -199,6 +204,8 @@ async def test_status_endpoint_e2e(nc: NATSClient, evidence: EvidenceRecorder) -
         payload = HeartbeatPayload.model_validate_json(reply.data)
         assert payload.agent == AGENT
         assert payload.owner == OWNER
+        # §8.7 reply uses exactly the §8.3 schema, so `session` must round-trip too.
+        assert payload.session == SESSION_NAME
         assert payload.interval_s == HEARTBEAT_INTERVAL_S
         assert payload.instance_id, "status payload MUST carry instance_id (§8.3 shape)"
         # `ts` is freshly built per request — non-empty ISO 8601 string is enough.

--- a/agent-sdk/python/tests/test_heartbeat_publisher.py
+++ b/agent-sdk/python/tests/test_heartbeat_publisher.py
@@ -44,21 +44,21 @@ INSTANCE_ID = "publisher-instance-A"
 
 
 def test_build_heartbeat_payload_populates_required_fields() -> None:
-    """§8.3: agent, owner, instance_id, ts, interval_s — no session field."""
+    """§8.3: agent, owner, session, instance_id, ts, interval_s."""
     subject = AgentSubject.new(agent=AGENT, owner=OWNER, session_name=SESSION_NAME)
     payload = build_heartbeat_payload(subject, interval_s=7, instance_id=INSTANCE_ID)
 
     assert payload.agent == AGENT
     assert payload.owner == OWNER
+    assert payload.session == SESSION_NAME
     assert payload.instance_id == INSTANCE_ID
     assert payload.interval_s == 7
     # `ts` is UTC ISO 8601 with seconds precision and a Z suffix.
     assert payload.ts.endswith("Z")
 
+    # §8.3: `session` mirrors the 5th subject token (== metadata.session).
     encoded = json.loads(payload.model_dump_json())
-    assert "session" not in encoded, (
-        "v0.3 §8.3 payload MUST NOT carry a session key — the publishing subject IS the session."
-    )
+    assert encoded["session"] == SESSION_NAME
 
 
 async def test_publish_one_emits_single_frame_on_heartbeat_subject(
@@ -74,6 +74,7 @@ async def test_publish_one_emits_single_frame_on_heartbeat_subject(
         payload = HeartbeatPayload.model_validate_json(msg.data)
         assert payload.agent == AGENT
         assert payload.owner == OWNER
+        assert payload.session == "publisher-one"
         assert payload.instance_id == INSTANCE_ID
         assert payload.interval_s == 5
         # No second frame should arrive — `publish_one` is one-shot.

--- a/agent-sdk/python/uv.lock
+++ b/agent-sdk/python/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agent-service"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },
@@ -416,7 +416,7 @@ dev = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../client-sdk/python" }
 dependencies = [
     { name = "nats-py" },

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -6,6 +6,35 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
+## [0.7.0] - 2026-05-04
+
+Restores wire-shape parity with the spec and TS SDK after the
+2026-04-28 session-name collapse mistakenly dropped `session` from
+`HeartbeatPayload`. Reported as
+[issue #73](https://github.com/synadia-ai/synadia-agents/issues/73).
+
+### Added
+
+- **`HeartbeatPayload.session`** — restored as an optional field
+  (`str | None`, default `None`) on the §8.3 wire model. Spec §8.3
+  defines `session` as "present iff `metadata.session` is set," so
+  the decoder must tolerate absence to interop with spec-compliant
+  session-less peers (e.g. a TS harness that omits `options.session`);
+  optional matches that contract while still surfacing the value
+  when present. The peer `synadia-ai-agent-service@0.3.0` always
+  populates the field on emission, so a Python-on-Python wire
+  carries `session` on every beat.
+
+### Fixed
+
+- **§8.3 / §8.7 `session` parity with the spec** — heartbeat and
+  status payloads emitted by the (sibling) `AgentService` now carry
+  `session`, matching `metadata.session`. Was a regression introduced
+  alongside the session-name collapse; the prior local docs codified
+  the wrong shape ("the publishing subject IS the session — no
+  payload field"), which is why no review caught it. Spec §8.3 +
+  appendix B.11 + B.11a are the source of truth.
+
 ## [0.6.0] - 2026-05-03
 
 Catch-up to the TypeScript SDK's

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -45,14 +45,17 @@ v0.3 wire shapes the SDK implements (full detail in `docs/protocol-mapping.md`):
   internally - an SDK implementation detail, not a protocol contract
   (see `src/synadia_ai/agents/subjects.py::_sanitize`).
 - **Service registration** (§3): every agent registers as a NATS micro
-  service named `agents` with `metadata = {agent, owner,
-  protocol_version = "0.3"}` — exactly three fields under v0.3; the
-  session lives in the subject, not in metadata. The `prompt` endpoint
-  MUST be registered with queue group `"agents"` (§3.3) - the framework
-  default differs between SDKs, so we pin the spec value explicitly.
-  The service name is shared across all compliant agents - callers
-  filter by this single value. The `status` endpoint (v0.3 §-TBD)
-  registers alongside with the same queue group.
+  service named `agents` with `metadata = {agent, owner, session,
+  protocol_version = "0.3"}`. `session` mirrors the 5th subject token
+  per §3.2; session-less harnesses MAY omit it OR set it to `"default"`,
+  and the agent-sdk takes a required `session_name` and always
+  advertises the value (defaulting to `"default"` when callers don't
+  care). The `prompt` endpoint MUST be registered with queue group
+  `"agents"` (§3.3) - the framework default differs between SDKs, so
+  we pin the spec value explicitly. The service name is shared across
+  all compliant agents - callers filter by this single value. The
+  `status` endpoint (v0.3 §8.7) registers alongside with the same
+  queue group.
 - **Request envelope** (§5.1): `{prompt: str, attachments?: [{filename,
   content: <base64>}]}`. Plain-text request payloads are promoted to
   `{"prompt": <text>}` (§5.3). The envelope no longer carries a
@@ -61,11 +64,14 @@ v0.3 wire shapes the SDK implements (full detail in `docs/protocol-mapping.md`):
   order, terminated by a zero-byte body with no NATS headers.
 - **Mid-stream queries** (§7): agent-initiated questions via
   `PromptStream.ask`; caller replies via `Query.reply`.
-- **Heartbeat** (§8.3): `{agent, owner, instance_id, ts, interval_s}`
-  on `agents.hb.{a}.{o}.{session_name}` (v0.3; verb is the abbreviation
-  `hb`). No `session` field on the payload — the publishing subject is
-  the session.
-- **Status** (v0.3 §-TBD): request/response on `agents.status.{a}.{o}.{n}`
+- **Heartbeat** (§8.3): `{agent, owner, session, instance_id, ts,
+  interval_s}` on `agents.hb.{a}.{o}.{session_name}` (v0.3; verb is
+  the abbreviation `hb`). `session` mirrors `metadata.session` per
+  §8.3 ("present iff metadata field is set"); the shared
+  `HeartbeatPayload` decoder accepts its absence so we interop with
+  spec-compliant session-less peers, while the sibling agent-sdk
+  always emits the value.
+- **Status** (v0.3 §8.7): request/response on `agents.status.{a}.{o}.{n}`
   returns the same payload shape as a heartbeat, freshly built per
   request. Future PRs extend the response with richer agent metadata
   in one place — `heartbeat.publish_one` and the status handler share

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -36,7 +36,7 @@ spec to catch up.
 | SDK                        | Wire behaviour                                                                                  | Spec ref   |
 | -------------------------- | ----------------------------------------------------------------------------------------------- | ---------- |
 | `AgentService.start()`     | `ServiceConfig(name="agents", ...)` - the single shared name from §3.1.                        | §3.1     |
-| Service metadata emitted   | `{agent, owner, protocol_version}` — exactly three fields under v0.3; the session lives in the subject's 5th token. | §3.2       |
+| Service metadata emitted   | `{agent, owner, session, protocol_version}` — `session` mirrors the 5th subject token; session-less callers see `"default"` per §3.2's allowance. | §3.2       |
 | `protocol_version` value   | `"0.3"` - MAJOR.MINOR only (§11.1).                                                             | §3.2, §11.1 |
 | Endpoint `prompt` metadata | `{max_payload, attachments_ok}`. Boolean serialised as `"true"`/`"false"` on the wire.          | §2.1       |
 | `prompt` queue group       | `"agents"` - pinned explicitly; framework defaults differ between SDKs and would break interop. | §3.3       |
@@ -98,7 +98,7 @@ spec to catch up.
 | ---------------------------- | ------------------------------------------------------------------------------------------------ | ---------- |
 | Subject                      | `agents.hb.{agent}.{owner}.{session_name}` (v0.3 verb-first; `hb` abbreviates `heartbeat`).      | §8.1       |
 | Default interval             | `AgentService(heartbeat_interval_s=30)` (spec recommendation).                                   | §8.2       |
-| Payload fields               | `{agent, owner, instance_id, ts, interval_s}` — no `session` (the publishing subject IS the session under v0.3). | §8.3 |
+| Payload fields               | `{agent, owner, session, instance_id, ts, interval_s}` — `session` mirrors `metadata.session` (== subject token 5); decoder tolerates absence to interop with spec-compliant session-less peers that omit the field. | §8.3 |
 | `HeartbeatPayload` tolerance | `extra="ignore"` - unknown fields silently accepted per §8.3.                                    | §8.3       |
 | `instance_id` source         | `service.id` assigned by nats-py's micro framework (matches `$SRV.INFO` `id`).                   | §3.4, §8.3 |
 | First heartbeat              | Published immediately after service registration so subscribe-then-discover sees liveness.       | §8.5       |

--- a/client-sdk/python/pyproject.toml
+++ b/client-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agents"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python client SDK for the NATS Agent Protocol — discover and prompt spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/client-sdk/python/src/synadia_ai/agents/heartbeat.py
+++ b/client-sdk/python/src/synadia_ai/agents/heartbeat.py
@@ -42,21 +42,24 @@ DEFAULT_LIVENESS_SLACK = 3
 class HeartbeatPayload(BaseModel):
     """Heartbeat wire payload per §8.3.
 
-    The payload no longer carries a session field — under v0.3 the
-    publishing subject IS the session
-    (``agents.hb.{agent}.{owner}.{session_name}``). Receivers that want
-    the session name read it from the 5th subject token. The tracker
-    keys on ``payload.instance_id`` per §8.3 so multiple instances of
-    the same logical session stay distinguishable. ``extra="ignore"``
-    because §8.3 requires callers to tolerate unknown fields for forward
-    compat; pydantic will silently drop them during decode (a stray
-    ``session`` from a non-compliant v0.2 peer is dropped here).
+    ``session`` mirrors ``$SRV.INFO.metadata.session`` (§3.2): present
+    iff the metadata field is set. The Python ``AgentService`` always
+    advertises a session (using ``"default"`` for session-less callers,
+    per §3.2's allowance), so its own publishes always carry the field;
+    the field is optional on the model so we can decode heartbeats from
+    spec-compliant session-less peers (e.g. a TS harness that omits
+    ``options.session``). The tracker keys on ``payload.instance_id``
+    per §8.3 so multiple instances of the same logical session stay
+    distinguishable. ``extra="ignore"`` because §8.3 requires callers
+    to tolerate unknown fields for forward compat; pydantic silently
+    drops them on decode.
     """
 
     model_config = ConfigDict(extra="ignore", frozen=True)
 
     agent: str
     owner: str
+    session: str | None = None
     instance_id: str
     ts: str  # UTC ISO 8601
     interval_s: int

--- a/client-sdk/python/tests/test_heartbeat.py
+++ b/client-sdk/python/tests/test_heartbeat.py
@@ -24,64 +24,71 @@ if TYPE_CHECKING:
 
 
 def test_decodes_spec_example() -> None:
-    """v0.3 wire shape — heartbeat payload no longer carries a session."""
+    """Round-trips the canonical §8.3 / appendix B.11 wire example."""
     wire = (
-        b'{"agent":"claude-code","owner":"aconnolly",'
+        b'{"agent":"claude-code","owner":"aconnolly","session":"synadia-com-2",'
         b'"instance_id":"VMKS6MHK71PCPWGY38A7N5",'
         b'"ts":"2026-04-21T14:23:01Z","interval_s":30}'
     )
     hb = HeartbeatPayload.model_validate_json(wire)
     assert hb.agent == "claude-code"
     assert hb.owner == "aconnolly"
+    assert hb.session == "synadia-com-2"
     assert hb.instance_id == "VMKS6MHK71PCPWGY38A7N5"
     assert hb.ts == "2026-04-21T14:23:01Z"
     assert hb.interval_s == 30
 
 
-def test_inbound_session_is_silently_dropped() -> None:
-    """A non-compliant v0.2 peer might send a stray `session`; §8.3 says
-    receivers MUST tolerate unknown fields. ``HeartbeatPayload`` uses
-    ``extra="ignore"``, so the stray field is dropped on decode rather
-    than surfacing as a first-class attribute or riding into a re-encode."""
+def test_decoder_tolerates_missing_session() -> None:
+    """§8.3: ``session`` is present iff ``metadata.session`` is set, so the
+    decoder MUST accept payloads from spec-compliant session-less peers
+    that omit the field entirely. ``payload.session`` is ``None`` in that
+    case; the receiver can fall back to the 5th subject token if it cares.
+    """
     wire = (
-        b'{"agent":"claude-code","owner":"alice","session":"legacy",'
-        b'"instance_id":"ABC","ts":"2026-04-21T00:00:00Z","interval_s":30}'
+        b'{"agent":"openclaw","owner":"alice",'
+        b'"instance_id":"X","ts":"2026-04-21T00:00:00Z","interval_s":30}'
     )
     hb = HeartbeatPayload.model_validate_json(wire)
-    assert hb.agent == "claude-code"
-    # `session` is no longer a HeartbeatPayload field at all.
-    assert "session" not in HeartbeatPayload.model_fields
-    # And the stray field did NOT round-trip — `extra="ignore"` drops it.
-    parsed = json.loads(hb.model_dump_json())
-    assert "session" not in parsed
+    assert hb.session is None
 
 
 def test_unknown_fields_tolerated() -> None:
     """§8.3: receivers MUST tolerate additional unknown fields."""
     wire = (
-        b'{"agent":"claude-code","owner":"alice","instance_id":"X",'
-        b'"ts":"2026-04-21T00:00:00Z","interval_s":30,'
+        b'{"agent":"claude-code","owner":"alice","session":"default",'
+        b'"instance_id":"X","ts":"2026-04-21T00:00:00Z","interval_s":30,'
         b'"future_field":42,"another":"ok"}'
     )
     hb = HeartbeatPayload.model_validate_json(wire)
     assert hb.agent == "claude-code"
+    # ``extra="ignore"`` drops the unknowns on re-encode.
+    parsed = json.loads(hb.model_dump_json())
+    assert "future_field" not in parsed
+    assert "another" not in parsed
 
 
-def test_encoded_form_carries_no_session_key() -> None:
-    """Regression guard: the §8.3 payload MUST NOT carry a `session` key
-    on the wire — under v0.3 the publishing subject IS the session."""
+def test_encoded_form_carries_session_key() -> None:
+    """§8.3 / appendix B.11: the heartbeat payload carries `session` on the wire.
+
+    Mirrors ``metadata.session`` per §3.2; for session-less harnesses the
+    Python SDK emits ``"default"`` rather than omitting the field, so the
+    on-wire shape stays uniform across session-aware and session-less
+    callers.
+    """
     hb = HeartbeatPayload(
         agent="openclaw",
         owner="rene",
+        session="default",
         instance_id="X",
         ts="2026-04-21T00:00:00Z",
         interval_s=30,
     )
     parsed = json.loads(hb.model_dump_json())
-    assert "session" not in parsed
     assert parsed == {
         "agent": "openclaw",
         "owner": "rene",
+        "session": "default",
         "instance_id": "X",
         "ts": "2026-04-21T00:00:00Z",
         "interval_s": 30,
@@ -105,6 +112,7 @@ async def test_tracker_keys_on_instance_id_not_subject(nc: NATSClient) -> None:
             payload = HeartbeatPayload(
                 agent="test",
                 owner="pytest",
+                session="shared",
                 instance_id=instance_id,
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
@@ -148,6 +156,7 @@ async def test_tracker_liveness_is_offline_when_stale(nc: NATSClient) -> None:
         payload = HeartbeatPayload(
             agent="test",
             owner="pytest",
+            session="stale",
             instance_id="stale-id",
             ts="2026-04-21T00:00:00Z",
             interval_s=5,
@@ -188,6 +197,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
             payload = HeartbeatPayload(
                 agent="test",
                 owner="pytest",
+                session="listener",
                 instance_id="listener-id",
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
@@ -208,6 +218,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
             HeartbeatPayload(
                 agent="test",
                 owner="pytest",
+                session="listener",
                 instance_id="listener-id",
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
@@ -228,6 +239,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
                 HeartbeatPayload(
                     agent="test",
                     owner="pytest",
+                    session="listener",
                     instance_id="listener-id",
                     ts="2026-04-21T00:00:00Z",
                     interval_s=5,

--- a/client-sdk/python/uv.lock
+++ b/client-sdk/python/uv.lock
@@ -413,7 +413,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
Closes #73 — reported by @jarretlavallee.

> Note on history: an identical fix was pushed straight to `main` as
> commit `11fe3d2` earlier today by mistake (Claude Code session — my
> bad). That commit was reverted on `main` in `73ed51f` so this PR
> can carry the same content through normal review and pick up the
> reviewer bot like every other substantive change. The diff below
> is what would have been on `main` in the absence of the misstep,
> rebased on top of `2aeafa1` (the 0.5.0 release-prep wave that
> landed in between).

## Summary

- Restores `session` on `$SRV.INFO.metadata` (§3.2), the §8.3
  heartbeat payload, and the §8.7 status reply.
- The Python SDKs had dropped these during the 2026-04-28 session-
  name collapse, on the (wrong) reasoning that "the publishing subject
  IS the session." The spec disagrees: §3.2 + §8.3 + appendix
  B.11/B.11a all carry `session` on the wire, mirroring the 5th
  subject token (or `"default"` for session-less harnesses).
- The local CLAUDE.md / docs/protocol-mapping.md files codified the
  wrong shape, which is why neither I nor the reviewer bot caught it
  on the original collapse PR. Those are now fixed alongside the
  code so the next sweep doesn't re-validate the regression.

## What changed

Code:

- `agent-sdk/python` — `AgentService.start()` advertises
  `metadata.session = subject.session_name`; `build_heartbeat_payload`
  populates `session` (used by both the heartbeat publisher and the
  §8.7 status endpoint, so they emit the same shape).
- `client-sdk/python` — `HeartbeatPayload.session` restored as
  `str | None = None`. Optional on decode lets the SDK interop with
  spec-compliant session-less peers (e.g. a TS agent that omits
  `options.session`); the agent-host always populates it on emit.

Tests:

- Flipped the negative regression guards (`assert "session" not in
  metadata` / `not in encoded`) into positive assertions on the
  field.
- Added `test_decoder_tolerates_missing_session` to lock in the
  optional-decode contract.
- Round-tripped the canonical §8.3 / appendix B.11 wire example.

Versioning:

- `synadia-ai-agents` 0.6.0 → 0.7.0 (new optional field on the
  shared wire model).
- `synadia-ai-agent-service` 0.2.0 → 0.3.0 with floor bumped to
  `synadia-ai-agents>=0.7` so the publisher can populate the field.

Docs:

- Both Python `CLAUDE.md` files corrected (no more "exactly three
  fields", no more "no `session` on the payload").
- `client-sdk/python/docs/protocol-mapping.md` rows for §3.2 and
  §8.3 updated.
- CHANGELOG entries on both packages.

## Test plan

- [x] `uv run pytest` in `client-sdk/python` — 211 passed (incl.
      `test_interop_e2e.py` against the TS reference agent).
- [x] `uv run pytest` in `agent-sdk/python` — 38 passed.
- [x] `uv run ruff check --no-cache .` clean in both packages.
- [x] `uv run ruff format --check .` clean in both packages.
- [x] `uv run mypy --no-incremental src tests examples` clean in both.
- [x] Inspected `tests/_evidence/.../srv-info.json` — confirms
      `metadata.session` lands on the wire.
- [x] Inspected `tests/_evidence/.../heartbeat.json` — confirms
      `session` lands on the heartbeat frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)