### PR TITLE
Chore(examples/agent-web-ui): bump version 0.4.0 → 0.5.0

### DIFF
--- a/examples/agent-web-ui/package.json
+++ b/examples/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-ai-testui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Bun + Vue 3 web test client for the @synadia-ai/agents SDK — prompt NATS agents with optional attachments and stream responses.",
   "keywords": [
     "nats",


### PR DESCRIPTION
Tiny chore PR — single-line version bump in \`examples/agent-web-ui/package.json\`. The dashboard footer reads \`__APP_VERSION__\` from this file at Vite build time, so this gets the displayed UI version aligned with the rest of the 0.5.0 family. Private package (\`private: true\`), no npm publish.

The VPS at \`agents.m64.io\` is already running this build (rsync + rebuild + restart done out-of-band).