### PR TITLE
Fix(agents/{pi,openclaw}): drop broken bundleDependencies (0.5.1)

### DIFF
--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-channel",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "NATS Agent Protocol channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "openclaw",
@@ -57,10 +57,6 @@
     "@synadia-ai/agents": "file:../../client-sdk/typescript",
     "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
   },
-  "bundleDependencies": [
-    "@synadia-ai/agents",
-    "@synadia-ai/agent-service"
-  ],
   "peerDependencies": {
     "openclaw": ""
   },

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-pi-channel",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "NATS Agent Protocol channel for PI Agent. Makes every PI session a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "pi-package",
@@ -45,10 +45,6 @@
     "@synadia-ai/agents": "file:../../client-sdk/typescript",
     "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
   },
-  "bundleDependencies": [
-    "@synadia-ai/agents",
-    "@synadia-ai/agent-service"
-  ],
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"
   }


### PR DESCRIPTION
## Summary

Both `agents/pi` and `agents/openclaw` had `bundleDependencies: ["@synadia-ai/agents", "@synadia-ai/agent-service"]` in their `package.json`, **but neither has a build step that actually vendors those SDKs into the published tarball.** `npm publish` shipped just the source files (extension entry + README + LICENSE), so the bundle declaration silently lied to consumers.

Effect on `npm install`: when a consumer installs `@synadia-ai/nats-pi-channel`, npm sees `bundleDependencies` and assumes the deps are already inside the tarball, so it **skips fetching them from the registry**. The deps end up missing entirely, and any downstream `require("@synadia-ai/agents")` blows up:

```
Failed to load extension ".../extensions/nats-channel.ts":
Cannot find module '@synadia-ai/agents'
```

Repro from a fresh prefix:

```bash
rm -rf /tmp/pi-test && mkdir /tmp/pi-test
npm install --prefix=/tmp/pi-test -g @synadia-ai/nats-pi-channel@0.5.0
npm ls --prefix=/tmp/pi-test -g --depth=1
# →  ├── UNMET DEPENDENCY @synadia-ai/agent-service@^0.5.0
#    └── UNMET DEPENDENCY @synadia-ai/agents@^0.5.0
```

This was **pre-existing** — both 0.4.0 publishes carried the same broken declaration. It went undetected because the smoke tests use `file:` links to local SDK source, never exercising a real `npm install` from the registry. First user-visible failure landed today, `pi install npm:@synadia-ai/nats-pi-channel` on 0.5.0.

### Fix

Remove the `bundleDependencies` field from both package.json files. The regular `dependencies` block already lists both SDKs at `^0.5.0`, so npm will fetch them from the registry as expected. Module resolution from the extension entrypoint (e.g. `agents/pi/extensions/nats-channel.ts`) walks up to the install root and finds the deps in the standard `node_modules/` location.

### Versions

- `@synadia-ai/nats-pi-channel`  0.5.0 → **0.5.1**
- `@synadia-ai/nats-channel`     0.5.0 → **0.5.1**

Patch bump because the source code is unchanged; the only difference is the install-time wiring.

### After merge

Same publish dance as the 0.5.0 wave, but only for these two packages:

```bash
./devtools/devmode.sh off    # flip both to ^0.5.x semver pins
cd agents/pi       && npm publish
cd agents/openclaw && npm publish
./devtools/devmode.sh on     # restore dev mode
```

### Post-publish verification

```bash
rm -rf /tmp/pi-verify && mkdir /tmp/pi-verify
npm install --prefix=/tmp/pi-verify -g @synadia-ai/nats-pi-channel@0.5.1
ls /tmp/pi-verify/lib/node_modules/@synadia-ai/nats-pi-channel/node_modules/@synadia-ai/
# expect:  agents/  agent-service/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)