### PR TITLE
agents/openclaw: declare activation.onStartup (0.5.5) so gateway loads us on install

### DIFF
--- a/agents/openclaw/openclaw.plugin.json
+++ b/agents/openclaw/openclaw.plugin.json
@@ -2,6 +2,9 @@
   "id": "nats",
   "kind": "channel",
   "channels": ["nats"],
+  "activation": {
+    "onStartup": true
+  },
   "channelConfigs": {
     "nats": {
       "label": "NATS",

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-channel",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "NATS Agent Protocol channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary
End-to-end test of 0.5.4 against `openclaw@2026.5.4` in a clean container revealed the previous fix was incomplete: even with the `setRuntime` hook wired, the gateway never loaded our plugin module on a fresh install — so the bootstrap callback never fired, `channels.nats` was never written, and no NATS connection happened. Symptom: install reports success, gateway start log shows "7 plugins: …, telegram" with no nats, no `[nats] created default channel config entry` line, `nats micro list` empty.

`openclaw plugins inspect nats` *did* show `Status: loaded` — but that's the inspect command's separate loader, not the gateway startup loader.

## Root cause
`openclaw/src/plugins/gateway-startup-plugin-ids.ts:134` `shouldConsiderForGatewayStartup`:

```ts
function shouldConsiderForGatewayStartup(params: {…}): boolean {
  if (params.manifest?.activation?.onStartup === true) return true;
  if (params.contextEngineSlotStartupPluginId === params.plugin.pluginId) return true;
  if (!isGatewayStartupMemoryPlugin(params.plugin)) return false;
  …
}
```

Non-bundled channel plugins only enter the gateway's startup load set via:
- (a) `hasConfiguredStartupChannel` — requires `channels.<id>` to already be in cfg, OR
- (b) `manifest.activation.onStartup === true`

We had neither. (a) is the chicken/egg — `ensureNatsChannelConfig` in `setRuntime` is what would write `channels.nats` in the first place. Result: gateway never imports our module, `setRuntime` never fires, no bootstrap.

## Fix
Add the same declaration that openclaw's own startup-eager extensions (`extensions/browser/openclaw.plugin.json`, `extensions/file-transfer/openclaw.plugin.json`) use:

```json
{
  "id": "nats",
  "kind": "channel",
  "channels": ["nats"],
  "activation": { "onStartup": true },
  …
}
```

With this:
1. Gateway includes `nats` in its startup `pluginIds`.
2. Loader imports `dist/index.js`, calls `register({mode: 'discovery'|'full'})`.
3. `registerChannel` + `setRuntime` fire.
4. `ensureNatsChannelConfig(runtime)` writes `channels.nats.accounts.default = {}`.
5. Gateway's channel iteration sees the new entry and starts the channel using the resolved env-var account.

## Cost
nats now loads on every gateway start regardless of whether NATS is configured. The cost is one extra plugin module import + one `setRuntime` callback per gateway start. The `bootstrapAttempted` flag from 0.5.4 keeps the actual `writeConfigFile` to once per process. In effect this is the same shape as bundled channels (telegram, mattermost, …) which all load at startup whether configured or not.

## Test plan
- [ ] Bump to 0.5.5, publish to npm
- [ ] Fresh container: `openclaw plugins install @synadia-ai/nats-channel`
- [ ] `export NATS_CONTEXT=… NATS_AGENT_NAME=… NATS_OWNER=…`
- [ ] `openclaw gateway` shows `nats` in the startup plugin list, `[nats] created default channel config entry` in the log, and `channels.nats.accounts.default = {}` lands in `~/.openclaw/openclaw.json`
- [ ] `nats micro list` (or `$SRV.INFO.agents`) sees the agent — same invocation if openclaw's iteration order is friendly, second `openclaw gateway` start otherwise

## Caveat
Same-invocation success depends on whether openclaw's channel iteration picks up our async `writeConfigFile` before deciding which channels to start. If not, second `openclaw gateway` does it. Either way: zero manual edits, zero symlinks, zero wizard steps. Verifying empirically post-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)