### PR TITLE
devtools/devmode.sh: retry bun install once after SIGILL by removing bun.lock

### DIFF
--- a/devtools/devmode.sh
+++ b/devtools/devmode.sh
@@ -527,6 +527,20 @@ bun_install_each() {
     # peer dep is the canonical case — burns CPU forever otherwise).
     ( cd "$dir" && timeout "$BUN_INSTALL_TIMEOUT" bun install --silent ) \
       >"$log" 2>&1 || rc=$?
+    # bun@1.3.x can SIGILL (exit 132 = 128+SIGILL) while reconciling an
+    # existing bun.lock whose shape it can't parse. The deterministic
+    # workaround is to drop the lockfile and let bun rebuild from
+    # scratch. Only retry on this specific signal, only when a lock
+    # exists — most consumers track bun.lock in git, so unconditional
+    # deletion would dirty the working tree on every devmode toggle.
+    if (( rc == 132 )) && [[ -f "$dir/bun.lock" ]]; then
+      sayf '  %b…%b %s%b (bun SIGILL — removing bun.lock and retrying)%b\n' \
+        "$C_YELLOW$C_BOLD" "$C_RESET" "$rel" "$C_DIM" "$C_RESET"
+      rm -f "$dir/bun.lock"
+      rc=0
+      ( cd "$dir" && timeout "$BUN_INSTALL_TIMEOUT" bun install --silent ) \
+        >"$log" 2>&1 || rc=$?
+    fi
     if (( rc == 0 )); then
       sayf '  %b✓%b %s\n' "$C_GREEN$C_BOLD" "$C_RESET" "$rel"
       ok=$((ok + 1))


### PR DESCRIPTION
## Summary
- `bun@1.3.x` intermittently SIGILLs (exit 132) while reconciling an existing `bun.lock` whose shape it can't parse. Symptom from a recent `./devmode.sh off` after the openclaw 0.5.3 release work:

  ```
  ./devtools/devmode.sh: line 521: 664368 Illegal instruction
  ✗ agents/openclaw (bun install exit 132)
  Bun v1.3.13 (bf2e2cec) Linux x64
  ```

- The deterministic workaround is to drop the lockfile and let bun rebuild from scratch. Adds a SIGILL-aware retry to `bun_install_each`: on `rc == 132` with `bun.lock` present, log a one-liner, `rm -f bun.lock`, run `bun install` once more.
- The `package.json` edits still happen unconditionally, so the mode flip itself never blocks on the bun crash — only the lockfile refresh does.

## Why a targeted retry, not unconditional pre-delete
9 of 11 consumers **track** `bun.lock` in git (only `agents/openclaw` and `agents/pi` gitignore it). Unconditionally removing the lock pre-install would dirty the working tree with large lockfile diffs on every devmode toggle. Retrying only when bun has actually proven it can't reconcile that file is surgical.

## Test plan
- [x] `bash -n devtools/devmode.sh` — syntax OK
- [x] `./devtools/devmode.sh status` — still works after the change
- [ ] Reproduce on a fresh checkout: `./devmode.sh off` (which today SIGILLs on the agent packages) should now succeed, with the new "(bun SIGILL — removing bun.lock and retrying)" line surfacing on the affected consumers
- [ ] No state divergence: post-flip, `git status` should show only the expected package.json edits + bun.lock regenerations (same as a clean run)

## Out of scope
- Upstream Bun fix. The crash is reproducible on `bun@1.3.13` against several lockfile shapes in this repo; happy to file an issue with a minimal repro if useful, but the retry here unblocks the day-to-day flow regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)