### PR TITLE
agents/openclaw: auto-bootstrap channels.nats from setRuntime (0.5.4)

### DIFF
--- a/agents/openclaw/index.ts
+++ b/agents/openclaw/index.ts
@@ -1,4 +1,4 @@
-import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import type { ChannelPlugin, OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk/core";
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { natsPlugin } from "./src/channel.js";
 import { setNatsRuntime } from "./src/runtime.js";
@@ -8,16 +8,25 @@ export default defineChannelPluginEntry({
   name: "NATS",
   description: "NATS agent connectivity channel plugin",
   plugin: natsPlugin as ChannelPlugin,
-  setRuntime: setNatsRuntime,
+  setRuntime: (runtime: PluginRuntime) => {
+    setNatsRuntime(runtime);
+    // Fires in "discovery" mode (openclaw's load mode for npm-installed
+    // channel plugins that aren't yet in `cfg.channels.<id>`). Without this,
+    // a fresh install never bootstraps `channels.nats.accounts.default = {}`,
+    // so the gateway never iterates the channel and env-var-only quickstart
+    // breaks. registerFull below is a belt-and-suspenders for the full-mode
+    // path used by bundled/catalog-known plugins.
+    ensureNatsChannelConfig(runtime);
+  },
   registerFull(api: OpenClawPluginApi) {
-    ensureNatsChannelConfig(api);
+    ensureNatsChannelConfig(api.runtime);
   },
 });
 
 /** Ensure channels.nats.accounts.default exists so the gateway starts the channel. */
-function ensureNatsChannelConfig(api: OpenClawPluginApi): void {
+function ensureNatsChannelConfig(runtime: PluginRuntime): void {
   try {
-    const cfg = api.runtime.config.loadConfig() as Record<string, unknown>;
+    const cfg = runtime.config.loadConfig() as Record<string, unknown>;
     const channels = (cfg.channels ?? {}) as Record<string, unknown>;
     const nats = (channels.nats ?? {}) as Record<string, unknown>;
     const accounts = (nats.accounts ?? {}) as Record<string, unknown>;
@@ -29,10 +38,12 @@ function ensureNatsChannelConfig(api: OpenClawPluginApi): void {
     nats.accounts = accounts;
     channels.nats = nats;
     cfg.channels = channels;
-    api.runtime.config.writeConfigFile(cfg as Record<string, unknown>);
-    api.logger.info?.("nats: created default channel config entry");
+    Promise.resolve(runtime.config.writeConfigFile(cfg as Record<string, unknown>)).catch(
+      (err) => console.warn(`[nats] could not persist channel config skeleton: ${err}`),
+    );
+    console.log("[nats] created default channel config entry");
   } catch (err) {
-    api.logger.warn?.(`nats: could not ensure channel config: ${err}`);
+    console.warn(`[nats] could not ensure channel config: ${err}`);
   }
 }
 

--- a/agents/openclaw/index.ts
+++ b/agents/openclaw/index.ts
@@ -23,25 +23,35 @@ export default defineChannelPluginEntry({
   },
 });
 
+// In "full" mode openclaw fires both setRuntime AND registerFull. The
+// writeConfigFile is async, so without this guard both callbacks pass the
+// idempotency check before the first write lands and we double-log
+// "created default channel config entry" on a single gateway start.
+let bootstrapAttempted = false;
+
 /** Ensure channels.nats.accounts.default exists so the gateway starts the channel. */
 function ensureNatsChannelConfig(runtime: PluginRuntime): void {
+  if (bootstrapAttempted) return;
   try {
     const cfg = runtime.config.loadConfig() as Record<string, unknown>;
     const channels = (cfg.channels ?? {}) as Record<string, unknown>;
     const nats = (channels.nats ?? {}) as Record<string, unknown>;
     const accounts = (nats.accounts ?? {}) as Record<string, unknown>;
 
-    if (channels.nats && accounts.default !== undefined) return; // already set
+    if (channels.nats && accounts.default !== undefined) {
+      bootstrapAttempted = true; // nothing to do, but don't re-check the cfg
+      return;
+    }
 
     // Write skeleton so the gateway discovers this channel
     accounts.default = accounts.default ?? {};
     nats.accounts = accounts;
     channels.nats = nats;
     cfg.channels = channels;
-    Promise.resolve(runtime.config.writeConfigFile(cfg as Record<string, unknown>)).catch(
-      (err) => console.warn(`[nats] could not persist channel config skeleton: ${err}`),
-    );
-    console.log("[nats] created default channel config entry");
+    bootstrapAttempted = true;
+    Promise.resolve(runtime.config.writeConfigFile(cfg as Record<string, unknown>))
+      .then(() => console.log("[nats] created default channel config entry"))
+      .catch((err) => console.warn(`[nats] could not persist channel config skeleton: ${err}`));
   } catch (err) {
     console.warn(`[nats] could not ensure channel config: ${err}`);
   }

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-channel",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "NATS Agent Protocol channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "openclaw",

--- a/devtools/devmode.sh
+++ b/devtools/devmode.sh
@@ -527,6 +527,20 @@ bun_install_each() {
     # peer dep is the canonical case — burns CPU forever otherwise).
     ( cd "$dir" && timeout "$BUN_INSTALL_TIMEOUT" bun install --silent ) \
       >"$log" 2>&1 || rc=$?
+    # bun@1.3.x can SIGILL (exit 132 = 128+SIGILL) while reconciling an
+    # existing bun.lock whose shape it can't parse. The deterministic
+    # workaround is to drop the lockfile and let bun rebuild from
+    # scratch. Only retry on this specific signal, only when a lock
+    # exists — most consumers track bun.lock in git, so unconditional
+    # deletion would dirty the working tree on every devmode toggle.
+    if (( rc == 132 )) && [[ -f "$dir/bun.lock" ]]; then
+      sayf '  %b…%b %s%b (bun SIGILL — removing bun.lock and retrying)%b\n' \
+        "$C_YELLOW$C_BOLD" "$C_RESET" "$rel" "$C_DIM" "$C_RESET"
+      rm -f "$dir/bun.lock"
+      rc=0
+      ( cd "$dir" && timeout "$BUN_INSTALL_TIMEOUT" bun install --silent ) \
+        >"$log" 2>&1 || rc=$?
+    fi
     if (( rc == 0 )); then
       sayf '  %b✓%b %s\n' "$C_GREEN$C_BOLD" "$C_RESET" "$rel"
       ok=$((ok + 1))


### PR DESCRIPTION
## Summary
- After fresh `openclaw plugins install @synadia-ai/nats-channel`, the plugin loaded into the runtime registry but the gateway never started a NATS channel — `channels.nats` was missing from `openclaw.json`, so the gateway's channel iteration skipped it. End-user symptom: install succeeded, env vars set, gateway started, **no NATS connection**.
- **Root cause**: openclaw 2026.5.4 fires `registerFull` only for plugins it considers "configured" (i.e., `channels.<id>` already present in cfg). For npm-installed channel plugins not in openclaw's official catalog, the loader uses **"discovery" mode** — `registerChannel` + `setRuntime` fire, `registerFull` doesn't. Our `ensureNatsChannelConfig` was wired only to `registerFull`, so the bootstrap step never ran.
- **Fix**: also call `ensureNatsChannelConfig` from `setRuntime`, which fires in discovery mode (proof: `openclaw plugins inspect nats` reports `Capabilities: channel: nats` — that means `registerChannel` ran, and per the SDK, `setRuntime` always runs alongside `registerChannel`). `registerFull` keeps the call as belt-and-suspenders for the full-mode path that bundled / catalog-known plugins use. The function is idempotent and fast, so re-running across modes is safe.
- **User-visible effect**: post-merge + publish, the entire quickstart becomes:
  ```sh
  openclaw plugins install @synadia-ai/nats-channel
  export NATS_CONTEXT=ngs NATS_AGENT_NAME=my-agent NATS_OWNER=my-org
  openclaw gateway
  ```
  No manual `openclaw.json` edit. No wizard. No symlink workaround.

## Implementation notes
- `ensureNatsChannelConfig(api)` → `ensureNatsChannelConfig(runtime)` since `setRuntime` only receives the `PluginRuntime`. Logging falls back to `console.*` because `api.logger` isn't available in the `setRuntime` callback.
- Wraps the previously-unawaited `writeConfigFile` Promise in a `.catch` so persistence errors surface instead of silently triggering an unhandled rejection.

## What this does *not* fix
- The wizard (`openclaw configure --section channels`) still won't show NATS — that requires either openclaw catalog enrollment of `@synadia-ai/nats-channel` or an upstream fix to `listChannelCatalogEntries` (it doesn't pass `installRecords` to `discoverOpenClawPlugins`). Both are separate openclaw PRs and tracked elsewhere.

## Test plan
- [ ] After publish to npm, fresh install in a clean openclaw container:
  - [ ] `openclaw plugins install @synadia-ai/nats-channel` succeeds
  - [ ] `[nats] created default channel config entry` appears in startup logs
  - [ ] `channels.nats.accounts.default = {}` lands in `~/.openclaw/openclaw.json`
  - [ ] With `NATS_CONTEXT=ngs NATS_AGENT_NAME=demo NATS_OWNER=m64`, `openclaw gateway` brings up the channel and `nats micro list` (or `$SRV.INFO.agents`) sees the agent
  - [ ] Re-running `openclaw plugins install` or `openclaw gateway` is idempotent (no duplicate writes, no errors)

## Caveat — runtime not yet verified
This is a code-trace fix: the openclaw SDK clearly invokes `setRuntime` whenever `registerChannel` fires, and `inspect nats` confirms the latter for our plugin. But we have not actually restarted a gateway with the new dist and observed the bootstrap log line. End-to-end validation will happen post-publish from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)