### PR TITLE
Fix: expired headless sessions can no longer be prompted

### DIFF
--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -648,10 +648,17 @@ export class Bridge {
       // and headless **controllers** still auto-evict — for those the
       // card carries no transcript worth preserving and removing it
       // just reflects reality.
+      //
+      // Drop the timestamp once we've decided to exempt — otherwise
+      // every subsequent sweep re-iterates the same stale entry and
+      // re-makes the same decision. If the session ever resumes
+      // heartbeats (rare; disposed sessions don't typically come
+      // back), the wildcard tracker will re-seed the entry.
       if (
         (agent.agent === "pi-headless" || agent.agent === "cc-headless") &&
         agent.metadata["role"] === "session"
       ) {
+        this.lastHeartbeatAt.delete(instanceId);
         continue;
       }
       this.forgetAgent(instanceId);

--- a/examples/agent-web-ui/server/bridge.ts
+++ b/examples/agent-web-ui/server/bridge.ts
@@ -42,7 +42,23 @@ export class Bridge {
   private heartbeatTracker: HeartbeatTracker | null = null;
   private heartbeatWatchUnsub: (() => void) | null = null;
   private pendingInstanceLookups = new Set<string>();
+  /** Last heartbeat receipt per instance, used to evict silent agents. */
+  private lastHeartbeatAt = new Map<string, { atMs: number; intervalS: number }>();
+  private staleSweepTimer: ReturnType<typeof setInterval> | null = null;
   private closed = false;
+
+  /**
+   * Stale-heartbeat eviction. After {@link STALE_MISS_FACTOR} missed
+   * heartbeats from an instance, the bridge gives up on it and emits
+   * `agent-removed` to the UI — without this, a disposed pi/cc-headless
+   * session leaves a zombie card on screen until the user hits Refresh.
+   * `STALE_SWEEP_INTERVAL_MS` is the cadence at which we evaluate the
+   * map; the actual eviction threshold is `intervalS * STALE_MISS_FACTOR`
+   * (so an agent with `intervalS = 30` is evicted after ~90 s of silence).
+   */
+  private static readonly STALE_SWEEP_INTERVAL_MS = 5_000;
+  private static readonly STALE_MISS_FACTOR = 3;
+  private static readonly DEFAULT_HB_INTERVAL_S = 30;
 
   constructor(
     private readonly agents: Agents,
@@ -62,6 +78,7 @@ export class Bridge {
       ...(natsServer ? { natsServer } : {}),
     });
     this.startHeartbeatWatch();
+    this.startStaleSweep();
   }
 
   onMessage(raw: string): void {
@@ -129,6 +146,11 @@ export class Bridge {
       void this.heartbeatTracker.stop();
       this.heartbeatTracker = null;
     }
+    if (this.staleSweepTimer) {
+      clearInterval(this.staleSweepTimer);
+      this.staleSweepTimer = null;
+    }
+    this.lastHeartbeatAt.clear();
     this.pendingInstanceLookups.clear();
     this.ws = null;
   }
@@ -580,9 +602,60 @@ export class Bridge {
     });
     this.heartbeatWatchUnsub = tracker.onAnyHeartbeat((hb) => {
       if (this.closed) return;
+      // Record receipt regardless of whether the instance is already
+      // tracked — stale-sweep needs the timestamp for both newly-seen
+      // and already-known instances.
+      this.lastHeartbeatAt.set(hb.instanceId, {
+        atMs: Date.now(),
+        intervalS: hb.intervalS || Bridge.DEFAULT_HB_INTERVAL_S,
+      });
       if (this.agentsByInstanceId.has(hb.instanceId)) return;
       void this.ensureAgentKnown(hb.instanceId);
     });
+  }
+
+  /**
+   * Sweep `lastHeartbeatAt` and forget any instance whose last heartbeat
+   * is older than `intervalS * STALE_MISS_FACTOR`. Runs on a single
+   * unref'd timer so it doesn't keep the process alive on its own.
+   */
+  private startStaleSweep(): void {
+    if (this.staleSweepTimer) return;
+    this.staleSweepTimer = setInterval(
+      () => this.evictStaleAgents(),
+      Bridge.STALE_SWEEP_INTERVAL_MS,
+    );
+    this.staleSweepTimer.unref?.();
+  }
+
+  private evictStaleAgents(): void {
+    if (this.closed) return;
+    const now = Date.now();
+    for (const [instanceId, last] of this.lastHeartbeatAt) {
+      const cutoffMs = last.intervalS * 1000 * Bridge.STALE_MISS_FACTOR;
+      if (now - last.atMs <= cutoffMs) continue;
+      const agent = this.agentsByInstanceId.get(instanceId);
+      if (!agent) {
+        // Wildcard heartbeat from an instance whose lookup is still
+        // pending. Drop the timestamp; it'll be re-seeded by the next
+        // heartbeat (if one ever arrives) or by registerAgent.
+        this.lastHeartbeatAt.delete(instanceId);
+        continue;
+      }
+      // Disposed pi/cc-headless **sessions** are deliberately kept on
+      // screen so the user can copy / read past chat messages from
+      // them; the trash button removes them manually. Regular agents
+      // and headless **controllers** still auto-evict — for those the
+      // card carries no transcript worth preserving and removing it
+      // just reflects reality.
+      if (
+        (agent.agent === "pi-headless" || agent.agent === "cc-headless") &&
+        agent.metadata["role"] === "session"
+      ) {
+        continue;
+      }
+      this.forgetAgent(instanceId);
+    }
   }
 
   /**
@@ -612,8 +685,22 @@ export class Bridge {
 
   private registerAgent(agent: Agent): void {
     this.agentsByInstanceId.set(agent.instanceId, agent);
+    // Seed the stale-sweep clock at registration time so a freshly-
+    // discovered agent isn't immediately evicted before its first
+    // heartbeat arrives. The wildcard tracker may have already set a
+    // newer timestamp; don't overwrite it.
+    if (!this.lastHeartbeatAt.has(agent.instanceId)) {
+      this.lastHeartbeatAt.set(agent.instanceId, {
+        atMs: Date.now(),
+        intervalS: Bridge.DEFAULT_HB_INTERVAL_S,
+      });
+    }
     if (!this.heartbeatSubs.has(agent.instanceId)) {
       const unsub = this.agents.onHeartbeat(agent.instanceId, (hb) => {
+        this.lastHeartbeatAt.set(agent.instanceId, {
+          atMs: Date.now(),
+          intervalS: hb.intervalS || Bridge.DEFAULT_HB_INTERVAL_S,
+        });
         this.send({
           kind: "heartbeat",
           instanceId: agent.instanceId,
@@ -628,6 +715,7 @@ export class Bridge {
 
   private forgetAgent(instanceId: string): void {
     if (!this.agentsByInstanceId.delete(instanceId)) return;
+    this.lastHeartbeatAt.delete(instanceId);
     const unsub = this.heartbeatSubs.get(instanceId);
     if (unsub) {
       try {

--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -191,6 +191,13 @@ const sessionState = computed<"alive" | "expired">(() => {
   if (!isPiSession.value && !isCcSession.value) return "alive";
   const s = piSummary.value ?? ccSummary.value;
   if (!s) return "expired";
+  // `max_lifetime_s = 0` means the session was spawned with no expiry —
+  // it runs until explicitly stopped. The controller's summary still
+  // reports `remaining_lifetime_s = 0` in that case (the field is
+  // computed as `max - elapsed` clamped to ≥ 0, and `max = 0` short-
+  // circuits to 0), so without this guard infinite sessions would
+  // be flagged as expired.
+  if (s.max_lifetime_s === 0) return "alive";
   if (s.remaining_lifetime_s <= 0) return "expired";
   return "alive";
 });

--- a/examples/agent-web-ui/src/components/ChatPanel.vue
+++ b/examples/agent-web-ui/src/components/ChatPanel.vue
@@ -11,7 +11,8 @@ import {
   messagesFor,
   type Message,
 } from "../stores/chat.ts";
-import { bumpCcSessionCost } from "../stores/ccexec.ts";
+import { ccexecState, bumpCcSessionCost } from "../stores/ccexec.ts";
+import { piexecState } from "../stores/piexec.ts";
 import { bucketOf, BUCKETS } from "../stores/agents.ts";
 import { randomUUID } from "../uuid.ts";
 import type { DiscoveredAgentDTO } from "../wire.ts";
@@ -26,6 +27,30 @@ const isCcSession = computed(
     props.agent.agent === "cc-headless" &&
     props.agent.metadata?.["role"] === "session",
 );
+
+const isPiSession = computed(
+  () =>
+    props.agent.agent === "pi-headless" &&
+    props.agent.metadata?.["role"] === "session",
+);
+
+/**
+ * True for a headless session that's no longer accepting prompts —
+ * either the controller cleaned it up (no summary) or its lifetime
+ * ran out (`remaining_lifetime_s <= 0`). Mirrors the corresponding
+ * `sessionState` computed in AgentCard. Infinite-lifetime sessions
+ * (`max_lifetime_s = 0`) are explicitly excluded so they stay
+ * promptable forever, matching the badge behavior on the card.
+ */
+const isExpired = computed<boolean>(() => {
+  if (!isPiSession.value && !isCcSession.value) return false;
+  const s = isPiSession.value
+    ? piexecState.summaries.get(props.agent.name)
+    : ccexecState.summaries.get(props.agent.name);
+  if (!s) return true;
+  if (s.max_lifetime_s === 0) return false;
+  return s.remaining_lifetime_s <= 0;
+});
 
 // Human label for the chat-header pill. Mirrors AgentCard's tagLabel
 // so a card and its chat header always show the same friendly name.
@@ -224,9 +249,12 @@ function onStop(): void {
     </header>
     <div v-if="error" class="error mono">{{ error }}</div>
     <MessageList :messages="currentMessages" @reply="onQueryReply" />
+    <div v-if="isExpired" class="expired-banner mono">
+      Session expired — past messages are read-only. Start a new session to keep working.
+    </div>
     <PromptArea
       :busy="busy"
-      :disabled="false"
+      :disabled="isExpired"
       :attachments-ok="attachmentsOk"
       :max-payload-bytes="maxPayloadBytes"
       @submit="onSubmit"
@@ -283,5 +311,14 @@ function onStop(): void {
   color: var(--error);
   background: var(--error-dim);
   border-bottom: 1px solid rgba(248, 113, 113, 0.3);
+}
+.expired-banner {
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--text-xs);
+  color: var(--error);
+  background: var(--error-dim);
+  border-top: 1px solid rgba(248, 113, 113, 0.3);
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
 }
 </style>

--- a/examples/claude-code-headless/CHANGELOG.md
+++ b/examples/claude-code-headless/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   that arrived between expiry and the next sweep tick was served
   normally — the session accepted work it was about to drop. The
   session itself is unchanged; the guard only refuses new requests.
+- **Reject prompts to disposed sessions with `503 session stopped`.**
+  The pre-existing `disposed` short-circuit emitted only a §6.5
+  terminator — indistinguishable on the wire from "stream completed
+  cleanly with no chunks." Now sends an error header first so callers
+  can tell "session was stopped" apart from "session ran and produced
+  no output."
 
 ### Changed
 

--- a/examples/claude-code-headless/CHANGELOG.md
+++ b/examples/claude-code-headless/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-04
+
+### Fixed
+
+- **Reject prompts to expired sessions.** `handlePrompt` now responds
+  with `Nats-Service-Error-Code: 410 session expired` (plus the §6.5
+  empty terminator) when the session's lifetime has run out but the
+  manager's sweep loop hasn't disposed it yet. Previously, a prompt
+  that arrived between expiry and the next sweep tick was served
+  normally — the session accepted work it was about to drop. The
+  session itself is unchanged; the guard only refuses new requests.
+
+### Changed
+
+- **Tighten the session-manager sweep cadence from 30 s to 2 s.**
+  Combined with the `expired()` prompt guard, an expired session is
+  disposed and unregistered from NATS within a couple of seconds of
+  hitting its limit instead of up to 30 s.
+
 ## [0.5.1] - 2026-05-04
 
 ### Changed

--- a/examples/claude-code-headless/package.json
+++ b/examples/claude-code-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-claude-code-headless",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Headless NATS agent host that spawns, prompts, and stops Claude Code sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.cc-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",

--- a/examples/claude-code-headless/src/claude-session-manager.ts
+++ b/examples/claude-code-headless/src/claude-session-manager.ts
@@ -13,7 +13,11 @@ import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
 import { ManagedSession, type SessionSummary } from "./managed-session.js";
 import { generateSessionId, validateSessionId } from "./subjects.js";
 
-const LIFETIME_CHECK_INTERVAL_MS = 30_000;
+// 2s — quick enough that an expired session is disposed within a couple
+// of seconds of hitting its limit (so the NATS service drops off the bus
+// promptly), and well below any reasonable session lifetime so the timer
+// itself is negligible CPU even with hundreds of sessions in the map.
+const LIFETIME_CHECK_INTERVAL_MS = 2_000;
 const STALE_PRUNE_INTERVAL_MS = 60_000;
 const STALE_REQUEST_CUTOFF_MS = 30 * 60 * 1000;
 

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -200,6 +200,15 @@ export class ManagedSession {
 
   private async handlePrompt(msg: ServiceMsg): Promise<void> {
     if (this.disposed) {
+      // Send an error header before the §6.5 terminator so callers can
+      // tell "session was stopped" apart from "stream completed cleanly
+      // with no chunks." Both have a zero-byte body, so without the
+      // error header they look identical on the wire.
+      try {
+        msg.respondError(503, "session stopped");
+      } catch {
+        /* connection gone */
+      }
       try {
         msg.respond("");
       } catch {

--- a/examples/claude-code-headless/src/managed-session.ts
+++ b/examples/claude-code-headless/src/managed-session.ts
@@ -208,6 +208,24 @@ export class ManagedSession {
       return;
     }
 
+    // Reject prompts to a session whose lifetime ran out. The manager's
+    // sweep loop disposes expired sessions on a tick; without this guard,
+    // a prompt that arrives between expiry and the next sweep would be
+    // served normally — accepting work the session is about to drop.
+    if (this.expired()) {
+      try {
+        msg.respondError(410, "session expired");
+      } catch {
+        /* connection gone */
+      }
+      try {
+        msg.respond("");
+      } catch {
+        /* connection gone */
+      }
+      return;
+    }
+
     let envelope;
     try {
       envelope = parseEnvelope(msg.data);

--- a/examples/pi-headless/CHANGELOG.md
+++ b/examples/pi-headless/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   that arrived between expiry and the next sweep tick was served
   normally — the session accepted work it was about to drop. The
   session itself is unchanged; the guard only refuses new requests.
+- **Reject prompts to disposed sessions with `503 session stopped`.**
+  The pre-existing `disposed` short-circuit emitted only a §6.5
+  terminator — indistinguishable on the wire from "stream completed
+  cleanly with no chunks." Now sends an error header first so callers
+  can tell "session was stopped" apart from "session ran and produced
+  no output."
 
 ### Changed
 

--- a/examples/pi-headless/CHANGELOG.md
+++ b/examples/pi-headless/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-04
+
+### Fixed
+
+- **Reject prompts to expired sessions.** `handlePrompt` now responds
+  with `Nats-Service-Error-Code: 410 session expired` (plus the §6.5
+  empty terminator) when the session's lifetime has run out but the
+  manager's sweep loop hasn't disposed it yet. Previously, a prompt
+  that arrived between expiry and the next sweep tick was served
+  normally — the session accepted work it was about to drop. The
+  session itself is unchanged; the guard only refuses new requests.
+
+### Changed
+
+- **Tighten the session-manager sweep cadence from 30 s to 2 s.**
+  Combined with the `expired()` prompt guard, an expired session is
+  disposed and unregistered from NATS within a couple of seconds of
+  hitting its limit instead of up to 30 s.
+
 ## [0.5.1] - 2026-05-04
 
 ### Changed

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-pi-headless",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Headless NATS agent host that spawns, prompts, and stops PI coding-agent sessions as first-class NATS Agent Protocol v0.3 instances. Each session registers as agents.prompt.pi-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",

--- a/examples/pi-headless/src/managed-session.ts
+++ b/examples/pi-headless/src/managed-session.ts
@@ -167,6 +167,24 @@ export class ManagedSession {
       return;
     }
 
+    // Reject prompts to a session whose lifetime ran out. The manager's
+    // sweep loop disposes expired sessions on a tick; without this guard,
+    // a prompt that arrives between expiry and the next sweep would be
+    // served normally — accepting work the session is about to drop.
+    if (this.expired()) {
+      try {
+        msg.respondError(410, "session expired");
+      } catch {
+        /* connection gone */
+      }
+      try {
+        msg.respond("");
+      } catch {
+        /* connection gone */
+      }
+      return;
+    }
+
     let envelope: ReturnType<typeof decodeEnvelope>;
     try {
       envelope = decodeEnvelope(msg.data);

--- a/examples/pi-headless/src/managed-session.ts
+++ b/examples/pi-headless/src/managed-session.ts
@@ -159,6 +159,15 @@ export class ManagedSession {
 
   private async handlePrompt(msg: ServiceMsg): Promise<void> {
     if (this.disposed) {
+      // Send an error header before the §6.5 terminator so callers can
+      // tell "session was stopped" apart from "stream completed cleanly
+      // with no chunks." Both have a zero-byte body, so without the
+      // error header they look identical on the wire.
+      try {
+        msg.respondError(503, "session stopped");
+      } catch {
+        /* connection gone */
+      }
       try {
         msg.respond("");
       } catch {

--- a/examples/pi-headless/src/pi-session-manager.ts
+++ b/examples/pi-headless/src/pi-session-manager.ts
@@ -19,7 +19,11 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import { ManagedSession, type SessionSummary } from "./managed-session.js";
 import { generateSessionId, validateSessionId } from "./subjects.js";
 
-const LIFETIME_CHECK_INTERVAL_MS = 30_000;
+// 2s — quick enough that an expired session is disposed within a couple
+// of seconds of hitting its limit (so the NATS service drops off the bus
+// promptly), and well below any reasonable session lifetime so the timer
+// itself is negligible CPU even with hundreds of sessions in the map.
+const LIFETIME_CHECK_INTERVAL_MS = 2_000;
 const STALE_PRUNE_INTERVAL_MS = 60_000;
 const STALE_REQUEST_CUTOFF_MS = 30 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Two-phase fix for "an expired pi/cc-headless session can still be
talked to." Single PR, two clearly-scoped commits — Phase A is
web-ui-only, Phase B is the publishable headless examples.

### Phase A — `agent-web-ui` (private, no publish)

Two related dashboard fixes:

- **`AgentCard.vue` — infinite-lifetime sessions are not "expired".**
  A session spawned with `max_lifetime_s = 0` (no expiry) was being
  flagged with the red "expired" badge because the controller's
  summary reports `remaining_lifetime_s = 0` for infinite sessions.
  Special-case `max_lifetime_s === 0` as alive.
- **`bridge.ts` — auto-evict agents whose heartbeats stop.**
  Previously the bridge only forgot agents on explicit stop or
  `discover()` refresh; a crashed regular agent or vanished headless
  controller would leave a zombie card on screen until the user hit
  Refresh. Add a stale-heartbeat sweep that runs every 5 s and evicts
  any instance whose last heartbeat is older than `3 × intervalS`.
  **pi/cc-headless _sessions_ are exempt from auto-eviction** — by
  design, disposed sessions stay on screen so the user can copy /
  read past chat messages, with the trash button as the explicit
  removal path.

### Phase B — `examples/{pi,cc}-headless@0.5.2` (publishes)

A finite-lifetime headless session was serving prompts for up to 30 s
after its `max_lifetime_s` ran out, because:

1. `handlePrompt` only short-circuited on `disposed` — never on
   `expired()`. So an expired-but-not-yet-disposed session accepted
   work it was about to drop.
2. `checkLifetimes()` swept every 30 s, which defined the upper bound
   on the dispose latency.

Two-line fix on each side:

- `managed-session.ts` — `handlePrompt` now responds with
  `Nats-Service-Error-Code: 410 session expired` (plus the §6.5 empty
  terminator) when `expired()` is true, before any envelope decode.
- `{pi,claude}-session-manager.ts` — `LIFETIME_CHECK_INTERVAL_MS`
  drops from 30_000 to 2_000. Combined with the prompt guard, an
  expired session is unregistered from NATS within ~2 s of its limit.

Both packages bump to 0.5.2 with `[0.5.2] - 2026-05-04` CHANGELOG
entries. `@synadia-ai/agent-service` is unchanged.

## Release impact

- `agent-web-ui` is `private: true` — **no publish**.
- `@synadia-ai/nats-pi-headless@0.5.2` and
  `@synadia-ai/nats-claude-code-headless@0.5.2` need to be **published
  after merge**. The `@synadia-ai/agent-service` SDK does not change,
  so its pin in both examples (`^0.5.1`) keeps resolving correctly.

## Test plan

- [x] `bun run typecheck` + `bun run build` pass in `examples/agent-web-ui`, `examples/pi-headless`, `examples/claude-code-headless`
- [ ] Manual on `agents.m64.io`: spawn pi-headless session with `max_lifetime_s = 0` → confirm card is *not* tagged "expired"
- [ ] Manual: spawn pi-headless session with `max_lifetime_s = 30` → wait 30s+ → confirm next prompt fails with `410 session expired`, confirm card disappears from grid only after a controller-side stop or trash button (not auto-evicted)
- [ ] Manual: kill a pi-headless **controller** → confirm its card disappears from the grid within ~90s (auto-eviction kicks in for non-session instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)