### PR TITLE
agent-web-ui: virtual sessions — aggregate fan-out chats (Phase 2)

### DIFF
--- a/examples/agent-web-ui/src/components/AgentGrid.vue
+++ b/examples/agent-web-ui/src/components/AgentGrid.vue
@@ -2,11 +2,18 @@
 import { computed } from "vue";
 import AgentGroup from "./AgentGroup.vue";
 import MultiSelectBar from "./MultiSelectBar.vue";
+import VirtualSessionsSection from "./VirtualSessionsSection.vue";
 import { agentsState, agentSections } from "../stores/agents.ts";
 import { selectionState } from "../stores/selection.ts";
+import { virtualSessionsList } from "../stores/virtualSessions.ts";
 
 const groups = computed(() => agentSections.value);
-const isEmpty = computed(() => groups.value.length === 0);
+// Empty state for the placeholder card only fires when there are no real
+// agents AND no virtual sessions; a fresh page with virtual sessions
+// alone still needs the grid header chrome.
+const isEmpty = computed(
+  () => groups.value.length === 0 && virtualSessionsList.value.length === 0,
+);
 const hasSelection = computed(() => selectionState.ids.size > 0);
 </script>
 
@@ -33,6 +40,7 @@ const hasSelection = computed(() => selectionState.ids.size > 0);
         </p>
       </div>
       <div v-else class="groups">
+        <VirtualSessionsSection />
         <AgentGroup
           v-for="g in groups"
           :key="g.id"

--- a/examples/agent-web-ui/src/components/MultiSelectBar.vue
+++ b/examples/agent-web-ui/src/components/MultiSelectBar.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import AttachmentChips from "./AttachmentChips.vue";
-import { agentsState } from "../stores/agents.ts";
+import { agentsState, selectAgent } from "../stores/agents.ts";
 import { clearSelection, selectionState } from "../stores/selection.ts";
 import { getSession } from "../stores/chat.ts";
 import { fileToAttachment } from "../composables/useBridge.ts";
 import { startPromptStream } from "../composables/promptStreaming.ts";
+import { startVirtualTurn } from "../composables/virtualPromptStreaming.ts";
+import { createVirtualSession } from "../stores/virtualSessions.ts";
 
 const text = ref("");
 const files = ref<File[]>([]);
 const fileInput = ref<HTMLInputElement | null>(null);
 const textarea = ref<HTMLTextAreaElement | null>(null);
 const sending = ref(false);
+const virtualMode = ref(false);
 
 // "Last send report" — sticky inline near the Send button so the user can
 // see how many fired vs. how many were skipped (busy). Cleared on next send
@@ -35,9 +38,16 @@ const busyCount = computed(() => {
 
 const sendableCount = computed(() => selectedCount.value - busyCount.value);
 
-const canSend = computed(
-  () => !sending.value && text.value.trim().length > 0 && sendableCount.value > 0,
-);
+// In plain fan-out mode we need at least one non-busy target. In virtual
+// mode the selection is locked into the new session and busy targets
+// just get a "(busy — skipped)" placeholder — the user can retry later
+// from inside the virtual chat — so we allow Send as long as something
+// is selected.
+const canSend = computed(() => {
+  if (sending.value || text.value.trim().length === 0) return false;
+  if (virtualMode.value) return selectedCount.value > 0;
+  return sendableCount.value > 0;
+});
 
 function autoResize(): void {
   const el = textarea.value;
@@ -94,13 +104,33 @@ async function send(): Promise<void> {
   // shift indices, and so the inline report counts what we attempted.
   let okN = 0;
   let busyN = 0;
-  for (const agent of selectedAgents.value) {
-    if (getSession(agent.instanceId).activePromptId !== null) {
-      busyN++;
-      continue;
+
+  if (virtualMode.value) {
+    // Phase 2: spin up a virtual session locked to the current selection,
+    // route the right panel to it, and let the virtual transcript host
+    // every future prompt against this same target list. The first turn
+    // also fires immediately so the user sees streaming responses without
+    // a second click.
+    const targetIds = selectedAgents.value.map((a) => a.instanceId);
+    const virtualId = createVirtualSession(targetIds);
+    const report = startVirtualTurn(virtualId, t, attachments);
+    okN = report.ok;
+    busyN = report.busy;
+    selectAgent(virtualId);
+    // Drop the multi-selection — the virtual session is now the surface
+    // for further prompting against this group.
+    clearSelection();
+    // Reset the toggle so the next selection starts in plain fan-out mode.
+    virtualMode.value = false;
+  } else {
+    for (const agent of selectedAgents.value) {
+      if (getSession(agent.instanceId).activePromptId !== null) {
+        busyN++;
+        continue;
+      }
+      startPromptStream(agent, t, attachments);
+      okN++;
     }
-    startPromptStream(agent, t, attachments);
-    okN++;
   }
 
   if (reportTimer !== null) clearTimeout(reportTimer);
@@ -150,11 +180,17 @@ onUnmounted(() => {
 
       <span class="bar-spacer" />
 
-      <!-- Phase-2 placeholder. Disabled with an explanatory tooltip so
-           the affordance is visible from day one and the bar's layout
-           doesn't shift when Phase 2 lands. -->
-      <label class="virtual-toggle mono" title="Coming next: aggregate streams into a single virtual session">
-        <input type="checkbox" disabled />
+      <!-- When ticked, Send creates a new persistent virtual session
+           locked to the current selection, fires the first turn against
+           every target, and switches the right panel to the aggregate
+           transcript. The virtual session keeps the same target list
+           for every subsequent prompt typed into it. -->
+      <label
+        class="virtual-toggle mono"
+        :class="{ active: virtualMode }"
+        title="Create a new virtual session that fans every future prompt out to these N agents"
+      >
+        <input type="checkbox" v-model="virtualMode" />
         <span>Stream all to a virtual session</span>
       </label>
 
@@ -192,9 +228,11 @@ onUnmounted(() => {
         class="textarea"
         rows="1"
         :placeholder="
-          sendableCount === 0
-            ? 'All selected agents are busy — wait for them to finish or pick others'
-            : `Type a prompt — Enter to send to ${sendableCount} agent${sendableCount === 1 ? '' : 's'}`
+          virtualMode
+            ? `Type a prompt — creates a virtual session of ${selectedCount} agent${selectedCount === 1 ? '' : 's'}`
+            : sendableCount === 0
+              ? 'All selected agents are busy — wait for them to finish or pick others'
+              : `Type a prompt — Enter to send to ${sendableCount} agent${sendableCount === 1 ? '' : 's'}`
         "
         @keydown="onKey"
       />
@@ -202,9 +240,13 @@ onUnmounted(() => {
       <button
         type="button"
         class="btn send"
+        :class="{ 'is-virtual': virtualMode }"
         :disabled="!canSend"
         @click="send"
-      >Send to {{ sendableCount }}</button>
+      >
+        <template v-if="virtualMode">Create virtual + send</template>
+        <template v-else>Send to {{ sendableCount }}</template>
+      </button>
     </div>
   </div>
 </template>
@@ -252,12 +294,24 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
-  color: var(--text-dim);
+  color: var(--text-muted);
   font-size: 11px;
-  cursor: not-allowed;
+  cursor: pointer;
   user-select: none;
+  padding: 3px 8px;
+  border-radius: var(--border-radius-sm);
+  border: 1px solid transparent;
+  transition: all var(--transition-fast);
 }
-.virtual-toggle input { cursor: not-allowed; }
+.virtual-toggle:hover {
+  color: var(--text-secondary);
+}
+.virtual-toggle.active {
+  color: var(--bucket-virtual);
+  background: color-mix(in srgb, var(--bucket-virtual) 10%, transparent);
+  border-color: color-mix(in srgb, var(--bucket-virtual) 35%, transparent);
+}
+.virtual-toggle input { cursor: pointer; accent-color: var(--bucket-virtual); }
 
 .clear-btn {
   width: 24px;
@@ -352,4 +406,7 @@ onUnmounted(() => {
 }
 .btn.send:hover:not(:disabled) { filter: brightness(1.1); }
 .btn.send:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn.send.is-virtual {
+  background: linear-gradient(135deg, var(--bucket-virtual), #c026d3);
+}
 </style>

--- a/examples/agent-web-ui/src/components/RightPanel.vue
+++ b/examples/agent-web-ui/src/components/RightPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import ChatPanel from "./ChatPanel.vue";
+import VirtualChatPanel from "./VirtualChatPanel.vue";
 import PiSpawnForm from "./piexec/SpawnForm.vue";
 import PiFanoutPanel from "./piexec/FanoutPanel.vue";
 import CcSpawnForm from "./ccexec/SpawnForm.vue";
@@ -9,6 +10,7 @@ import { selectedAgent } from "../stores/agents.ts";
 import { selectAgent } from "../stores/agents.ts";
 import { piexecState } from "../stores/piexec.ts";
 import { ccexecState } from "../stores/ccexec.ts";
+import { selectedVirtualSession } from "../stores/virtualSessions.ts";
 import type { PiExecSpawnDescriptor, CcExecSpawnDescriptor } from "../wire.ts";
 
 type Tab = "spawn" | "fanout";
@@ -46,8 +48,15 @@ function focusSpawnedSession(d: PiExecSpawnDescriptor | CcExecSpawnDescriptor): 
 
 <template>
   <aside class="right-panel">
+    <!-- Virtual session: aggregate fan-out chat. Wins over the real-agent
+         routing because virtual ids never resolve to a `selectedAgent`. -->
+    <VirtualChatPanel
+      v-if="selectedVirtualSession"
+      :session="selectedVirtualSession"
+    />
+
     <!-- Empty state -->
-    <div v-if="!agent" class="empty">
+    <div v-else-if="!agent" class="empty">
       <div class="empty-inner">
         <h2>Pick something</h2>
         <p>

--- a/examples/agent-web-ui/src/components/VirtualChatPanel.vue
+++ b/examples/agent-web-ui/src/components/VirtualChatPanel.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import MessageBubble from "./MessageBubble.vue";
+import PromptArea from "./PromptArea.vue";
+import { fileToAttachment, useBridge } from "../composables/useBridge.ts";
+import { startVirtualTurn } from "../composables/virtualPromptStreaming.ts";
+import { agentsState } from "../stores/agents.ts";
+import { getSession } from "../stores/chat.ts";
+import {
+  activePromptIdsOf,
+  isVirtualSessionActive,
+  type VirtualSession,
+} from "../stores/virtualSessions.ts";
+
+const props = defineProps<{ session: VirtualSession }>();
+
+const bridge = useBridge();
+const error = ref<string | null>(null);
+const lastReport = ref<{ ok: number; busy: number; offline: number } | null>(null);
+let reportTimer: ReturnType<typeof setTimeout> | null = null;
+
+const messages = computed(() => props.session.messages);
+
+const targetCount = computed(() => props.session.targets.length);
+
+const onlineTargets = computed(() =>
+  props.session.targets.filter((id) =>
+    agentsState.list.some((a) => a.instanceId === id),
+  ),
+);
+
+const sendableTargets = computed(() =>
+  onlineTargets.value.filter(
+    (id) => getSession(id).activePromptId === null,
+  ),
+);
+
+const sendableCount = computed(() => sendableTargets.value.length);
+
+// Busy here = at least one of the locked targets is mid-prompt for this
+// virtual session; the Stop button cancels every per-source stream of any
+// active turn.
+const busy = computed(() => isVirtualSessionActive(props.session.id));
+
+// Auto-scroll: the message list itself manages its scroll position; we
+// just need to nudge it after each new bubble.
+const listRef = ref<HTMLElement | null>(null);
+function scrollToBottom(): void {
+  const el = listRef.value;
+  if (!el) return;
+  el.scrollTop = el.scrollHeight;
+}
+watch(
+  () => messages.value.length,
+  () => void nextTick(scrollToBottom),
+);
+watch(
+  () =>
+    messages.value.length > 0
+      ? messages.value[messages.value.length - 1]?.content
+      : "",
+  () => {
+    const el = listRef.value;
+    if (!el) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 80) {
+      void nextTick(scrollToBottom);
+    }
+  },
+);
+
+// Per-bubble source-header rule: render a header before any sourced
+// bubble whose previous sibling has a different source (or none).
+// Avoids repeating "@derek · CLAUDE-CODE" before every consecutive
+// agent / tool bubble from the same source.
+function showSourceHeader(i: number): boolean {
+  const m = messages.value[i];
+  if (!m || !m.sourceInstanceId) return false;
+  const prev = messages.value[i - 1];
+  if (!prev) return true;
+  return prev.sourceInstanceId !== m.sourceInstanceId;
+}
+
+async function onSubmit(text: string, files: File[]): Promise<void> {
+  let attachments: Awaited<ReturnType<typeof fileToAttachment>>[] | undefined;
+  if (files.length > 0) {
+    try {
+      attachments = await Promise.all(files.map(fileToAttachment));
+    } catch (e) {
+      error.value = `failed to read file: ${(e as Error).message}`;
+      return;
+    }
+  }
+  error.value = null;
+  const report = startVirtualTurn(props.session.id, text, attachments);
+  if (reportTimer !== null) clearTimeout(reportTimer);
+  lastReport.value = { ok: report.ok, busy: report.busy, offline: report.offline };
+  reportTimer = setTimeout(() => {
+    lastReport.value = null;
+    reportTimer = null;
+  }, 5_000);
+}
+
+function onStop(): void {
+  for (const promptId of activePromptIdsOf(props.session.id)) {
+    bridge.cancel(promptId);
+  }
+}
+</script>
+
+<template>
+  <section class="chat-pane">
+    <header class="chat-head">
+      <div class="chat-title">
+        <span class="chat-tag mono">VIRTUAL</span>
+        <span class="chat-name">{{ session.label }}</span>
+      </div>
+      <div class="chat-sub mono">
+        Fans out to {{ onlineTargets.length }} of {{ targetCount }} target{{ targetCount === 1 ? "" : "s" }}
+        <template v-if="lastReport">
+          · last send: {{ lastReport.ok }}<template v-if="lastReport.busy + lastReport.offline > 0">
+            ({{ lastReport.busy }} busy, {{ lastReport.offline }} offline)</template>
+        </template>
+      </div>
+    </header>
+
+    <div v-if="error" class="error mono">{{ error }}</div>
+
+    <div ref="listRef" class="list">
+      <div v-if="messages.length === 0" class="empty">
+        <p>No messages yet.</p>
+        <p class="hint">
+          Type a prompt below — it will fan out to all {{ targetCount }} target{{ targetCount === 1 ? "" : "s" }} and
+          stream every response into this transcript.
+        </p>
+      </div>
+      <template v-for="(m, i) in messages" :key="m.id">
+        <div v-if="showSourceHeader(i)" class="source-header">
+          <span class="source-label mono">{{ m.sourceLabel }}</span>
+        </div>
+        <MessageBubble :message="m" />
+      </template>
+    </div>
+
+    <PromptArea
+      :busy="busy"
+      :disabled="sendableCount === 0 && !busy"
+      :attachments-ok="true"
+      @submit="onSubmit"
+      @stop="onStop"
+    />
+  </section>
+</template>
+
+<style scoped>
+.chat-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg-deep);
+}
+.chat-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-md) var(--space-lg);
+  background: var(--bg-primary);
+  border-bottom: var(--border-subtle);
+  flex-shrink: 0;
+}
+.chat-title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+.chat-tag {
+  font-size: var(--text-xs);
+  color: var(--bucket-virtual);
+  background: color-mix(in srgb, var(--bucket-virtual) 14%, transparent);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.chat-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.chat-sub {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+.error {
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--text-xs);
+  color: var(--error);
+  background: var(--error-dim);
+  border-bottom: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+.list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  overflow-y: auto;
+  background: var(--bg-deep);
+}
+.empty {
+  margin: auto;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  max-width: 420px;
+}
+.hint {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  margin-top: var(--space-xs);
+  line-height: var(--leading-relaxed);
+}
+
+/* Per-source headers split the linear transcript into one labelled block
+   per agent per turn. The label is the only visual marker that bubbles
+   below it came from a specific source (ToolBubble + AgentBubble can
+   both follow without a repeated header). */
+.source-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: var(--space-md) 0 calc(var(--space-md) * -1 + var(--space-xs));
+  padding: 0 var(--space-xs);
+}
+.source-header::before,
+.source-header::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: color-mix(in srgb, var(--bucket-virtual) 18%, transparent);
+}
+.source-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bucket-virtual);
+  padding: 2px 8px;
+  border-radius: var(--border-radius-sm);
+  background: color-mix(in srgb, var(--bucket-virtual) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--bucket-virtual) 20%, transparent);
+}
+</style>

--- a/examples/agent-web-ui/src/components/VirtualChatPanel.vue
+++ b/examples/agent-web-ui/src/components/VirtualChatPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 import MessageBubble from "./MessageBubble.vue";
 import PromptArea from "./PromptArea.vue";
 import { fileToAttachment, useBridge } from "../composables/useBridge.ts";
@@ -105,6 +105,13 @@ function onStop(): void {
     bridge.cancel(promptId);
   }
 }
+
+// Clear the inline-report timer if the user navigates away mid-countdown
+// (e.g. opens a different session or deletes this one) — otherwise the
+// callback fires into an orphaned ref and emits an unhandled warning.
+onUnmounted(() => {
+  if (reportTimer !== null) clearTimeout(reportTimer);
+});
 </script>
 
 <template>

--- a/examples/agent-web-ui/src/components/VirtualSessionCard.vue
+++ b/examples/agent-web-ui/src/components/VirtualSessionCard.vue
@@ -33,8 +33,10 @@ function onTrash(e: Event): void {
   e.stopPropagation();
   if (!confirm(`Delete ${props.session.label}?`)) return;
   // Cancel any in-flight per-source streams so nothing keeps writing into
-  // a session we're about to drop.
-  for (const promptId of props.session.activePromptIds.values()) {
+  // a session we're about to drop. Snapshot the values first so a future
+  // bridge.cancel that synchronously mutates the map (it doesn't today)
+  // wouldn't break the iteration mid-loop.
+  for (const promptId of [...props.session.activePromptIds.values()]) {
     bridge.cancel(promptId);
   }
   deleteVirtualSession(props.session.id);

--- a/examples/agent-web-ui/src/components/VirtualSessionCard.vue
+++ b/examples/agent-web-ui/src/components/VirtualSessionCard.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { agentsState, selectAgent } from "../stores/agents.ts";
+import {
+  deleteVirtualSession,
+  isVirtualSessionActive,
+  virtualTargetLabel,
+  type VirtualSession,
+} from "../stores/virtualSessions.ts";
+import { useBridge } from "../composables/useBridge.ts";
+
+const props = defineProps<{ session: VirtualSession }>();
+
+const bridge = useBridge();
+
+const selected = computed(
+  () => agentsState.selectedInstanceId === props.session.id,
+);
+
+const targetLabels = computed(() =>
+  props.session.targets.map((id) => {
+    const agent = agentsState.list.find((a) => a.instanceId === id);
+    if (!agent) return { label: `${id.slice(0, 8)}…`, online: false };
+    return { label: virtualTargetLabel(agent), online: true };
+  }),
+);
+
+const onlineCount = computed(() => targetLabels.value.filter((t) => t.online).length);
+
+const running = computed(() => isVirtualSessionActive(props.session.id));
+
+function onTrash(e: Event): void {
+  e.stopPropagation();
+  if (!confirm(`Delete ${props.session.label}?`)) return;
+  // Cancel any in-flight per-source streams so nothing keeps writing into
+  // a session we're about to drop.
+  for (const promptId of props.session.activePromptIds.values()) {
+    bridge.cancel(promptId);
+  }
+  deleteVirtualSession(props.session.id);
+}
+</script>
+
+<template>
+  <div class="card-wrap">
+    <div
+      class="card"
+      :class="{ selected }"
+      role="button"
+      tabindex="0"
+      @click="selectAgent(session.id)"
+      @keydown.enter.prevent="selectAgent(session.id)"
+      @keydown.space.prevent="selectAgent(session.id)"
+    >
+      <header class="card-head">
+        <div class="head-tags">
+          <span class="agent-tag mono">VIRTUAL</span>
+          <span v-if="running" class="running-tag mono" title="At least one target is mid-stream">running</span>
+        </div>
+      </header>
+
+      <h3 class="card-title">{{ session.label }}</h3>
+
+      <p class="meta mono">
+        <span>{{ onlineCount }} of {{ session.targets.length }} online</span>
+      </p>
+
+      <div class="grow-spacer" aria-hidden="true" />
+
+      <ul class="targets">
+        <li
+          v-for="(t, i) in targetLabels"
+          :key="i"
+          class="target mono"
+          :class="{ offline: !t.online }"
+          :title="t.label"
+        >{{ t.label }}</li>
+      </ul>
+    </div>
+
+    <button
+      type="button"
+      class="trash-btn"
+      title="Delete virtual session"
+      @click.stop="onTrash"
+    >
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M3 6h18" />
+        <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.card-wrap {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  flex: 1;
+  padding: var(--space-md);
+  background: var(--bg-secondary);
+  border: 1px solid color-mix(in srgb, var(--bucket-virtual) 30%, transparent);
+  border-radius: var(--border-radius);
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  width: 100%;
+  overflow: hidden;
+  /* Subtle vertical wash that distinguishes virtual cards from agent
+     cards at a glance — same affordance pattern as the controller card's
+     violet wash. */
+  background: linear-gradient(
+    180deg,
+    var(--bg-secondary) 0%,
+    color-mix(in srgb, var(--bucket-virtual) 6%, var(--bg-secondary)) 100%
+  );
+}
+.card:hover {
+  background: var(--bg-tertiary);
+  border-color: color-mix(in srgb, var(--bucket-virtual) 55%, transparent);
+  transform: translateY(-1px);
+}
+.card:focus-visible {
+  outline: 2px solid var(--bucket-virtual);
+  outline-offset: 2px;
+}
+.card.selected {
+  border-color: var(--bucket-virtual);
+  box-shadow:
+    0 0 0 1px var(--bucket-virtual),
+    0 0 18px color-mix(in srgb, var(--bucket-virtual) 30%, transparent);
+}
+
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+.head-tags {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+.agent-tag {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bucket-virtual);
+  background: color-mix(in srgb, var(--bucket-virtual) 14%, transparent);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+}
+.running-tag {
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: var(--border-radius-sm);
+  background: var(--accent-glow);
+  color: var(--accent-primary);
+}
+
+.card-title {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.grow-spacer { flex: 1; min-height: 0; }
+
+.targets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.target {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: var(--border-radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.target.offline {
+  color: var(--text-dim);
+  text-decoration: line-through;
+}
+
+.trash-btn {
+  position: absolute;
+  bottom: var(--space-md);
+  right: var(--space-sm);
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  color: var(--error);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  z-index: 1;
+}
+.trash-btn:hover {
+  background: var(--error-dim);
+  border-color: var(--error);
+  transform: scale(1.08);
+}
+.trash-btn .icon { width: 11px; height: 11px; display: block; }
+.card-wrap:hover .trash-btn { transform: translateY(-1px); }
+.card-wrap:hover .trash-btn:hover { transform: translateY(-1px) scale(1.08); }
+</style>

--- a/examples/agent-web-ui/src/components/VirtualSessionsSection.vue
+++ b/examples/agent-web-ui/src/components/VirtualSessionsSection.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import VirtualSessionCard from "./VirtualSessionCard.vue";
+import { virtualSessionsList } from "../stores/virtualSessions.ts";
+</script>
+
+<template>
+  <section v-if="virtualSessionsList.length > 0" class="group">
+    <header class="group-head">
+      <h2 class="group-title">Virtual Sessions</h2>
+      <span class="group-count mono">{{ virtualSessionsList.length }}</span>
+    </header>
+    <div class="group-grid">
+      <VirtualSessionCard
+        v-for="vs in virtualSessionsList"
+        :key="vs.id"
+        :session="vs"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+.group-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  padding-bottom: var(--space-xs);
+  border-bottom: var(--border-subtle);
+}
+.group-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--bucket-virtual);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+.group-count {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  border: var(--border-subtle);
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.group-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--space-md);
+}
+</style>

--- a/examples/agent-web-ui/src/composables/virtualPromptStreaming.ts
+++ b/examples/agent-web-ui/src/composables/virtualPromptStreaming.ts
@@ -1,0 +1,333 @@
+import {
+  appendMessage,
+  findMessage,
+  findMessageByToolId,
+  getSession,
+} from "../stores/chat.ts";
+import { agentsState } from "../stores/agents.ts";
+import { bumpCcSessionCost } from "../stores/ccexec.ts";
+import {
+  appendVirtualMessage,
+  findVirtualMessage,
+  findVirtualMessageByToolId,
+  getVirtualSession,
+  trackVirtualPrompt,
+  untrackVirtualPrompt,
+  virtualTargetLabel,
+} from "../stores/virtualSessions.ts";
+import { useBridge } from "./useBridge.ts";
+import { randomUUID } from "../uuid.ts";
+import type { DiscoveredAgentDTO, WireAttachment } from "../wire.ts";
+
+export type VirtualTurnReport = {
+  /** Real prompts dispatched (one bridge.prompt per non-busy, online target). */
+  ok: number;
+  /** Targets skipped because they're already mid-prompt. */
+  busy: number;
+  /** Targets skipped because they're no longer in the discovered list. */
+  offline: number;
+  /** Stable id for this turn — every bubble produced shares it. */
+  turnId: string;
+};
+
+/**
+ * Fire one prompt against every locked target of a virtual session and
+ * mirror each per-source stream into both the per-instance chat AND the
+ * virtual transcript. Returns a report so the caller (the virtual chat
+ * panel) can render an inline "sent to N of M" badge.
+ *
+ * The user prompt becomes one bubble in the virtual transcript (with an
+ * optional matching user bubble in each per-instance chat). Each non-busy,
+ * online target gets a streaming agent bubble in BOTH places, sharing the
+ * `turnId` so future grouping/styling can locate them. Offline and busy
+ * targets get a tiny synthetic placeholder bubble in the virtual transcript
+ * only (no per-instance pollution since no prompt actually fires).
+ */
+export function startVirtualTurn(
+  virtualId: string,
+  text: string,
+  attachments: WireAttachment[] | undefined,
+): VirtualTurnReport {
+  const turnId = randomUUID();
+  const report: VirtualTurnReport = { ok: 0, busy: 0, offline: 0, turnId };
+
+  const vs = getVirtualSession(virtualId);
+  if (!vs) return report;
+
+  // 1. The user prompt itself — one bubble at the top of the turn.
+  const userMsgId = randomUUID();
+  appendVirtualMessage(virtualId, {
+    id: userMsgId,
+    role: "user",
+    content: text,
+    streaming: false,
+    timestamp: Date.now(),
+    attachments: attachments?.map((a) => ({ filename: a.filename, base64: a.base64 })),
+    turnId,
+  });
+
+  // 2. For each locked target: classify (online/offline/busy) and either
+  //    fire a real stream or drop a synthetic placeholder.
+  for (const targetId of vs.targets) {
+    const agent = agentsState.list.find((a) => a.instanceId === targetId);
+    if (!agent) {
+      appendVirtualMessage(virtualId, {
+        id: randomUUID(),
+        role: "agent",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        statusNote: "(offline — skipped)",
+        sourceInstanceId: targetId,
+        sourceLabel: `instanceId ${targetId.slice(0, 8)}…`,
+        turnId,
+      });
+      report.offline += 1;
+      continue;
+    }
+
+    if (getSession(targetId).activePromptId !== null) {
+      appendVirtualMessage(virtualId, {
+        id: randomUUID(),
+        role: "agent",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        statusNote: "(busy — skipped)",
+        sourceInstanceId: targetId,
+        sourceLabel: virtualTargetLabel(agent),
+        turnId,
+      });
+      report.busy += 1;
+      continue;
+    }
+
+    fanoutOneTarget(virtualId, agent, text, attachments, turnId);
+    report.ok += 1;
+  }
+
+  return report;
+}
+
+/**
+ * Fire one prompt against `agent` and tee every wire event into both:
+ *   1. the agent's per-instance chat (so the agent's own ChatPanel
+ *      shows the same response), and
+ *   2. the virtual session transcript (the aggregate view).
+ *
+ * Mirrors the bubble lifecycle of `startPromptStream` (single-agent) +
+ * an additional virtual-side mirror. The duplication is bounded: every
+ * SDK callback handles two store writes, but the structure stays linear.
+ */
+function fanoutOneTarget(
+  virtualId: string,
+  agent: DiscoveredAgentDTO,
+  text: string,
+  attachments: WireAttachment[] | undefined,
+  turnId: string,
+): void {
+  const bridge = useBridge();
+  const instanceId = agent.instanceId;
+  const sourceLabel = virtualTargetLabel(agent);
+  const session = getSession(instanceId);
+  const isCcSession =
+    agent.agent === "cc-headless" && agent.metadata?.["role"] === "session";
+
+  // ----- per-instance chat: user bubble + initial agent bubble -----
+  const userMsg = appendMessage(instanceId, {
+    id: randomUUID(),
+    role: "user",
+    content: text,
+    streaming: false,
+    timestamp: Date.now(),
+  });
+  if (attachments && attachments.length > 0) {
+    userMsg.attachments = attachments.map((a) => ({ filename: a.filename, base64: a.base64 }));
+  }
+
+  let currentAgentMsgId = randomUUID();
+  appendMessage(instanceId, {
+    id: currentAgentMsgId,
+    role: "agent",
+    content: "",
+    streaming: true,
+    timestamp: Date.now(),
+  });
+
+  // ----- virtual transcript: initial agent bubble -----
+  let currentVirtualMsgId = randomUUID();
+  appendVirtualMessage(virtualId, {
+    id: currentVirtualMsgId,
+    role: "agent",
+    content: "",
+    streaming: true,
+    timestamp: Date.now(),
+    sourceInstanceId: instanceId,
+    sourceLabel,
+    turnId,
+  });
+
+  function newPerInstanceAgentBubble(): void {
+    currentAgentMsgId = randomUUID();
+    appendMessage(instanceId, {
+      id: currentAgentMsgId,
+      role: "agent",
+      content: "",
+      streaming: true,
+      timestamp: Date.now(),
+    });
+  }
+  function newVirtualAgentBubble(): void {
+    currentVirtualMsgId = randomUUID();
+    appendVirtualMessage(virtualId, {
+      id: currentVirtualMsgId,
+      role: "agent",
+      content: "",
+      streaming: true,
+      timestamp: Date.now(),
+      sourceInstanceId: instanceId,
+      sourceLabel,
+      turnId,
+    });
+  }
+
+  let syncErrored = false;
+  let promptId = "";
+  promptId = bridge.prompt(instanceId, text, attachments, {
+    onResponse(chunk, responseAttachments) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) {
+        m.content += chunk;
+        if (responseAttachments && responseAttachments.length > 0) {
+          m.attachments = [...(m.attachments ?? []), ...responseAttachments];
+        }
+      }
+      const vm = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (vm) {
+        vm.content += chunk;
+        if (responseAttachments && responseAttachments.length > 0) {
+          vm.attachments = [...(vm.attachments ?? []), ...responseAttachments];
+        }
+      }
+    },
+    onStatus(status) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m && status === "stopped") m.statusNote = "(stopped)";
+      const vm = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (vm && status === "stopped") vm.statusNote = "(stopped)";
+    },
+    onQuery(queryId, queryPrompt, queryAttachments) {
+      const prev = findMessage(instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      const prevV = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (prevV) prevV.streaming = false;
+      // Per-instance: queries are interactive so promptId is wired up.
+      appendMessage(instanceId, {
+        id: randomUUID(),
+        role: "query",
+        content: queryPrompt,
+        streaming: false,
+        timestamp: Date.now(),
+        queryId,
+        promptId,
+        replied: false,
+        attachments: queryAttachments,
+      });
+      // Virtual: queries from inside an aggregate are read-only — replying
+      // back to a single source from the virtual chat is out of scope for
+      // Phase 2. Render the prompt as a non-interactive query bubble.
+      appendVirtualMessage(virtualId, {
+        id: randomUUID(),
+        role: "query",
+        content: queryPrompt,
+        streaming: false,
+        timestamp: Date.now(),
+        queryId,
+        promptId,
+        replied: true,
+        sourceInstanceId: instanceId,
+        sourceLabel,
+        turnId,
+        attachments: queryAttachments,
+      });
+      newPerInstanceAgentBubble();
+      newVirtualAgentBubble();
+    },
+    onToolUse(toolUseId, toolName, input) {
+      const prev = findMessage(instanceId, currentAgentMsgId);
+      if (prev) prev.streaming = false;
+      const prevV = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (prevV) prevV.streaming = false;
+      appendMessage(instanceId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+      });
+      appendVirtualMessage(virtualId, {
+        id: randomUUID(),
+        role: "tool",
+        content: "",
+        streaming: false,
+        timestamp: Date.now(),
+        tool: { id: toolUseId, name: toolName, input },
+        sourceInstanceId: instanceId,
+        sourceLabel,
+        turnId,
+      });
+      newPerInstanceAgentBubble();
+      newVirtualAgentBubble();
+    },
+    onToolResult(toolUseId, output, isError) {
+      const m = findMessageByToolId(instanceId, toolUseId);
+      if (m && m.tool) {
+        m.tool.result = output;
+        m.tool.isError = isError;
+      }
+      const vm = findVirtualMessageByToolId(virtualId, toolUseId);
+      if (vm && vm.tool) {
+        vm.tool.result = output;
+        vm.tool.isError = isError;
+      }
+    },
+    onCost(turnCostUsd, totalCostUsd) {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) m.costUsd = turnCostUsd;
+      const vm = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (vm) vm.costUsd = turnCostUsd;
+      if (isCcSession) bumpCcSessionCost(agent.name, totalCostUsd);
+    },
+    onDone() {
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) m.streaming = false;
+      const vm = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (vm) vm.streaming = false;
+      session.activePromptId = null;
+      untrackVirtualPrompt(virtualId, turnId, instanceId);
+    },
+    onError(message, code, details) {
+      syncErrored = true;
+      const detail = code ? ` [${code}]` : "";
+      const extra = details ? ` ${JSON.stringify(details)}` : "";
+      const formatted = `${message}${detail}${extra}`;
+      const m = findMessage(instanceId, currentAgentMsgId);
+      if (m) {
+        m.error = formatted;
+        m.streaming = false;
+      }
+      const vm = findVirtualMessage(virtualId, currentVirtualMsgId);
+      if (vm) {
+        vm.error = formatted;
+        vm.streaming = false;
+      }
+      session.activePromptId = null;
+      untrackVirtualPrompt(virtualId, turnId, instanceId);
+    },
+  });
+  if (!syncErrored) {
+    session.activePromptId = promptId;
+    trackVirtualPrompt(virtualId, turnId, instanceId, promptId);
+  }
+}

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -26,11 +26,12 @@ export function selectAgent(instanceId: string | null): void {
 export function setAgents(list: DiscoveredAgentDTO[]): void {
   agentsState.list = list;
   agentsState.lastDiscoveredAt = Date.now();
-  // If the previously selected agent vanished, clear selection.
-  if (
-    agentsState.selectedInstanceId &&
-    !list.some((a) => a.instanceId === agentsState.selectedInstanceId)
-  ) {
+  // If the previously selected agent vanished, clear selection — but
+  // skip this for virtual-session ids (`virtual:<uuid>`) which are
+  // UI-only entities not present in `list` and shouldn't be wiped on
+  // every refresh.
+  const sel = agentsState.selectedInstanceId;
+  if (sel && !sel.startsWith("virtual:") && !list.some((a) => a.instanceId === sel)) {
     agentsState.selectedInstanceId = null;
   }
 }

--- a/examples/agent-web-ui/src/stores/agents.ts
+++ b/examples/agent-web-ui/src/stores/agents.ts
@@ -1,5 +1,6 @@
 import { reactive, computed } from "vue";
 import type { DiscoveredAgentDTO } from "../wire.ts";
+import { isVirtualId } from "./virtualSessions.ts";
 
 export const agentsState = reactive<{
   list: DiscoveredAgentDTO[];
@@ -29,9 +30,11 @@ export function setAgents(list: DiscoveredAgentDTO[]): void {
   // If the previously selected agent vanished, clear selection — but
   // skip this for virtual-session ids (`virtual:<uuid>`) which are
   // UI-only entities not present in `list` and shouldn't be wiped on
-  // every refresh.
+  // every refresh. The prefix check goes through the canonical helper
+  // exported from `virtualSessions.ts` so the prefix string lives in
+  // exactly one place.
   const sel = agentsState.selectedInstanceId;
-  if (sel && !sel.startsWith("virtual:") && !list.some((a) => a.instanceId === sel)) {
+  if (sel && !isVirtualId(sel) && !list.some((a) => a.instanceId === sel)) {
     agentsState.selectedInstanceId = null;
   }
 }

--- a/examples/agent-web-ui/src/stores/virtualSessions.ts
+++ b/examples/agent-web-ui/src/stores/virtualSessions.ts
@@ -1,0 +1,188 @@
+import { computed, reactive } from "vue";
+import { agentsState } from "./agents.ts";
+import type { Message } from "./chat.ts";
+import type { DiscoveredAgentDTO, WireAttachment } from "../wire.ts";
+import { randomUUID } from "../uuid.ts";
+
+/**
+ * UI-only "virtual sessions" — synthetic right-panel conversations that
+ * fan out every prompt to a locked set of real agents and aggregate the
+ * streamed responses into a single transcript.
+ *
+ *  - Created from the multi-select bar by ticking
+ *    "Stream all to a virtual session" before pressing Send.
+ *  - Persistent for the page lifetime; cleared on reload.
+ *  - Targets are locked at creation; a target that vanishes from
+ *    discovery is silently skipped on subsequent prompts.
+ *  - Lives entirely in the browser. The wire surface is unchanged —
+ *    each prompt is N independent `bridge.prompt` calls under the hood.
+ *
+ * IDs use a `virtual:` prefix so the existing `agentsState.selectedInstanceId`
+ * can address either a real agent (instanceId is a UUID) or a virtual
+ * session (instanceId starts with `virtual:`). The right panel routes on
+ * the prefix.
+ */
+
+export type VirtualMessage = Message & {
+  /** instanceId of the real agent that produced this bubble. Absent on the
+   *  user prompt and on synthetic "(busy)" / "(offline)" placeholders. */
+  sourceInstanceId?: string;
+  /** Cosmetic display label cached at message-create time, so historical
+   *  bubbles still render meaningfully if the source agent later vanishes. */
+  sourceLabel?: string;
+  /** Per-turn group key. Every bubble produced by a single Send share one. */
+  turnId?: string;
+};
+
+export type VirtualSession = {
+  id: string;
+  label: string;
+  /** instanceIds of the real agents this virtual session fans out to.
+   *  Captured at creation time and never mutated thereafter. */
+  targets: string[];
+  messages: VirtualMessage[];
+  /** Active per-source promptIds keyed by `${turnId}:${sourceInstanceId}`,
+   *  so the chat panel's Stop button can cancel the whole turn at once. */
+  activePromptIds: Map<string, string>;
+};
+
+type VirtualSessionsState = {
+  sessions: Map<string, VirtualSession>;
+  counter: number;
+};
+
+export const virtualSessionsState = reactive<VirtualSessionsState>({
+  sessions: new Map(),
+  counter: 0,
+});
+
+const VIRTUAL_PREFIX = "virtual:";
+
+export function isVirtualId(id: string | null | undefined): boolean {
+  return typeof id === "string" && id.startsWith(VIRTUAL_PREFIX);
+}
+
+export const virtualSessionsList = computed<VirtualSession[]>(() =>
+  Array.from(virtualSessionsState.sessions.values()),
+);
+
+export const selectedVirtualSession = computed<VirtualSession | null>(() => {
+  const id = agentsState.selectedInstanceId;
+  if (!id || !isVirtualId(id)) return null;
+  return virtualSessionsState.sessions.get(id) ?? null;
+});
+
+/** Build a friendly per-target label like "@derek · CLAUDE-CODE". Falls
+ *  back to the wire token uppercased if no friendlier mapping exists. */
+export function virtualTargetLabel(agent: DiscoveredAgentDTO): string {
+  const a = agent.agent;
+  let display = a.toUpperCase();
+  if (a === "claude-code" || a === "cc" || a === "ccc") display = "CLAUDE CODE";
+  else if (a === "openclaw" || a === "oc") display = "OPENCLAW";
+  else if (a === "pi") display = "PI";
+  else if (a === "hermes") display = "HERMES";
+  else if (a === "open-agent") display = "OPEN AGENT";
+  else if (a === "pi-headless") display = "PI HEADLESS";
+  else if (a === "cc-headless") display = "CC HEADLESS";
+  const session = agent.session && agent.session !== agent.name ? ` ${agent.session}` : "";
+  return `@${agent.owner} · ${display}${session}`;
+}
+
+/**
+ * Create a new virtual session locked to `targetIds`. Returns the new
+ * session id (with the `virtual:` prefix). Caller is responsible for
+ * routing the right panel to it via `selectAgent(newId)` if desired.
+ */
+export function createVirtualSession(targetIds: string[]): string {
+  virtualSessionsState.counter += 1;
+  const id = `${VIRTUAL_PREFIX}${randomUUID()}`;
+  const n = targetIds.length;
+  const label = `Virtual #${virtualSessionsState.counter} (${n} agent${n === 1 ? "" : "s"})`;
+  virtualSessionsState.sessions.set(id, {
+    id,
+    label,
+    targets: [...targetIds],
+    messages: [],
+    activePromptIds: new Map(),
+  });
+  return id;
+}
+
+export function deleteVirtualSession(id: string): void {
+  virtualSessionsState.sessions.delete(id);
+  if (agentsState.selectedInstanceId === id) {
+    agentsState.selectedInstanceId = null;
+  }
+}
+
+export function getVirtualSession(id: string): VirtualSession | undefined {
+  return virtualSessionsState.sessions.get(id);
+}
+
+export function appendVirtualMessage(
+  virtualId: string,
+  msg: VirtualMessage,
+): VirtualMessage | undefined {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return undefined;
+  vs.messages.push(msg);
+  return vs.messages[vs.messages.length - 1];
+}
+
+export function findVirtualMessage(
+  virtualId: string,
+  messageId: string,
+): VirtualMessage | undefined {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return undefined;
+  return vs.messages.find((m) => m.id === messageId);
+}
+
+export function findVirtualMessageByToolId(
+  virtualId: string,
+  toolUseId: string,
+): VirtualMessage | undefined {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return undefined;
+  return vs.messages.find((m) => m.role === "tool" && m.tool?.id === toolUseId);
+}
+
+/** Whether ANY turn in the virtual session is still in flight. */
+export function isVirtualSessionActive(virtualId: string): boolean {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return false;
+  return vs.activePromptIds.size > 0;
+}
+
+/** Snapshot of currently-active per-source promptIds (for the Stop button). */
+export function activePromptIdsOf(virtualId: string): string[] {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return [];
+  return [...vs.activePromptIds.values()];
+}
+
+/** Used by virtualPromptStreaming on stream init/teardown to track which
+ *  per-source streams are still live for the Stop button. */
+export function trackVirtualPrompt(
+  virtualId: string,
+  turnId: string,
+  sourceInstanceId: string,
+  promptId: string,
+): void {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return;
+  vs.activePromptIds.set(`${turnId}:${sourceInstanceId}`, promptId);
+}
+
+export function untrackVirtualPrompt(
+  virtualId: string,
+  turnId: string,
+  sourceInstanceId: string,
+): void {
+  const vs = virtualSessionsState.sessions.get(virtualId);
+  if (!vs) return;
+  vs.activePromptIds.delete(`${turnId}:${sourceInstanceId}`);
+}
+
+/** Re-export so the prompt-area can show attachment-handling badges. */
+export type { WireAttachment };

--- a/examples/agent-web-ui/src/styles/variables.css
+++ b/examples/agent-web-ui/src/styles/variables.css
@@ -47,6 +47,8 @@
   --bucket-hermes: #f59e0b;                 /* amber / orange */
   --bucket-open-agent: #34d399;             /* emerald — open-agent bridge */
   --bucket-other: var(--text-muted);        /* muted gray */
+  --bucket-virtual: #e879f9;                /* fuchsia — UI-only virtual sessions
+                                                that fan out to N real agents */
 
   /* Typography */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',


### PR DESCRIPTION
## Summary

Builds on PR #86's multi-select fan-out. Ticking the new "Stream all to a virtual session" toggle in the multi-select bar + Send creates a persistent UI-only **virtual session** locked to the current selection: every prompt fans out to the same N agents and aggregates the streamed responses into one transcript. State is in-memory only — refreshing the page clears virtual sessions.

- **New top section "Virtual Sessions"** above Agents / Sessions in the grid; hidden when none exist (matches our hide-empty-section rule). Fuchsia palette entry (`--bucket-virtual`) so virtual cards are distinct from agent / controller / session families.
- **Per-card UI**: VIRTUAL pill, label ("Virtual #1 (3 agents)"), online-target count, full target list (offline targets are line-through), and a trash button that cancels in-flight streams before deletion.
- **VirtualChatPanel** opens in the right panel when a virtual card is selected. One linear transcript with: one user bubble per turn, then one streaming bubble per non-busy target. Per-source headers ("@derek · CLAUDE-CODE") render between bubbles when the source changes — they don't repeat across consecutive bubbles from the same source (so a tool-use → tool-result → agent-text sequence from one agent stays under a single header).
- **Streams mirror to both** the per-instance chat and the virtual transcript, so an agent's own ChatPanel stays consistent if you click into it. Tool calls, query bubbles, per-turn cost, attachments, and stop are all wired up.
- **Offline / busy targets** at send time get a `(offline — skipped)` / `(busy — skipped)` placeholder bubble in the virtual transcript and no real prompt fires. Subsequent prompts (after the busy ones free up) fan out normally.

## Implementation notes

- `stores/virtualSessions.ts`: reactive `Map` of sessions keyed by `virtual:<uuid>`. The id prefix lets the existing `agentsState.selectedInstanceId` address either a real agent or a virtual session; `agents.ts setAgents` skips clearing the selection when the id is a virtual one.
- `composables/virtualPromptStreaming.ts`: `startVirtualTurn` classifies each target (online/offline/busy) and `fanoutOneTarget` fires the actual `bridge.prompt`, with every callback mirroring to both stores. Same `syncErrored` guard as the single-agent helper.
- `MultiSelectBar`: the toggle is enabled, sends now branch on `virtualMode`. Send button gains a fuchsia gradient when virtual mode is on; placeholder/label text adapts.
- Right panel selection routing is `selectedVirtualSession ?? selectedAgent ?? empty-state` — virtual takes precedence because virtual ids never resolve to a real agent.

## Test plan

- [ ] Tick at least 2 selectable cards → tick "Stream all to a virtual session" → type a prompt → Send. A new "Virtual Sessions" section appears at the top of the grid; the right panel opens the new virtual chat with one user bubble + one per-source streaming bubble per target.
- [ ] Tool-using agent (e.g. claude-code-headless): tool-use + tool-result bubbles render under the same source header without repeating it.
- [ ] Type a follow-up prompt inside the virtual chat → fans out to the same locked targets. Source headers reset per turn.
- [ ] One target busy at send time: a `(busy — skipped)` placeholder appears in the virtual transcript; the real prompt is not fired (per-instance chat is untouched).
- [ ] One target removed (controller stops the session, or agent disconnects): subsequent virtual turn skips it with `(offline — skipped)`.
- [ ] Click into one of the per-instance chats while a virtual turn is streaming: same response is mirrored there.
- [ ] Stop button in the virtual chat cancels every per-source stream of the active turn.
- [ ] Trash button on a virtual card cancels in-flight streams + removes the session + clears the right-panel selection if it was viewing that virtual session.
- [ ] Plain (non-virtual) fan-out from Phase 1 still works exactly as before when the toggle is off.