### PR TITLE
agent-web-ui: rename to 'NATS Agent Console' + hide top-bar versions

### DIFF
--- a/examples/agent-web-ui/index.html
+++ b/examples/agent-web-ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NATS Agent Dashboard</title>
+    <title>NATS Agent Console</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/agent-web-ui/src/components/ConnectionBar.vue
+++ b/examples/agent-web-ui/src/components/ConnectionBar.vue
@@ -5,9 +5,10 @@ import { agentsState } from "../stores/agents.ts";
 
 const emit = defineEmits<{ refresh: [] }>();
 
-// Dashboard's own version — Vite-`define`d at build time from package.json
-// so `bun run build` always picks up the current value without a runtime
-// fetch. Sits next to the protocol version in the bar for parity.
+// Build version — Vite-`define`d at build time from package.json so
+// `bun run build` always picks up the current value without a runtime
+// fetch. No longer rendered visibly in the bar; surfaced on the brand
+// title's hover tooltip alongside the SDK protocol version.
 const appVersion = __APP_VERSION__;
 
 const statusLabel = computed(() => {
@@ -41,13 +42,10 @@ const statusLabel = computed(() => {
     </div>
 
     <div class="brand">
-      <span class="brand-title">NATS Agent Dashboard</span>
       <span
-        class="brand-versions mono"
-        :title="`Dashboard build v${appVersion}` + (bridgeState.sdkProtocolVersion ? ` · protocol v${bridgeState.sdkProtocolVersion}` : '')"
-      >
-        (v{{ appVersion }}<template v-if="bridgeState.sdkProtocolVersion"> / protocol v{{ bridgeState.sdkProtocolVersion }}</template>)
-      </span>
+        class="brand-title"
+        :title="`Build v${appVersion}` + (bridgeState.sdkProtocolVersion ? ` · protocol v${bridgeState.sdkProtocolVersion}` : '')"
+      >NATS Agent Console</span>
     </div>
 
     <div class="right">
@@ -106,12 +104,6 @@ const statusLabel = computed(() => {
   font-size: var(--text-sm);
   color: var(--text-secondary);
   letter-spacing: 0.04em;
-}
-
-.brand-versions {
-  font-size: var(--text-xs);
-  color: var(--text-dim);
-  letter-spacing: 0.02em;
 }
 
 .dot {


### PR DESCRIPTION
## Summary

Two tiny cleanups:

- **Rename** "NATS Agent Dashboard" → **NATS Agent Console**. "Dashboard" leans toward graphs / KPI tiles / read-only monitoring in English; this UI is interactive (prompt, fan out, dispose sessions, virtual sessions), so "console" reads truer. Hits `index.html`'s `<title>` and the `ConnectionBar` brand label — no other strings reference the old name.
- **Hide the visible `(v0.5.0 / protocol v0.3)` line** in the top bar. Build + protocol versions are still surfaced on hover via the brand-title's `title=` tooltip, so the data is one mouse-over away when actually needed. Per-card `v0.3` protocol badges on agent cards are untouched per the design call.

## Test plan

- [ ] Browser tab title shows "NATS Agent Console".
- [ ] Top bar centre reads "NATS Agent Console" with no parenthesised versions next to it.
- [ ] Hovering the title shows the build + protocol version in the tooltip.
- [ ] Per-card `v0.3` badges on non-session agent cards still render.