### PR TITLE
open-agent-vercel: --nats-context support + README clarifications

### DIFF
--- a/agents/open-agent/src/index.ts
+++ b/agents/open-agent/src/index.ts
@@ -18,6 +18,11 @@ export {
   type OpenRouterFactoryOptions,
 } from "./model-factory.js";
 export { translatePart, type UIPart } from "./chunk-translator.js";
+export {
+  connectFrom,
+  resolveConnectionOptions,
+  type ResolveNatsOptions,
+} from "./nats-context.js";
 export { connectLocalSandbox, type LocalSandboxState } from "../vendor/sandbox/local.js";
 export {
   connectSandbox,

--- a/examples/open-agent-vercel/README.md
+++ b/examples/open-agent-vercel/README.md
@@ -15,12 +15,30 @@ sandbox shape that fits their threat model.
 
 ## Prerequisites
 
-- A `nats-server` running locally (or any NATS endpoint via
-  `NATS_URL`).
+- A reachable NATS endpoint — local `nats-server`, a `NATS_URL`, or a
+  saved `nats` CLI context (see **Connecting to NATS** below).
 - `VERCEL_TOKEN` — a Vercel API token with sandbox-create scope.
 - A model API key (see **Models** below).
 - `bun install` resolves `@vercel/sandbox` from npm; the rest of the
   graph is wired by `file:` links to the sibling packages.
+
+## Connecting to NATS
+
+Same precedence as the `agents/open-agent/` CLI:
+
+1. `NATS_URL` env var, if set — wins over everything.
+2. `--nats-context <name>` flag — resolves a saved `nats` CLI context
+   via `@synadia-ai/agents`'s `loadContextOptions`. Use `current` to
+   pick whichever context `nats context select` last chose.
+3. Otherwise: `nats://127.0.0.1:4222`.
+
+```bash
+# Saved context (e.g. an NGS account)
+bun start --nats-context my-ngs-account
+
+# Direct URL — overrides any context
+NATS_URL=nats://nats.example.com:4222 bun start
+```
 
 ## Models
 
@@ -65,8 +83,20 @@ nats req 'agents.prompt.open-agent.'"$USER"'.demo' --timeout=5m \
   "list the top-level files in this sandbox"
 ```
 
-`OPEN_AGENT_REPO_URL` (optional) clones a GitHub repo into the sandbox
-at boot — passed straight through to Vercel's `source.url`.
+`OPEN_AGENT_REPO_URL` (optional) clones a public GitHub repository
+into the sandbox at boot. The value is passed verbatim to Vercel's
+`source.url`, which expects a `https://github.com/<owner>/<repo>`
+URL — for example:
+
+```bash
+OPEN_AGENT_REPO_URL=https://github.com/synadia-io/nats.go \
+  VERCEL_TOKEN=... AI_GATEWAY_API_KEY=... \
+  OPEN_AGENT_OWNER=$USER OPEN_AGENT_SESSION=demo \
+  bun start
+```
+
+Private repos need a `githubToken` on the underlying Vercel sandbox
+config — not currently surfaced as an env var by this example.
 
 ## Vendoring
 

--- a/examples/open-agent-vercel/README.md
+++ b/examples/open-agent-vercel/README.md
@@ -27,9 +27,9 @@ sandbox shape that fits their threat model.
 Same precedence as the `agents/open-agent/` CLI:
 
 1. `NATS_URL` env var, if set — wins over everything.
-2. `--nats-context <name>` flag — resolves a saved `nats` CLI context
-   via `@synadia-ai/agents`'s `loadContextOptions`. Use `current` to
-   pick whichever context `nats context select` last chose.
+2. `--nats-context <name>` flag — resolves a saved `nats` CLI context.
+   Use `current` to pick whichever context `nats context select` last
+   chose.
 3. Otherwise: `nats://127.0.0.1:4222`.
 
 ```bash

--- a/examples/open-agent-vercel/src/main.ts
+++ b/examples/open-agent-vercel/src/main.ts
@@ -6,8 +6,8 @@
 
 import process from "node:process";
 
-import { connect } from "@nats-io/transport-node";
 import {
+  connectFrom,
   gatewayModelFactory,
   openRouterModelFactory,
   runBridge,
@@ -15,11 +15,24 @@ import {
 } from "@synadia-ai/open-agent";
 import { connectVercelSandbox } from "../vendor/vercel/index.js";
 
-const NATS_URL = process.env["NATS_URL"] ?? "nats://127.0.0.1:4222";
+// Same flag plumbing as the CLI in agents/open-agent: only --nats-context is
+// a flag; everything else is env. NATS_URL still wins over a context if set.
+const NATS_CONTEXT = parseNatsContextFlag(process.argv.slice(2));
+const NATS_URL = process.env["NATS_URL"];
 const OWNER = process.env["OPEN_AGENT_OWNER"] ?? process.env["USER"] ?? "vercel-demo";
 const SESSION = process.env["OPEN_AGENT_SESSION"] ?? "default";
 const REPO_URL = process.env["OPEN_AGENT_REPO_URL"]; // optional GitHub URL to clone
 const MODEL = process.env["OPEN_AGENT_MODEL"];
+
+function parseNatsContextFlag(argv: ReadonlyArray<string>): string | undefined {
+  const args = [...argv];
+  while (args.length > 0) {
+    const a = args.shift() as string;
+    if (a === "--nats-context") return args.shift();
+    if (a.startsWith("--nats-context=")) return a.slice("--nats-context=".length);
+  }
+  return undefined;
+}
 
 if (!process.env["VERCEL_TOKEN"]) {
   console.error(
@@ -71,7 +84,12 @@ if (provider === "openrouter") {
   modelFactory = gatewayModelFactory();
 }
 
-const nc = await connect({ servers: NATS_URL });
+const nc = await connectFrom({
+  ...(NATS_CONTEXT !== undefined && NATS_CONTEXT.length > 0
+    ? { natsContext: NATS_CONTEXT }
+    : {}),
+  ...(NATS_URL !== undefined && NATS_URL.length > 0 ? { natsUrl: NATS_URL } : {}),
+});
 
 const { stop } = await runBridge({
   nc,

--- a/examples/open-agent-vercel/src/main.ts
+++ b/examples/open-agent-vercel/src/main.ts
@@ -28,7 +28,15 @@ function parseNatsContextFlag(argv: ReadonlyArray<string>): string | undefined {
   const args = [...argv];
   while (args.length > 0) {
     const a = args.shift() as string;
-    if (a === "--nats-context") return args.shift();
+    if (a === "--nats-context") {
+      const next = args[0];
+      // Guard against the next token being another flag (e.g.
+      // `--nats-context --provider openrouter`), which would otherwise
+      // silently consume `--provider` as the context name and surface as
+      // a confusing context-not-found error.
+      if (next !== undefined && !next.startsWith("--")) return args.shift();
+      return undefined;
+    }
     if (a.startsWith("--nats-context=")) return a.slice("--nats-context=".length);
   }
   return undefined;


### PR DESCRIPTION
## Summary

The Vercel sandbox example previously only honoured `NATS_URL`,
forcing users to spell out a URL even when they already had a saved
`nats` CLI context (NGS account, mTLS bundle, etc). The standalone
CLI in `agents/open-agent/` already supports `--nats-context`; this
brings the example in line, and clarifies a couple of README gaps
spotted while reading it cold.

- **`agents/open-agent`**: re-export `connectFrom`,
  `resolveConnectionOptions`, and `ResolveNatsOptions` from the
  package barrel so external consumers (here, the Vercel example)
  can reuse the same NATS-resolution helper the CLI uses, instead of
  reaching into the SDK directly.
- **`examples/open-agent-vercel`**: parse `--nats-context <name>`
  (and `--nats-context=name`) and route through `connectFrom`.
  Precedence matches the CLI: `NATS_URL` env wins, then
  `--nats-context`, then the localhost default.
- **README**: new "Connecting to NATS" section documenting the
  precedence with examples; rewritten `OPEN_AGENT_REPO_URL`
  paragraph with a concrete `https://github.com/owner/repo` example
  and a note that private repos need a `githubToken` not currently
  surfaced as env.

## Test plan

- [x] `bun run typecheck` clean in `agents/open-agent`.
- [x] `bun run typecheck` clean in `examples/open-agent-vercel`.
- [x] `bun run test` in `agents/open-agent` — 71/71 pass.
- [ ] Manual: `bun start --nats-context <saved-context>` connects to
      the context's server; `NATS_URL=...` overrides it; neither
      set falls back to `127.0.0.1:4222`.
- [ ] Manual: `OPEN_AGENT_REPO_URL=https://github.com/owner/repo bun start`
      boots the Vercel sandbox with the repo cloned at the working
      directory.