### PR TITLE
agent-web-ui: show openclaw agentName instead of "default" on card subtitle

### DIFF
--- a/examples/agent-web-ui/src/components/AgentCard.vue
+++ b/examples/agent-web-ui/src/components/AgentCard.vue
@@ -95,6 +95,16 @@ const subtitle = computed<string | null>(() => {
   ) {
     return null;
   }
+  // OpenClaw agents share the NATS service name "agents" and almost
+  // always run a single account named "default" — so both `name` and
+  // `session` are non-distinguishing across multiple openclaw instances
+  // on the same bus. The configured agentName is the differentiator and
+  // lives only in the prompt subject's last token (spec layout
+  // `agents.prompt.<platform>.<owner>.<agentName>`). Pull it from there.
+  if (bucket.value === BUCKETS.OPENCLAW) {
+    const last = props.agent.promptEndpoint.subject.split(".").pop();
+    if (last) return last;
+  }
   return props.agent.session ?? props.agent.name;
 });
 


### PR DESCRIPTION
## Summary
- Multiple openclaw agents on the same NATS bus all show the literal text **"default"** in the agent card's second row, making them indistinguishable at a glance.
- Cause: the subtitle is `agent.session ?? agent.name`. For openclaw, the NATS service name is always `"agents"` and the configured account id is almost always `"default"`, so neither field differentiates instances.
- Fix: for the `OPENCLAW` bucket, derive the configured `agentName` from the prompt subject's last token (spec layout `agents.prompt.<platform>.<owner>.<agentName>`). For two openclaws named `demo-agent` and `prod-agent`, the cards now display those names instead of two identical "default" labels.

All other buckets (pi sessions, cc sessions, hermes, open-agent, headless controllers) keep their existing subtitle behavior unchanged.

## Test plan
- [ ] Open the web UI with multiple openclaw agents discovered (e.g. `claw1` and `claw2` containers, each running with its own `NATS_AGENT_NAME`).
- [ ] Each openclaw card's second row shows its `agentName` (the configured `NATS_AGENT_NAME` / `channels.nats.accounts.<id>.agentName`), not "default".
- [ ] pi-headless sessions, cc-headless sessions, hermes, open-agent, and headless controller cards display unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)