### PR TITLE
agents/openclaw: lead README with env-var quickstart, flag wizard issue

### DIFF
--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -18,7 +18,7 @@ Set env vars and start the gateway — the channel auto-bootstraps on first star
 # Pick one connection path:
 export NATS_CONTEXT=ngs                       # a NATS CLI context (recommended for NGS / managed NATS)
 # — or —
-export NATS_URL=nats://demo.nats.io:4222      # raw URL
+export NATS_URL=nats://demo.nats.io            # raw URL
 export NATS_CREDENTIALS=/path/to/your.creds   # optional, for NKEY/JWT auth
 
 export NATS_AGENT_NAME=my-agent               # required: agent identity (5th subject token)
@@ -27,7 +27,7 @@ export NATS_OWNER=my-org                      # optional: 4th subject token (def
 openclaw gateway
 ```
 
-On first start the plugin writes `channels.nats.accounts.default = {}` into `~/.openclaw/openclaw.json` and brings up the channel — your agent is then reachable at `agents.prompt.oc.<owner>.<agentName>`. No `openclaw configure` step, no manual JSON edit, no extensions/ symlink.
+The channel comes up on first start at `agents.prompt.oc.<owner>.<agentName>`. **No edits to `~/.openclaw/openclaw.json` needed** — the plugin's account resolver falls back to a `"default"` account when none is configured and fills every field from env vars. No `openclaw configure` step, no extensions/ symlink.
 
 > **Only one account is active at a time.** The plugin runs a single gateway process and registers one account on it. Adding multiple `accounts.<id>` blocks in your config doesn't register multiple agents simultaneously — pick the one you want active.
 

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -10,9 +10,32 @@ openclaw plugins install @synadia-ai/nats-channel
 
 If your OpenClaw config has a non-empty `plugins.allow` list, add `"nats"` to it — that list, if set, gates which non-bundled plugins are enabled.
 
-## Configure
+## Quickstart (env vars)
 
-The fastest path is the wizard:
+Set env vars and start the gateway — the channel auto-bootstraps on first start:
+
+```bash
+# Pick one connection path:
+export NATS_CONTEXT=ngs                       # a NATS CLI context (recommended for NGS / managed NATS)
+# — or —
+export NATS_URL=nats://demo.nats.io:4222      # raw URL
+export NATS_CREDENTIALS=/path/to/your.creds   # optional, for NKEY/JWT auth
+
+export NATS_AGENT_NAME=my-agent               # required: agent identity (5th subject token)
+export NATS_OWNER=my-org                      # optional: 4th subject token (defaults to "default")
+
+openclaw gateway
+```
+
+On first start the plugin writes `channels.nats.accounts.default = {}` into `~/.openclaw/openclaw.json` and brings up the channel — your agent is then reachable at `agents.prompt.oc.<owner>.<agentName>`. No `openclaw configure` step, no manual JSON edit, no extensions/ symlink.
+
+> **Only one account is active at a time.** The plugin runs a single gateway process and registers one account on it. Adding multiple `accounts.<id>` blocks in your config doesn't register multiple agents simultaneously — pick the one you want active.
+
+## Configure via the wizard (alternative)
+
+> **Known issue on OpenClaw 2026.5.4+.** The wizard's channel list (`openclaw configure --section channels`, `openclaw channels add`) doesn't currently surface npm-installed channel plugins that aren't in OpenClaw's official channel catalog. Tracked upstream; until then, prefer the env-var quickstart above.
+
+If you're on an older OpenClaw (or the catalog enrollment lands), the wizard path still works:
 
 ```bash
 openclaw configure --section channels
@@ -25,8 +48,6 @@ After restarting OpenClaw, your agent is reachable at:
 ```
 agents.prompt.oc.<owner>.<agentName>
 ```
-
-> **Only one account is active at a time.** The plugin runs a single gateway process and registers one account on it. Adding multiple `accounts.<id>` blocks in your config doesn't register multiple agents simultaneously — pick the one you want active.
 
 ### Three common configurations
 


### PR DESCRIPTION
## Summary
- After 0.5.5 landed, `openclaw plugins install @synadia-ai/nats-channel` + env vars + `openclaw gateway` brings up the channel on the **first** gateway start (verified in a clean container against `openclaw@2026.5.4`).
- The README previously led with `openclaw configure --section channels` ("the fastest path is the wizard"). That path is currently blocked on OpenClaw 2026.5.4+ because the wizard's channel list doesn't include npm-installed plugins that aren't in OpenClaw's official channel catalog (separate upstream issue).
- This PR re-orders the README:
  - **Quickstart (env vars)** is now the lead Configure section — concrete recipe with both connection paths (`NATS_CONTEXT` vs `NATS_URL` / `NATS_CREDENTIALS`), required `NATS_AGENT_NAME`, optional `NATS_OWNER`.
  - **Configure via the wizard (alternative)** keeps the wizard instructions but with a known-issue note pointing back to the env-var path on 2026.5.4+.
- Reference tables (Configuration reference, Environment variables, Resolution order) unchanged — they stay accurate for both paths.

## Out of scope (separate work)
- Upstream openclaw fix for catalog discovery of npm-installed plugins, or enrolling `@synadia-ai/nats-channel` in `scripts/lib/official-external-channel-catalog.json`. Either lifts the "wizard doesn't show NATS" caveat. Not blocking — the env-var path is fully self-contained.

## Test plan
- [x] Verified env-var-only install + start works in a clean OpenClaw 2026.5.4 container against the published 0.5.5
- [ ] README renders cleanly on github (markdown spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)