### PR TITLE
Docs: nats-req --reply-timeout gotcha for streaming agents

### DIFF
--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -188,19 +188,23 @@ From the CLI:
 
 ```bash
 # Plain text prompt
-nats req agents.prompt.oc.<owner>.<agentName> "Hello!" --wait-for-empty --timeout 60s
+nats req agents.prompt.oc.<owner>.<agentName> "Hello!" \
+  --wait-for-empty --reply-timeout 30s --timeout 60s
 
 # JSON envelope (caller SDKs use this form under the hood)
-nats req agents.prompt.oc.<owner>.<agentName> '{"prompt":"Hello!"}' --wait-for-empty --timeout 60s
+nats req agents.prompt.oc.<owner>.<agentName> '{"prompt":"Hello!"}' \
+  --wait-for-empty --reply-timeout 30s --timeout 60s
 
 # With an attachment
 nats req agents.prompt.oc.<owner>.<agentName> '{
   "prompt": "describe this image",
   "attachments": [{"filename":"pic.png","content":"<base64>"}]
-}' --wait-for-empty --timeout 120s
+}' --wait-for-empty --reply-timeout 30s --timeout 120s
 ```
 
 `--wait-for-empty` is required: replies stream as multiple chunks and end with an empty terminator message.
+
+`--reply-timeout` matters too. Its default is **300 ms** — the maximum gap allowed between consecutive replies. The agent publishes an immediate `{type:"status",data:"ack"}` chunk on request receipt, but the LLM's first response chunk typically lands 1–2 s later, so the default fires before the first response and the CLI exits after just the ack. Setting `--reply-timeout 30s` gives the LLM enough warm-up time. SDK callers (`requestMany` with `strategy:"sentinel"`) don't hit this — they wait the full `maxWait` regardless of inter-arrival gaps.
 
 From TypeScript using `@synadia-ai/agents`:
 
@@ -259,6 +263,7 @@ The agent subject layout has no per-tenant slot. For real isolation between tena
 
 - **`config field 'org' is deprecated`** — rename `org` → `owner` in `openclaw.json`. The old name still works, just noisy in logs.
 - **`NATS: disconnected`** — check `url` and (if using credentials) that the `.creds` file exists and is readable by the gateway process.
+- **`nats req` returns only the initial ack and exits** — pass `--reply-timeout 30s` (default is 300 ms, shorter than the gap between the ack chunk and the LLM's first response). See the "Talk to your agent" section above for the full command. `--wait-for-empty` alone isn't enough.
 - **`nats req` hangs or returns nothing** — pass `--wait-for-empty`. The protocol ends streams with an empty-body message, not a single response.
 - **`400 attachment[N] has invalid base64 content`** — the caller emitted URL-safe base64 or unpadded output. `Buffer.from(bytes).toString("base64")` (Node) produces the right form.
 - **`400 attachment[N] has unsafe filename`** — send the basename only (`"pic.png"`), not a path (`"./images/pic.png"`).

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -146,13 +146,17 @@ From the CLI:
 
 ```bash
 # Plain text prompt
-nats req agents.prompt.pi.<owner>.<session> "What files are here?" --wait-for-empty --timeout 120s
+nats req agents.prompt.pi.<owner>.<session> "What files are here?" \
+  --wait-for-empty --reply-timeout 30s --timeout 120s
 
 # JSON envelope (caller SDKs use this form)
-nats req agents.prompt.pi.<owner>.<session> '{"prompt":"What files are here?"}' --wait-for-empty --timeout 120s
+nats req agents.prompt.pi.<owner>.<session> '{"prompt":"What files are here?"}' \
+  --wait-for-empty --reply-timeout 30s --timeout 120s
 ```
 
 `--wait-for-empty` is required: replies stream as multiple chunks and end with an empty terminator message.
+
+`--reply-timeout` matters too. Its default is **300 ms** — the maximum gap allowed between consecutive replies. The agent publishes an immediate `{type:"status",data:"ack"}` chunk on request receipt, but the LLM's first response chunk typically lands 1–2 s later, so the default fires before the first response and the CLI exits after just the ack. Setting `--reply-timeout 30s` gives the LLM enough warm-up time. SDK callers (`requestMany` with `strategy:"sentinel"`) don't hit this — they wait the full `maxWait` regardless of inter-arrival gaps.
 
 From TypeScript using `@synadia-ai/agents`:
 
@@ -214,6 +218,7 @@ Deliberate deferrals:
 - **`NATS: disconnected` in footer** — run `/nats-status`, then check the context file at `~/.config/nats/context/<context>.json` and that the NATS server is reachable.
 - **`NATS: reconnecting…`** — the connection dropped; the client restores it automatically.
 - **My session got a `-2` suffix** — another PI session was already registered on the same `owner + session`. Use `/nats-configure session <name>` to pick a different one.
+- **`nats req` returns only the initial ack and exits** — pass `--reply-timeout 30s` (default is 300 ms, shorter than the gap between the ack chunk and the LLM's first response). See the "Talk to your session" section above for the full command. `--wait-for-empty` alone isn't enough.
 - **`nats req` hangs or returns nothing** — pass `--wait-for-empty`. The protocol ends streams with an empty-body message, not a single response.
 - **`400 attachment[N] has invalid base64 content`** — the caller emitted URL-safe base64 or unpadded output. `Buffer.from(bytes).toString("base64")` (Node) produces the right form.
 - **`400 attachment[N] has unsafe filename`** — send the basename only (`"report.pdf"`), not a path (`"./reports/report.pdf"`).

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -181,11 +181,14 @@ nats req agents.spawn.cc-headless.$USER.control \
 
 ```bash
 nats req agents.prompt.cc-headless.$USER.sess-a1b2c3d4 \
-  'list the files here and summarise what you see' --replies=0 --timeout=120s
+  'list the files here and summarise what you see' \
+  --replies=0 --reply-timeout=30s --timeout=120s
 # → {"type":"status","data":"ack"}
 # → {"type":"response","data":"There are three files: …"}
 # → (empty terminator)
 ```
+
+`--reply-timeout=30s` is important: the default 300 ms is shorter than the gap between the immediate ack chunk (sent on request receipt, before the Anthropic API call) and the LLM's first response, so `nats req` exits after the ack alone. SDK callers (`requestMany` with `strategy:"sentinel"`) wait the full `maxWait` regardless of inter-arrival gaps and don't need this flag.
 
 Programmatically with the SDK:
 

--- a/examples/pi-headless/README.md
+++ b/examples/pi-headless/README.md
@@ -135,11 +135,14 @@ nats req agents.spawn.pi-headless.$USER.control \
 
 ```bash
 nats req agents.prompt.pi-headless.$USER.sess-a1b2c3d4 \
-  'summarise the files in this directory' --replies=0 --timeout=60s
+  'summarise the files in this directory' \
+  --replies=0 --reply-timeout=30s --timeout=60s
 # → {"type":"status","data":"ack"}
 # → {"type":"response","data":"There are three files: …"}
 # → (empty terminator)
 ```
+
+`--reply-timeout=30s` is important: the default 300 ms is shorter than the gap between the immediate ack chunk and the LLM's first response, so `nats req` exits after the ack alone. SDK callers (`requestMany` with `strategy:"sentinel"`) wait the full `maxWait` regardless of inter-arrival gaps and don't need this flag.
 
 Programmatically with the SDK:
 


### PR DESCRIPTION
## Summary

`nats req --wait-for-empty` (and `--replies=0`) has a hidden default of `--reply-timeout=300ms` — the max gap allowed between consecutive replies. `pi`, `openclaw`, and `pi-headless` publish an immediate `{type:"status",data:"ack"}` chunk on request receipt, but the LLM's first response chunk typically lands 1–2 s later. The default fires in the ack→first-response gap and the CLI exits with just the ack, making the agent look broken from the CLI even though SDK callers see it stream cleanly.

This PR updates the three affected READMEs to pass `--reply-timeout 30s` in their `nats req` examples and adds a short note explaining the gotcha.

## Root cause walk-through

| Agent | First reply | Gap to first response | `nats req --wait-for-empty` outcome |
| --- | --- | --- | --- |
| **pi** | `{type:"status",data:"ack"}` at t≈100 ms | ~1.5 s | CLI exits after ack (default 300 ms) |
| **openclaw** | `{type:"status",data:"ack"}` at t≈100 ms | varies (LLM warmup) | CLI exits after ack |
| **hermes** (v0.2 fork) | first response chunk directly | n/a | streams cleanly |
| **claude-code** | first response chunk directly (ack is keep-alive only, 30 s interval) | n/a | streams cleanly |
| **open-agent** | same as claude-code | n/a | streams cleanly |

SDK callers (`nc.requestMany` with `strategy:"sentinel"`) wait the full `maxWait` regardless of inter-arrival gaps, which is why the web UI and all the example scripts work fine — only the Go CLI defaults bite.

## What changed

- `agents/pi/README.md` — updated the "Talk to your session" examples and added a troubleshooting entry
- `agents/openclaw/README.md` — same
- `examples/pi-headless/README.md` — updated the Prompt example

## Not affected

- `agents/claude-code/README.md`, `agents/open-agent/README.md` — these agents have no immediate ack, so the CLI examples work as-is.
- Root `README.md` — `nats req` is only used there for discovery (`$SRV.INFO.agents` with `--replies=0 --timeout=2s`), which is single-shot.

## Test plan

- [x] Verified the fix end-to-end against the user's deployed `pi` and `openclaw` on NGS — `nats req --wait-for-empty --reply-timeout 30s --timeout 60s` now streams the full response and terminates on the empty body.
- [x] Confirmed the issue does NOT exist for `claude-code`, `open-agent`, and `hermes` (different ack patterns).
- [x] No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)