### PR TITLE
Release: switch dev → ^0.5.0 pins for the publish wave

### DIFF
--- a/agent-sdk/typescript/package.json
+++ b/agent-sdk/typescript/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@nats-io/nats-core": "^3.3.0",
     "@nats-io/services": "^3.3.0",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0"
   },
   "devDependencies": {
     "@nats-io/transport-node": "^3.3.0",

--- a/agents/open-agent/package.json
+++ b/agents/open-agent/package.json
@@ -22,8 +22,8 @@
     "@nats-io/nats-core": "^3.3.1",
     "@nats-io/services": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
+    "@synadia-ai/agent-service": "^0.5.0",
+    "@synadia-ai/agents": "^0.5.0",
     "ai": "^6.0.165",
     "zod": "^4.3.6"
   },

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -54,8 +54,8 @@
     "@nats-io/services": "^3.3.0",
     "@nats-io/transport-node": "^3.3.0",
     "@sinclair/typebox": "^0.34.0",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0",
+    "@synadia-ai/agent-service": "^0.5.0"
   },
   "bundleDependencies": [
     "@synadia-ai/agents",

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -42,8 +42,8 @@
   "dependencies": {
     "@nats-io/transport-node": "^3.3.0",
     "@nats-io/services": "^3.3.0",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0",
+    "@synadia-ai/agent-service": "^0.5.0"
   },
   "bundleDependencies": [
     "@synadia-ai/agents",

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -76,7 +76,7 @@
     "@nats-io/transport-node": "^3.3.0"
   },
   "devDependencies": {
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
+    "@synadia-ai/agent-service": "^0.5.0",
     "@types/node": "^20.16.0",
     "@vitest/coverage-v8": "^3.2.0",
     "eslint": "^9.0.0",

--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/claude-code-headless/package.json
+++ b/examples/claude-code-headless/package.json
@@ -48,8 +48,8 @@
     "@anthropic-ai/claude-agent-sdk": "latest",
     "@nats-io/services": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0",
+    "@synadia-ai/agent-service": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/open-agent-vercel/package.json
+++ b/examples/open-agent-vercel/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@nats-io/nats-core": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
+    "@synadia-ai/agent-service": "^0.5.0",
+    "@synadia-ai/agents": "^0.5.0",
     "@synadia-ai/open-agent": "file:../../agents/open-agent",
     "@vercel/sandbox": "2.0.0-beta.11"
   },

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -47,8 +47,8 @@
     "@mariozechner/pi-coding-agent": "latest",
     "@nats-io/services": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+    "@synadia-ai/agents": "^0.5.0",
+    "@synadia-ai/agent-service": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary

Pure mechanical output of `./devtools/devmode.sh off` after the 0.5.0 wave (#75) merged. Flips every `@synadia-ai/agents` / `@synadia-ai/agent-service` dep across 9 consumers from the dev-mode `file:` link to `^0.5.0`. **No source changes**, just package.json pin edits — 15 lines total across 9 files.

After merge, `npm publish` in dep order:

1. `@synadia-ai/agents` — `client-sdk/typescript/`
2. `@synadia-ai/agent-service` — `agent-sdk/typescript/`
3. (parallel) `@synadia-ai/nats-pi-channel` (`agents/pi/`) and `@synadia-ai/nats-channel` (`agents/openclaw/`)
4. (parallel) `@synadia-ai/nats-pi-headless` (`examples/pi-headless/`) and `@synadia-ai/nats-claude-code-headless` (`examples/claude-code-headless/`)

`claude-channel-nats` (`agents/claude-code/`) ships via the Claude marketplace subtree, not npm — no `npm publish` for it.

After all six publishes land: locally run `./devtools/devmode.sh on` to restore dev mode for the next cycle.

## Pre-flight smoke (all in dev mode, file: links live)

- typecheck clean: `client-sdk`, `agent-sdk`, `examples/{pi-headless, claude-code-headless, agent-web-ui, dspy, open-agent-vercel}`, `agents/open-agent`
- builds clean: both SDKs (tsup ESM + CJS + DTS), `agent-web-ui` (Vite)
- 239 unit tests passing in `client-sdk/typescript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)