### PR TITLE
agent-web-ui: visual restructure + multi-select fan-out (Phase 1)

### DIFF
--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -11,6 +11,7 @@ import {
 } from "../stores/agents.ts";
 import { onStopped, piexecState } from "../stores/piexec.ts";
 import { ccexecState, onCcStopped } from "../stores/ccexec.ts";
+import { selectionState, toggleSelection } from "../stores/selection.ts";
 import { useBridge } from "../composables/useBridge.ts";
 
 const props = defineProps<{
@@ -203,6 +204,22 @@ const sessionState = computed<"alive" | "expired">(() => {
 });
 const isExpired = computed(() => sessionState.value === "expired");
 
+// A card is multi-selectable iff it represents a prompt-target the user
+// could meaningfully fan a prompt out to. Controllers (which spawn,
+// don't prompt) and expired sessions (which can't accept prompts) are
+// out — the selection circle isn't even rendered for them, so the card
+// looks normal.
+const multiSelectable = computed(() => !isController.value && !isExpired.value);
+const isMultiSelected = computed(() => selectionState.ids.has(props.agent.instanceId));
+
+function onToggleSelect(e: Event): void {
+  // Stop propagation so the card-body click handler (single-select for
+  // the right-panel chat) doesn't also fire — the two interactions are
+  // intentionally orthogonal.
+  e.stopPropagation();
+  toggleSelection(props.agent.instanceId);
+}
+
 // Find the controller that spawned this session (matched by agent token +
 // role + owner). Returns null if the controller has vanished — in which case
 // the stop button is shown disabled with a tooltip.
@@ -272,11 +289,36 @@ function onTrash(): void {
         selected,
         'is-controller': isController,
         'is-session': isPiSession || isCcSession,
+        'is-multi-selected': isMultiSelected,
       }"
       type="button"
       @click="$emit('select', agent.instanceId)"
     >
       <header class="card-head">
+        <span
+          v-if="multiSelectable"
+          class="select-circle"
+          :class="{ active: isMultiSelected }"
+          role="checkbox"
+          tabindex="0"
+          :aria-checked="isMultiSelected ? 'true' : 'false'"
+          :title="isMultiSelected ? 'Deselect for multi-prompt' : 'Select for multi-prompt'"
+          @click="onToggleSelect"
+          @keydown.space.prevent="onToggleSelect"
+          @keydown.enter.prevent="onToggleSelect"
+        >
+          <svg
+            v-if="isMultiSelected"
+            class="check"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          ><polyline points="20 6 9 17 4 12" /></svg>
+        </span>
         <div class="head-tags">
           <span class="agent-tag mono">{{ tagLabel }}</span>
           <span v-if="isController" class="role-badge mono" title="headless controller — spawns sessions">CONTROLLER</span>
@@ -488,6 +530,15 @@ function onTrash(): void {
     0 0 0 1px var(--memory-preference),
     0 0 18px rgba(167, 139, 250, 0.25);
 }
+/* Multi-select visual: a faint accent ring on the card so the user can
+   see which cards are ticked even with the right-panel selection on a
+   different card. Distinct from `.selected` (which is the right-panel
+   open-in-chat state) — both can apply at once. */
+.card.is-multi-selected {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 55%, transparent),
+    0 0 14px var(--accent-glow);
+}
 
 .card-head {
   display: flex;
@@ -503,6 +554,55 @@ function onTrash(): void {
   flex-wrap: wrap;
 }
 .status-led { flex-shrink: 0; }
+
+/* Selection circle. Always rendered for multi-selectable cards so the
+   layout slot is reserved (no shift on hover); fades in on card hover or
+   sticks visible when selected. Click toggles; propagation stops so the
+   card body's open-in-chat click doesn't fire. */
+.select-circle {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--text-dim) 80%, transparent);
+  background: var(--bg-primary);
+  color: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast),
+              border-color var(--transition-fast),
+              background var(--transition-fast),
+              transform var(--transition-fast);
+  /* Above the card's interactive surface so click events land here, not
+     on the parent button. */
+  position: relative;
+  z-index: 2;
+}
+.card-wrap:hover .select-circle,
+.select-circle.active,
+.select-circle:focus-visible {
+  opacity: 1;
+}
+.select-circle:hover {
+  border-color: var(--accent-primary);
+  background: var(--accent-glow);
+}
+.select-circle.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+.select-circle:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+.select-circle .check {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
 
 .role-badge {
   font-size: 9px;

--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -283,7 +283,11 @@ function onTrash(): void {
 
 <template>
   <div class="card-wrap" :style="{ '--tag-color': tagColor }">
-    <button
+    <!-- div+role=button (not a real <button>) so the inner select-circle
+         button is valid markup. Nesting interactive elements inside an
+         actual <button> violates the HTML spec and confuses screen readers,
+         which can merge them into a single control. -->
+    <div
       class="card"
       :class="{
         selected,
@@ -291,21 +295,22 @@ function onTrash(): void {
         'is-session': isPiSession || isCcSession,
         'is-multi-selected': isMultiSelected,
       }"
-      type="button"
+      role="button"
+      tabindex="0"
       @click="$emit('select', agent.instanceId)"
+      @keydown.enter.prevent="$emit('select', agent.instanceId)"
+      @keydown.space.prevent="$emit('select', agent.instanceId)"
     >
       <header class="card-head">
-        <span
+        <button
           v-if="multiSelectable"
+          type="button"
           class="select-circle"
           :class="{ active: isMultiSelected }"
           role="checkbox"
-          tabindex="0"
           :aria-checked="isMultiSelected ? 'true' : 'false'"
           :title="isMultiSelected ? 'Deselect for multi-prompt' : 'Select for multi-prompt'"
           @click="onToggleSelect"
-          @keydown.space.prevent="onToggleSelect"
-          @keydown.enter.prevent="onToggleSelect"
         >
           <svg
             v-if="isMultiSelected"
@@ -318,7 +323,7 @@ function onTrash(): void {
             stroke-linejoin="round"
             aria-hidden="true"
           ><polyline points="20 6 9 17 4 12" /></svg>
-        </span>
+        </button>
         <div class="head-tags">
           <span class="agent-tag mono">{{ tagLabel }}</span>
           <span v-if="isController" class="role-badge mono" title="headless controller — spawns sessions">CONTROLLER</span>
@@ -384,7 +389,7 @@ function onTrash(): void {
       </div>
 
       <p v-if="isController" class="hint">click to spawn or fan out</p>
-    </button>
+    </div>
 
     <button
       v-if="isPiSession || isCcSession"
@@ -508,6 +513,13 @@ function onTrash(): void {
   background: var(--bg-tertiary);
   border-color: color-mix(in srgb, var(--tag-color, var(--text-muted)) 45%, transparent);
   transform: translateY(-1px);
+}
+.card:focus-visible {
+  /* The card root is a div+role=button (not a real <button>) so the global
+     :focus-visible rule on form controls doesn't apply automatically.
+     Keep keyboard focus visible. */
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 .card.selected {
   border-color: var(--accent-primary);

--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -295,6 +295,11 @@ function onTrash(): void {
 
       <p v-if="cwd" class="cwd mono" :title="cwd">{{ cwd }}</p>
 
+      <!-- Eats the leftover height when cards in a row are equalised, so the
+           subject + stats + badges + hint dock to the card's bottom edge while
+           the head / title / meta / cwd block stays anchored to the top. -->
+      <div class="grow-spacer" aria-hidden="true" />
+
       <p
         v-if="agent.promptEndpoint.subject"
         class="subject mono"
@@ -381,8 +386,12 @@ function onTrash(): void {
 <style scoped>
 .card-wrap {
   position: relative;
-  display: block;
+  display: flex;
   width: 100%;
+  /* Fill the grid row's height. CSS Grid stretches items to the tallest
+     row sibling by default; this prop just makes that height visible to
+     the inner `.card` so it can flex-fill it. */
+  height: 100%;
 }
 
 .stop-btn {
@@ -436,6 +445,9 @@ function onTrash(): void {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  /* Fill the card-wrap so all cards in a row share the tallest card's
+     height — the `.grow-spacer` inside then pushes the bottom block down. */
+  flex: 1;
   padding: var(--space-md);
   background: var(--bg-secondary);
   /* Default border = a faint wash of the per-bucket tag colour. This
@@ -570,6 +582,14 @@ function onTrash(): void {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.grow-spacer {
+  flex: 1;
+  /* Honour the card's `gap` rule (`--space-xs`) by collapsing to 0 minimum
+     height — the gap on either side already provides breathing room when
+     no extra space is available. */
+  min-height: 0;
+}
+
 .subject {
   font-size: 11px;
   color: var(--text-dim);

--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -277,7 +277,10 @@ function onTrash(): void {
       @click="$emit('select', agent.instanceId)"
     >
       <header class="card-head">
-        <span class="agent-tag mono">{{ tagLabel }}</span>
+        <div class="head-tags">
+          <span class="agent-tag mono">{{ tagLabel }}</span>
+          <span v-if="isController" class="role-badge mono" title="headless controller — spawns sessions">CONTROLLER</span>
+        </div>
         <AgentStatusDot class="status-led" :instance-id="agent.instanceId" />
       </header>
 
@@ -480,7 +483,27 @@ function onTrash(): void {
   justify-content: space-between;
   gap: var(--space-sm);
 }
+.head-tags {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+  flex-wrap: wrap;
+}
 .status-led { flex-shrink: 0; }
+
+.role-badge {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+  color: var(--memory-preference);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--memory-preference) 45%, transparent);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
 
 .agent-tag {
   font-size: var(--text-xs);

--- a/examples/agent-web-ui/src/components/AgentGrid.vue
+++ b/examples/agent-web-ui/src/components/AgentGrid.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import AgentGroup from "./AgentGroup.vue";
-import { agentsState, agentsByBucket } from "../stores/agents.ts";
+import { agentsState, agentSections } from "../stores/agents.ts";
 
-const groups = computed(() => agentsByBucket.value);
+const groups = computed(() => agentSections.value);
 const isEmpty = computed(() => groups.value.length === 0);
 </script>
 
@@ -32,7 +32,7 @@ const isEmpty = computed(() => groups.value.length === 0);
       <div v-else class="groups">
         <AgentGroup
           v-for="g in groups"
-          :key="g.bucket"
+          :key="g.id"
           :label="g.label"
           :agents="g.agents"
         />

--- a/examples/agent-web-ui/src/components/AgentGrid.vue
+++ b/examples/agent-web-ui/src/components/AgentGrid.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import AgentGroup from "./AgentGroup.vue";
+import MultiSelectBar from "./MultiSelectBar.vue";
 import { agentsState, agentSections } from "../stores/agents.ts";
+import { selectionState } from "../stores/selection.ts";
 
 const groups = computed(() => agentSections.value);
 const isEmpty = computed(() => groups.value.length === 0);
+const hasSelection = computed(() => selectionState.ids.size > 0);
 </script>
 
 <template>
@@ -38,6 +41,10 @@ const isEmpty = computed(() => groups.value.length === 0);
         />
       </div>
     </div>
+
+    <Transition name="bar">
+      <MultiSelectBar v-if="hasSelection" />
+    </Transition>
   </main>
 </template>
 
@@ -96,5 +103,24 @@ const isEmpty = computed(() => groups.value.length === 0);
   color: var(--accent-primary);
   background: transparent;
   padding: 0;
+}
+
+/* Slide the multi-select action bar up from below the grid pane.
+   Transform-only animation so the layout reflow (grid-body shrinking to
+   make room for the bar) is the only DOM resize — the bar itself just
+   slides into the space that opens up. */
+.bar-enter-active,
+.bar-leave-active {
+  transition: transform 0.22s ease, opacity 0.18s ease;
+}
+.bar-enter-from,
+.bar-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+.bar-enter-to,
+.bar-leave-from {
+  transform: translateY(0);
+  opacity: 1;
 }
 </style>

--- a/examples/agent-web-ui/src/components/ChatPanel.vue
+++ b/examples/agent-web-ui/src/components/ChatPanel.vue
@@ -3,18 +3,11 @@ import { computed, ref } from "vue";
 import MessageList from "./MessageList.vue";
 import PromptArea from "./PromptArea.vue";
 import { fileToAttachment, useBridge } from "../composables/useBridge.ts";
-import {
-  appendMessage,
-  findMessage,
-  findMessageByToolId,
-  getSession,
-  messagesFor,
-  type Message,
-} from "../stores/chat.ts";
-import { ccexecState, bumpCcSessionCost } from "../stores/ccexec.ts";
+import { startPromptStream } from "../composables/promptStreaming.ts";
+import { getSession, messagesFor, type Message } from "../stores/chat.ts";
+import { ccexecState } from "../stores/ccexec.ts";
 import { piexecState } from "../stores/piexec.ts";
 import { bucketOf, BUCKETS } from "../stores/agents.ts";
-import { randomUUID } from "../uuid.ts";
 import type { DiscoveredAgentDTO } from "../wire.ts";
 
 const props = defineProps<{ agent: DiscoveredAgentDTO }>();
@@ -103,7 +96,6 @@ const maxPayloadBytes = computed(() => props.agent.promptEndpoint.maxPayloadByte
 
 async function onSubmit(text: string, files: File[]): Promise<void> {
   const agent = props.agent;
-  const session = getSession(agent.instanceId);
 
   let attachments: Awaited<ReturnType<typeof fileToAttachment>>[] | undefined;
   if (files.length > 0) {
@@ -115,112 +107,7 @@ async function onSubmit(text: string, files: File[]): Promise<void> {
     }
   }
 
-  const userMsg = appendMessage(agent.instanceId, {
-    id: randomUUID(),
-    role: "user",
-    content: text,
-    streaming: false,
-    timestamp: Date.now(),
-  });
-  if (attachments) {
-    userMsg.attachments = attachments.map((a) => ({ filename: a.filename, base64: a.base64 }));
-  }
-
-  let currentAgentMsgId = randomUUID();
-  appendMessage(agent.instanceId, {
-    id: currentAgentMsgId,
-    role: "agent",
-    content: "",
-    streaming: true,
-    timestamp: Date.now(),
-  });
-
-  function newAgentBubble(): void {
-    currentAgentMsgId = randomUUID();
-    appendMessage(agent.instanceId, {
-      id: currentAgentMsgId,
-      role: "agent",
-      content: "",
-      streaming: true,
-      timestamp: Date.now(),
-    });
-  }
-
-  let promptId = "";
-  promptId = bridge.prompt(agent.instanceId, text, attachments, {
-    onResponse(chunk, responseAttachments) {
-      const m = findMessage(agent.instanceId, currentAgentMsgId);
-      if (!m) return;
-      m.content += chunk;
-      if (responseAttachments && responseAttachments.length > 0) {
-        m.attachments = [...(m.attachments ?? []), ...responseAttachments];
-      }
-    },
-    onStatus(status) {
-      const m = findMessage(agent.instanceId, currentAgentMsgId);
-      if (!m) return;
-      if (status === "stopped") m.statusNote = "(stopped)";
-    },
-    onQuery(queryId, queryPrompt, queryAttachments) {
-      const prev = findMessage(agent.instanceId, currentAgentMsgId);
-      if (prev) prev.streaming = false;
-      appendMessage(agent.instanceId, {
-        id: randomUUID(),
-        role: "query",
-        content: queryPrompt,
-        streaming: false,
-        timestamp: Date.now(),
-        queryId,
-        promptId,
-        replied: false,
-        attachments: queryAttachments,
-      });
-      newAgentBubble();
-    },
-    onToolUse(toolUseId, toolName, input) {
-      const prev = findMessage(agent.instanceId, currentAgentMsgId);
-      if (prev) prev.streaming = false;
-      appendMessage(agent.instanceId, {
-        id: randomUUID(),
-        role: "tool",
-        content: "",
-        streaming: false,
-        timestamp: Date.now(),
-        tool: { id: toolUseId, name: toolName, input },
-      });
-      newAgentBubble();
-    },
-    onToolResult(toolUseId, output, isError) {
-      const m = findMessageByToolId(agent.instanceId, toolUseId);
-      if (m && m.tool) {
-        m.tool.result = output;
-        m.tool.isError = isError;
-      }
-    },
-    onCost(turnCostUsd, totalCostUsd) {
-      const m = findMessage(agent.instanceId, currentAgentMsgId);
-      if (m) m.costUsd = turnCostUsd;
-      // For claude-code-headless sessions the running total drives the
-      // session-card cost line in the agent grid.
-      if (isCcSession.value) bumpCcSessionCost(agent.name, totalCostUsd);
-    },
-    onDone() {
-      const m = findMessage(agent.instanceId, currentAgentMsgId);
-      if (m) m.streaming = false;
-      session.activePromptId = null;
-    },
-    onError(message, code, details) {
-      const m = findMessage(agent.instanceId, currentAgentMsgId);
-      if (m) {
-        const detail = code ? ` [${code}]` : "";
-        const extra = details ? ` ${JSON.stringify(details)}` : "";
-        m.error = `${message}${detail}${extra}`;
-        m.streaming = false;
-      }
-      session.activePromptId = null;
-    },
-  });
-  session.activePromptId = promptId;
+  startPromptStream(agent, text, attachments);
 }
 
 function onQueryReply(message: Message, answer: string): void {

--- a/examples/agent-web-ui/src/components/MultiSelectBar.vue
+++ b/examples/agent-web-ui/src/components/MultiSelectBar.vue
@@ -1,0 +1,355 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import AttachmentChips from "./AttachmentChips.vue";
+import { agentsState } from "../stores/agents.ts";
+import { clearSelection, selectionState } from "../stores/selection.ts";
+import { getSession } from "../stores/chat.ts";
+import { fileToAttachment } from "../composables/useBridge.ts";
+import { startPromptStream } from "../composables/promptStreaming.ts";
+
+const text = ref("");
+const files = ref<File[]>([]);
+const fileInput = ref<HTMLInputElement | null>(null);
+const textarea = ref<HTMLTextAreaElement | null>(null);
+const sending = ref(false);
+
+// "Last send report" — sticky inline near the Send button so the user can
+// see how many fired vs. how many were skipped (busy). Cleared on next send
+// or 5s after the last send finishes.
+const lastReport = ref<{ ok: number; busy: number } | null>(null);
+let reportTimer: ReturnType<typeof setTimeout> | null = null;
+
+const selectedAgents = computed(() =>
+  agentsState.list.filter((a) => selectionState.ids.has(a.instanceId)),
+);
+
+const selectedCount = computed(() => selectedAgents.value.length);
+
+const busyCount = computed(() => {
+  let n = 0;
+  for (const a of selectedAgents.value) {
+    if (getSession(a.instanceId).activePromptId !== null) n++;
+  }
+  return n;
+});
+
+const sendableCount = computed(() => selectedCount.value - busyCount.value);
+
+const canSend = computed(
+  () => !sending.value && text.value.trim().length > 0 && sendableCount.value > 0,
+);
+
+function autoResize(): void {
+  const el = textarea.value;
+  if (!el) return;
+  el.style.height = "auto";
+  el.style.height = Math.min(el.scrollHeight, 200) + "px";
+}
+
+watch(text, () => void nextTick(autoResize));
+
+function onKey(e: KeyboardEvent): void {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    void send();
+  }
+}
+
+function pickFiles(): void {
+  fileInput.value?.click();
+}
+
+function onFiles(e: Event): void {
+  const input = e.target as HTMLInputElement;
+  if (!input.files) return;
+  files.value = [...files.value, ...Array.from(input.files)];
+  input.value = "";
+}
+
+function removeFile(i: number): void {
+  files.value = files.value.filter((_, j) => j !== i);
+}
+
+const fileError = ref<string | null>(null);
+
+async function send(): Promise<void> {
+  const t = text.value.trim();
+  if (!t || sending.value) return;
+
+  sending.value = true;
+  fileError.value = null;
+
+  let attachments: Awaited<ReturnType<typeof fileToAttachment>>[] | undefined;
+  if (files.value.length > 0) {
+    try {
+      attachments = await Promise.all(files.value.map(fileToAttachment));
+    } catch (e) {
+      fileError.value = `failed to read file: ${(e as Error).message}`;
+      sending.value = false;
+      return;
+    }
+  }
+
+  // Snapshot the targets at send time so a card removed mid-loop doesn't
+  // shift indices, and so the inline report counts what we attempted.
+  let okN = 0;
+  let busyN = 0;
+  for (const agent of selectedAgents.value) {
+    if (getSession(agent.instanceId).activePromptId !== null) {
+      busyN++;
+      continue;
+    }
+    startPromptStream(agent, t, attachments);
+    okN++;
+  }
+
+  if (reportTimer !== null) clearTimeout(reportTimer);
+  lastReport.value = { ok: okN, busy: busyN };
+  reportTimer = setTimeout(() => {
+    lastReport.value = null;
+    reportTimer = null;
+  }, 5_000);
+
+  text.value = "";
+  files.value = [];
+  sending.value = false;
+}
+
+// Esc clears multi-selection. Close-on-Esc is a stronger expectation than
+// "Esc clears textarea content first" — if the user has unsent text, they
+// can copy it out before pressing Esc.
+function onDocKey(e: KeyboardEvent): void {
+  if (e.key === "Escape" && selectionState.ids.size > 0) {
+    clearSelection();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", onDocKey);
+});
+onUnmounted(() => {
+  document.removeEventListener("keydown", onDocKey);
+  if (reportTimer !== null) clearTimeout(reportTimer);
+});
+</script>
+
+<template>
+  <div class="bar" role="region" aria-label="Multi-select prompt">
+    <div class="bar-head">
+      <span class="count mono">
+        <strong>{{ selectedCount }}</strong> selected
+        <span v-if="busyCount > 0" class="busy-hint mono">
+          · {{ busyCount }} busy
+        </span>
+      </span>
+
+      <span v-if="lastReport" class="report mono">
+        Sent to {{ lastReport.ok }} of {{ lastReport.ok + lastReport.busy }}<template
+          v-if="lastReport.busy > 0"> ({{ lastReport.busy }} busy)</template>
+      </span>
+
+      <span class="bar-spacer" />
+
+      <!-- Phase-2 placeholder. Disabled with an explanatory tooltip so
+           the affordance is visible from day one and the bar's layout
+           doesn't shift when Phase 2 lands. -->
+      <label class="virtual-toggle mono" title="Coming next: aggregate streams into a single virtual session">
+        <input type="checkbox" disabled />
+        <span>Stream all to a virtual session</span>
+      </label>
+
+      <button
+        type="button"
+        class="clear-btn"
+        title="Clear selection (Esc)"
+        @click="clearSelection"
+      >×</button>
+    </div>
+
+    <div v-if="files.length" class="chips-row">
+      <AttachmentChips :files="files" @remove="removeFile" />
+    </div>
+    <div v-if="fileError" class="warn mono">{{ fileError }}</div>
+
+    <div class="row">
+      <button
+        type="button"
+        class="attach-btn"
+        title="Attach files"
+        @click="pickFiles"
+      >📎</button>
+      <input
+        ref="fileInput"
+        type="file"
+        multiple
+        style="display: none"
+        @change="onFiles"
+      />
+
+      <textarea
+        ref="textarea"
+        v-model="text"
+        class="textarea"
+        rows="1"
+        :placeholder="
+          sendableCount === 0
+            ? 'All selected agents are busy — wait for them to finish or pick others'
+            : `Type a prompt — Enter to send to ${sendableCount} agent${sendableCount === 1 ? '' : 's'}`
+        "
+        @keydown="onKey"
+      />
+
+      <button
+        type="button"
+        class="btn send"
+        :disabled="!canSend"
+        @click="send"
+      >Send to {{ sendableCount }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md) var(--space-md);
+  background: var(--bg-secondary);
+  border-top: 1px solid color-mix(in srgb, var(--accent-primary) 35%, transparent);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+  flex-shrink: 0;
+  /* Faint top accent to mark the bar as a layered overlay rather than a
+     pane edge. The sibling `.grid-body` shrinks when this appears, which
+     is the visible "make room for the bar" behaviour the user expects. */
+}
+
+.bar-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  font-size: var(--text-xs);
+}
+.count {
+  color: var(--text-secondary);
+  background: var(--accent-glow);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 35%, transparent);
+}
+.count strong {
+  color: var(--accent-primary);
+  font-weight: 700;
+}
+.busy-hint { color: var(--warning); }
+.report {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.bar-spacer { flex: 1; }
+
+.virtual-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: not-allowed;
+  user-select: none;
+}
+.virtual-toggle input { cursor: not-allowed; }
+
+.clear-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.clear-btn:hover {
+  color: var(--error);
+  border-color: var(--error);
+  background: var(--error-dim);
+}
+
+.chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.warn {
+  font-size: var(--text-xs);
+  color: var(--error);
+  background: var(--error-dim);
+  padding: 4px 8px;
+  border-radius: var(--border-radius-sm);
+}
+
+.row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-sm);
+}
+
+.textarea {
+  flex: 1;
+  min-height: 38px;
+  max-height: 200px;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-primary);
+  border: var(--border-subtle);
+  border-radius: var(--border-radius);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  resize: none;
+  line-height: var(--leading-normal);
+  overflow-y: auto;
+}
+.textarea:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.attach-btn {
+  height: 38px;
+  width: 38px;
+  border: var(--border-subtle);
+  background: var(--bg-primary);
+  border-radius: var(--border-radius);
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+  font-size: 1.1em;
+  cursor: pointer;
+}
+.attach-btn:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.btn {
+  height: 38px;
+  padding: 0 var(--space-lg);
+  border-radius: var(--border-radius);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  transition: all var(--transition-fast);
+  cursor: pointer;
+}
+.btn.send {
+  background: var(--accent-gradient);
+  color: white;
+  border: none;
+}
+.btn.send:hover:not(:disabled) { filter: brightness(1.1); }
+.btn.send:disabled { opacity: 0.4; cursor: not-allowed; }
+</style>

--- a/examples/agent-web-ui/src/composables/promptStreaming.ts
+++ b/examples/agent-web-ui/src/composables/promptStreaming.ts
@@ -67,6 +67,13 @@ export function startPromptStream(
     });
   }
 
+  // `bridge.prompt` invokes `onError` synchronously when the WebSocket is
+  // closed at call time (see `useBridge.ts` — the send guard rejects the
+  // payload before any async hop). The handler clears `activePromptId`,
+  // but we must not then *re-stamp* it with the returned id below — that
+  // would leave the session permanently flagged busy until reload, which
+  // for fan-out would lock every targeted agent on a single network blip.
+  let syncErrored = false;
   let promptId = "";
   promptId = bridge.prompt(instanceId, text, attachments, {
     onResponse(chunk, responseAttachments) {
@@ -129,6 +136,7 @@ export function startPromptStream(
       session.activePromptId = null;
     },
     onError(message, code, details) {
+      syncErrored = true;
       const m = findMessage(instanceId, currentAgentMsgId);
       if (m) {
         const detail = code ? ` [${code}]` : "";
@@ -139,6 +147,6 @@ export function startPromptStream(
       session.activePromptId = null;
     },
   });
-  session.activePromptId = promptId;
+  if (!syncErrored) session.activePromptId = promptId;
   return promptId;
 }

--- a/examples/agent-web-ui/src/composables/promptStreaming.ts
+++ b/examples/agent-web-ui/src/composables/promptStreaming.ts
@@ -1,0 +1,144 @@
+import {
+  appendMessage,
+  findMessage,
+  findMessageByToolId,
+  getSession,
+} from "../stores/chat.ts";
+import { bumpCcSessionCost } from "../stores/ccexec.ts";
+import { useBridge } from "./useBridge.ts";
+import { randomUUID } from "../uuid.ts";
+import type { DiscoveredAgentDTO, WireAttachment } from "../wire.ts";
+
+/**
+ * Fire a prompt against `agent`, mirroring every wire event into the
+ * per-instance chat store: user bubble + agent bubble(s) + tool bubbles +
+ * query bubbles + per-turn cost annotations + onError surfaces. The
+ * returned promptId is also stamped on `getSession(instanceId).activePromptId`
+ * so the chat panel's busy/stop UI works automatically, and so the
+ * MultiSelectBar can detect "this agent is mid-prompt — skip it".
+ *
+ * Shared by `ChatPanel.onSubmit` (single-agent) and `MultiSelectBar.send`
+ * (fan-out across N selected agents). Attachments must already be encoded —
+ * file→WireAttachment conversion stays in the caller so it can surface
+ * read errors in its own UI.
+ */
+export function startPromptStream(
+  agent: DiscoveredAgentDTO,
+  text: string,
+  attachments: WireAttachment[] | undefined,
+): string {
+  const bridge = useBridge();
+  const instanceId = agent.instanceId;
+  const session = getSession(instanceId);
+  const isCcSession =
+    agent.agent === "cc-headless" && agent.metadata?.["role"] === "session";
+
+  const userMsg = appendMessage(instanceId, {
+    id: randomUUID(),
+    role: "user",
+    content: text,
+    streaming: false,
+    timestamp: Date.now(),
+  });
+  if (attachments && attachments.length > 0) {
+    userMsg.attachments = attachments.map((a) => ({
+      filename: a.filename,
+      base64: a.base64,
+    }));
+  }
+
+  let currentAgentMsgId = randomUUID();
+  appendMessage(instanceId, {
+    id: currentAgentMsgId,
+    role: "agent",
+    content: "",
+    streaming: true,
+    timestamp: Date.now(),
+  });
+
+  function newAgentBubble(): void {
+    currentAgentMsgId = randomUUID();
+    appendMessage(instanceId, {
+      id: currentAgentMsgId,
+      role: "agent",
+      content: "",
+      streaming: true,
+      timestamp: Date.now(),
+    });
+  }
+
+  let promptId = "";
+  promptId = bridge.prompt(instanceId, text, attachments, {
+    onResponse(chunk, responseAttachments) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (!m) return;
+      m.content += chunk;
+      if (responseAttachments && responseAttachments.length > 0) {
+        m.attachments = [...(m.attachments ?? []), ...responseAttachments];
+      }
+    },
+    onStatus(status) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (!m) return;
+      if (status === "stopped") m.statusNote = "(stopped)";
+    },
+    onQuery(queryId, queryPrompt, queryAttachments) {
+      const prev = findMessage(instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(instanceId, {
+        id: randomUUID(),
+        role: "query",
+        content: queryPrompt,
+        streaming: false,
+        timestamp: Date.now(),
+        queryId,
+        promptId,
+        replied: false,
+        attachments: queryAttachments,
+      });
+      newAgentBubble();
+    },
+    onToolUse(toolUseId, toolName, input) {
+      const prev = findMessage(instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      appendMessage(instanceId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+      });
+      newAgentBubble();
+    },
+    onToolResult(toolUseId, output, isError) {
+      const m = findMessageByToolId(instanceId, toolUseId);
+      if (m && m.tool) {
+        m.tool.result = output;
+        m.tool.isError = isError;
+      }
+    },
+    onCost(turnCostUsd, totalCostUsd) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) m.costUsd = turnCostUsd;
+      if (isCcSession) bumpCcSessionCost(agent.name, totalCostUsd);
+    },
+    onDone() {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) m.streaming = false;
+      session.activePromptId = null;
+    },
+    onError(message, code, details) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) {
+        const detail = code ? ` [${code}]` : "";
+        const extra = details ? ` ${JSON.stringify(details)}` : "";
+        m.error = `${message}${detail}${extra}`;
+        m.streaming = false;
+      }
+      session.activePromptId = null;
+    },
+  });
+  session.activePromptId = promptId;
+  return promptId;
+}

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -141,10 +141,11 @@ export function bucketOf(agent: DiscoveredAgentDTO): Bucket {
  *   Claude Code → CC Headless Sessions → Hermes → Open Agent →
  *   OpenClaw → PI → PI Headless Sessions → Other
  *
- * Controller buckets are not in this section; they get -1 so a future stray
- * controller can't silently land in the wrong group.
+ * Controller buckets are deliberately absent — they're sorted by the separate
+ * `sortControllers` path. `Partial<>` lets us read with a sentinel fallback
+ * so a future stray bucket sorts to the end instead of crashing.
  */
-const PROMPTABLE_RANK: Record<Bucket, number> = {
+const PROMPTABLE_RANK: Partial<Record<Bucket, number>> = {
   [BUCKETS.CC_AGENT]: 1,
   [BUCKETS.CC_EXEC_SESSION]: 2,
   [BUCKETS.HERMES]: 3,
@@ -153,23 +154,32 @@ const PROMPTABLE_RANK: Record<Bucket, number> = {
   [BUCKETS.PI_AGENT]: 6,
   [BUCKETS.PI_EXEC_SESSION]: 7,
   [BUCKETS.OTHER]: 99,
-  [BUCKETS.PI_EXEC_CONTROL]: -1,
-  [BUCKETS.CC_EXEC_CONTROL]: -1,
 };
 
 function isController(bucket: Bucket): boolean {
   return bucket === BUCKETS.PI_EXEC_CONTROL || bucket === BUCKETS.CC_EXEC_CONTROL;
 }
 
+function byOwnerThenName(a: DiscoveredAgentDTO, b: DiscoveredAgentDTO): number {
+  const o = a.owner.localeCompare(b.owner);
+  if (o !== 0) return o;
+  return a.name.localeCompare(b.name);
+}
+
 function sortPromptables(list: DiscoveredAgentDTO[]): DiscoveredAgentDTO[] {
   return [...list].sort((a, b) => {
-    const ra = PROMPTABLE_RANK[bucketOf(a)];
-    const rb = PROMPTABLE_RANK[bucketOf(b)];
+    const ra = PROMPTABLE_RANK[bucketOf(a)] ?? 99;
+    const rb = PROMPTABLE_RANK[bucketOf(b)] ?? 99;
     if (ra !== rb) return ra - rb;
-    const byOwner = a.owner.localeCompare(b.owner);
-    if (byOwner !== 0) return byOwner;
-    return a.name.localeCompare(b.name);
+    return byOwnerThenName(a, b);
   });
+}
+
+function sortControllers(list: DiscoveredAgentDTO[]): DiscoveredAgentDTO[] {
+  // Controllers don't carry a family rank — there are at most a handful
+  // online at once and they all belong to the same conceptual "Controllers"
+  // group, so a flat owner→name sort is plenty.
+  return [...list].sort(byOwnerThenName);
 }
 
 export type AgentSectionId = "promptables" | "controllers";
@@ -195,7 +205,7 @@ export const agentSections = computed<{ id: AgentSectionId; label: string; agent
     out.push({ id: "promptables", label: "Agents / Sessions", agents: sortPromptables(promptables) });
   }
   if (controllers.length > 0) {
-    out.push({ id: "controllers", label: "Controllers", agents: sortPromptables(controllers) });
+    out.push({ id: "controllers", label: "Controllers", agents: sortControllers(controllers) });
   }
   return out;
 });

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -91,8 +91,10 @@ export const ccexecSessions = computed<DiscoveredAgentDTO[]>(() =>
 );
 
 /**
- * Coarse classification used by the agent grid to group cards. Order maps 1:1
- * with `BUCKET_ORDER` below.
+ * Coarse classification used to colour cards (`AgentCard`) and to split the
+ * grid into the two top-level sections (see `agentSections` below). The
+ * tokens line up with the wire-level `agent` + `metadata.role` so the UI
+ * vocabulary stays one term away from the spec.
  */
 export const BUCKETS = {
   PI_EXEC_SESSION: "pi-exec-session",
@@ -108,34 +110,6 @@ export const BUCKETS = {
 } as const;
 
 export type Bucket = (typeof BUCKETS)[keyof typeof BUCKETS];
-
-export const BUCKET_ORDER: Bucket[] = [
-  BUCKETS.PI_EXEC_SESSION,
-  BUCKETS.PI_EXEC_CONTROL,
-  BUCKETS.CC_EXEC_SESSION,
-  BUCKETS.CC_EXEC_CONTROL,
-  BUCKETS.PI_AGENT,
-  BUCKETS.CC_AGENT,
-  BUCKETS.OPENCLAW,
-  BUCKETS.HERMES,
-  BUCKETS.OPEN_AGENT,
-  BUCKETS.OTHER,
-];
-
-export const BUCKET_LABELS: Record<Bucket, string> = {
-  // Labels track the on-wire `agent` token + `metadata.role` so the UI
-  // vocabulary stays one term away from the docs.
-  [BUCKETS.PI_EXEC_SESSION]: "PI Headless Sessions",
-  [BUCKETS.PI_EXEC_CONTROL]: "PI Headless Controllers",
-  [BUCKETS.CC_EXEC_SESSION]: "Claude Code Headless Sessions",
-  [BUCKETS.CC_EXEC_CONTROL]: "Claude Code Headless Controllers",
-  [BUCKETS.PI_AGENT]: "PI Interactive",
-  [BUCKETS.CC_AGENT]: "Claude Code",
-  [BUCKETS.OPENCLAW]: "OpenClaw",
-  [BUCKETS.HERMES]: "Hermes",
-  [BUCKETS.OPEN_AGENT]: "Open Agent",
-  [BUCKETS.OTHER]: "Other",
-};
 
 export function bucketOf(agent: DiscoveredAgentDTO): Bucket {
   const role = agent.metadata?.["role"];
@@ -159,20 +133,69 @@ export function bucketOf(agent: DiscoveredAgentDTO): Bucket {
   return BUCKETS.OTHER;
 }
 
-/** Returns sorted-by-bucket groups; empty buckets are omitted. */
-export const agentsByBucket = computed<{ bucket: Bucket; label: string; agents: DiscoveredAgentDTO[] }[]>(() => {
-  const map = new Map<Bucket, DiscoveredAgentDTO[]>();
-  for (const b of BUCKET_ORDER) map.set(b, []);
+/**
+ * Top-section ("Agents / Sessions") sort rank. Families ordered alphabetically
+ * by their human label; within a family, the registered agent precedes its
+ * headless sessions so a PI agent and its live PI sessions sit adjacent.
+ *
+ *   Claude Code → CC Headless Sessions → Hermes → Open Agent →
+ *   OpenClaw → PI → PI Headless Sessions → Other
+ *
+ * Controller buckets are not in this section; they get -1 so a future stray
+ * controller can't silently land in the wrong group.
+ */
+const PROMPTABLE_RANK: Record<Bucket, number> = {
+  [BUCKETS.CC_AGENT]: 1,
+  [BUCKETS.CC_EXEC_SESSION]: 2,
+  [BUCKETS.HERMES]: 3,
+  [BUCKETS.OPEN_AGENT]: 4,
+  [BUCKETS.OPENCLAW]: 5,
+  [BUCKETS.PI_AGENT]: 6,
+  [BUCKETS.PI_EXEC_SESSION]: 7,
+  [BUCKETS.OTHER]: 99,
+  [BUCKETS.PI_EXEC_CONTROL]: -1,
+  [BUCKETS.CC_EXEC_CONTROL]: -1,
+};
+
+function isController(bucket: Bucket): boolean {
+  return bucket === BUCKETS.PI_EXEC_CONTROL || bucket === BUCKETS.CC_EXEC_CONTROL;
+}
+
+function sortPromptables(list: DiscoveredAgentDTO[]): DiscoveredAgentDTO[] {
+  return [...list].sort((a, b) => {
+    const ra = PROMPTABLE_RANK[bucketOf(a)];
+    const rb = PROMPTABLE_RANK[bucketOf(b)];
+    if (ra !== rb) return ra - rb;
+    const byOwner = a.owner.localeCompare(b.owner);
+    if (byOwner !== 0) return byOwner;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export type AgentSectionId = "promptables" | "controllers";
+
+/**
+ * Two-section view of the agent list:
+ *  - `promptables` — every prompt-target (registered agents + headless
+ *    sessions), one flat alphabetical grid.
+ *  - `controllers` — pi-headless + cc-headless controller cards.
+ *
+ * Empty sections are omitted entirely so the grid doesn't show vacant
+ * headers on a fresh dashboard.
+ */
+export const agentSections = computed<{ id: AgentSectionId; label: string; agents: DiscoveredAgentDTO[] }[]>(() => {
+  const promptables: DiscoveredAgentDTO[] = [];
+  const controllers: DiscoveredAgentDTO[] = [];
   for (const agent of agentsState.list) {
-    const list = map.get(bucketOf(agent));
-    if (list) list.push(agent);
+    if (isController(bucketOf(agent))) controllers.push(agent);
+    else promptables.push(agent);
   }
-  for (const list of map.values()) sortAgents(list).forEach(() => {}); // sortAgents returns a copy
-  const out: { bucket: Bucket; label: string; agents: DiscoveredAgentDTO[] }[] = [];
-  for (const b of BUCKET_ORDER) {
-    const raw = map.get(b) ?? [];
-    if (raw.length === 0) continue;
-    out.push({ bucket: b, label: BUCKET_LABELS[b], agents: sortAgents(raw) });
+  const out: { id: AgentSectionId; label: string; agents: DiscoveredAgentDTO[] }[] = [];
+  if (promptables.length > 0) {
+    out.push({ id: "promptables", label: "Agents / Sessions", agents: sortPromptables(promptables) });
+  }
+  if (controllers.length > 0) {
+    out.push({ id: "controllers", label: "Controllers", agents: sortPromptables(controllers) });
   }
   return out;
 });

--- a/examples/agent-web-ui/src/stores/selection.ts
+++ b/examples/agent-web-ui/src/stores/selection.ts
@@ -32,14 +32,15 @@ export function clearSelection(): void {
   selectionState.ids.clear();
 }
 
-// Drop selections for agents that vanished from discovery. The watch fires
-// whenever the list changes; we diff against the current set so a normal
-// list refresh that returns the same agents is a no-op. Selections survive
-// transient empties (controller hiccup, brief disconnect) only because the
-// list itself doesn't churn — if the bridge clears the list, selection
-// follows it down.
+// Drop selections for agents that vanished from discovery. We watch the
+// list reference: every mutator in `agents.ts` (`setAgents`, `addAgent`,
+// `removeAgent`) reassigns `agentsState.list`, so reference equality is
+// exactly the right key — fires on add / remove / wholesale refresh, and
+// stays inert on pure selection toggles. Avoids serialising instanceIds
+// into a string key (which would risk false equality if an id ever
+// contained the separator).
 watch(
-  () => agentsState.list.map((a) => a.instanceId).join(","),
+  () => agentsState.list,
   () => {
     const present = new Set(agentsState.list.map((a) => a.instanceId));
     for (const id of [...selectionState.ids]) {

--- a/examples/agent-web-ui/src/stores/selection.ts
+++ b/examples/agent-web-ui/src/stores/selection.ts
@@ -1,0 +1,49 @@
+import { computed, reactive, watch } from "vue";
+import { agentsState } from "./agents.ts";
+
+/**
+ * Multi-select state for the agent grid. A `Set<instanceId>` of cards the
+ * user has ticked via the per-card selection circle, used by the floating
+ * MultiSelectBar to fan out a single prompt to N agents/sessions at once.
+ *
+ * Orthogonal to `agentsState.selectedInstanceId` (which drives the right
+ * panel — what's "open in chat"). The two interactions don't share state,
+ * so a user can keep one chat open while ticking other cards for fan-out.
+ */
+export const selectionState = reactive({
+  ids: new Set<string>(),
+});
+
+export const selectedCount = computed(() => selectionState.ids.size);
+
+export function isSelected(instanceId: string): boolean {
+  return selectionState.ids.has(instanceId);
+}
+
+export function toggleSelection(instanceId: string): void {
+  if (selectionState.ids.has(instanceId)) {
+    selectionState.ids.delete(instanceId);
+  } else {
+    selectionState.ids.add(instanceId);
+  }
+}
+
+export function clearSelection(): void {
+  selectionState.ids.clear();
+}
+
+// Drop selections for agents that vanished from discovery. The watch fires
+// whenever the list changes; we diff against the current set so a normal
+// list refresh that returns the same agents is a no-op. Selections survive
+// transient empties (controller hiccup, brief disconnect) only because the
+// list itself doesn't churn — if the bridge clears the list, selection
+// follows it down.
+watch(
+  () => agentsState.list.map((a) => a.instanceId).join(","),
+  () => {
+    const present = new Set(agentsState.list.map((a) => a.instanceId));
+    for (const id of [...selectionState.ids]) {
+      if (!present.has(id)) selectionState.ids.delete(id);
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Five small steps that together move the dashboard from a per-bucket list view into a cleaner two-section grid with multi-prompt fan-out:

- **Top-row CONTROLLER badge** on pi-headless / cc-headless cards — violet outlined pill complementing the existing tag.
- **Two-section grid**: "Agents / Sessions" (everything promptable, alphabetical by family with agent before session-of-same-family) and "Controllers" (pi-headless + cc-headless only). Empty sections hide entirely; previous per-bucket list collapsed.
- **Equalised card heights per row** + a `flex: 1` spacer above the subject, so the head/title/meta/cwd block anchors to the top while subject/stats/badges/hint dock to the bottom.
- **`startPromptStream` helper** extracted out of `ChatPanel.onSubmit` (no behaviour change for ChatPanel; lets the new bar share the chat-mirroring logic without ~80 lines of duplication).
- **Phase 1 of multi-select fan-out**: a `Set`-based selection store, a hover-revealed circle on each promptable card (controllers + expired sessions excluded), and a slide-up action bar with prompt textarea + attach + Send-to-N + clear-×. Send fans the same prompt out to every selected non-busy agent; each stream lands in its own per-instance chat. Inline report after send: "Sent to 4 of 5 (1 busy)". Esc clears. Selection is in-memory and orthogonal to the right-panel chat.

Phase 2 (the "virtual session" that aggregates streams from N agents into one transcript) is queued for the next PR — the disabled toggle in the bar is its placeholder so the layout doesn't shift when it lands.

## Test plan

- [ ] Top-row badge: only pi-headless and cc-headless **controllers** show CONTROLLER. Sessions and other agent kinds don't.
- [ ] Sections: with mixed agents online, the order in "Agents / Sessions" is Claude Code → CC headless sessions → Hermes → Open Agent → OpenClaw → PI → PI headless sessions. Empty sections vanish.
- [ ] Card heights: in a row mixing a plain Hermes/Claude-Code agent and a CC-headless session with cost + lifetime, all cards in that row are the same height. Subject + badges sit at the bottom edge of each card.
- [ ] Multi-select: hover reveals the circle on agents/sessions, never on controllers and never on expired sessions. Click a few, the bar slides up; Esc dismisses; the × dismisses; clearing while sending works without crashing.
- [ ] Fan-out: with 3+ targets selected, "Send to N" produces a streaming response in each target's own chat panel. With one target mid-prompt, the busy count is correct and the inline report says "Sent to N-1 of N (1 busy)".
- [ ] Right-panel chat keeps working independently while multi-select is active.
- [ ] `claude / Automatic` reviewer bot has nothing load-bearing to flag.