### PR TITLE
test(client-sdk/python): drop redundant `exclude_none=True` from heartbeat tracker tests (#73 review)

### DIFF
--- a/client-sdk/python/tests/test_heartbeat.py
+++ b/client-sdk/python/tests/test_heartbeat.py
@@ -139,7 +139,7 @@ async def test_tracker_keys_on_instance_id_not_subject(nc: NATSClient) -> None:
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
             )
-            await nc.publish(subject, payload.model_dump_json(exclude_none=True).encode())
+            await nc.publish(subject, payload.model_dump_json().encode())
 
         # Wait for both heartbeats to land in the tracker. We poll rather
         # than sleep so the test is fast and deterministic.
@@ -183,7 +183,7 @@ async def test_tracker_liveness_is_offline_when_stale(nc: NATSClient) -> None:
             ts="2026-04-21T00:00:00Z",
             interval_s=5,
         )
-        await nc.publish(subject, payload.model_dump_json(exclude_none=True).encode())
+        await nc.publish(subject, payload.model_dump_json().encode())
 
         deadline = asyncio.get_event_loop().time() + 2.0
         while asyncio.get_event_loop().time() < deadline:
@@ -224,7 +224,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
             )
-            await nc.publish(subject, payload.model_dump_json(exclude_none=True).encode())
+            await nc.publish(subject, payload.model_dump_json().encode())
 
         deadline = asyncio.get_event_loop().time() + 2.0
         while asyncio.get_event_loop().time() < deadline:
@@ -245,7 +245,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
                 ts="2026-04-21T00:00:00Z",
                 interval_s=5,
             )
-            .model_dump_json(exclude_none=True)
+            .model_dump_json()
             .encode(),
         )
         # Give the broker a moment to deliver — then assert NO new entry.
@@ -266,7 +266,7 @@ async def test_tracker_on_heartbeat_listener_fires_and_unsubscribes(
                     ts="2026-04-21T00:00:00Z",
                     interval_s=5,
                 )
-                .model_dump_json(exclude_none=True)
+                .model_dump_json()
                 .encode(),
             )
             await asyncio.sleep(0.1)


### PR DESCRIPTION
Refs #73. Follows up on the reviewer-bot's last comment on #76.

## Context

`a724ddb` (currently on `main`) fixed the `"session": null` re-encode regression by adding `@model_serializer(mode="wrap")` to `HeartbeatPayload`, which strips the `session` key at the model layer whenever its value is `None`. The accompanying `test_encoder_omits_none_session` locks that contract in.

The reviewer-bot's [last comment on #76](https://github.com/synadia-ai/synadia-agents/pull/76#issuecomment-3499611919) noted that with the serializer in place, the per-call-site `model_dump_json(exclude_none=True)` calls in `tests/test_heartbeat.py` are now **redundant but harmless** — they were originally added as a defensive workaround in `9bd6e4b` before the serializer landed.

Quoting the relevant excerpt:

> The `exclude_none=True` in the tracker tests is now redundant but harmless.

## What this PR does

Drops `exclude_none=True` from the five `nc.publish(...)` call sites in `client-sdk/python/tests/test_heartbeat.py` (lines 142, 186, 227, 248, 269). The `@model_serializer` carries the contract on its own, so the test code is now consistent with how production-side `build_heartbeat_payload` callers already serialize (no `exclude_none` argument), and no longer signals that test authors needed a per-call workaround.

`test_encoder_omits_none_session` continues to assert that re-encoding a `session=None` payload omits the `session` key — that's the regression guard for the serializer, and it still passes.

## Procedural note

The `9bd6e4b` and `a724ddb` commits this PR builds on were unfortunately pushed straight to `main` by an earlier Claude Code session by mistake. This PR is the cleanup item flagged on top of that work, going through normal review for once.

## Test plan

- [x] `uv run pytest tests/test_heartbeat.py -v` in `client-sdk/python/` — 9 passed (including `test_encoder_omits_none_session`, which proves the serializer alone is sufficient)
- [x] `uv run pytest` (full suite) — 212 passed, including `test_interop_e2e.py` against the TS reference agent
- [x] `uv run ruff check --no-cache .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy --no-incremental src tests examples` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)