### PR TITLE
AgentService (TS): emit §6.4 mandatory leading ack before handler runs

### DIFF
--- a/agent-sdk/typescript/CHANGELOG.md
+++ b/agent-sdk/typescript/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Leading `status=ack` chunk is now emitted unconditionally (§6.4).**
+  Spec §6.4 was sharpened to require that every prompt handler emit
+  exactly one `{"type":"status","data":"ack"}` chunk as the **first**
+  message on the reply subject, **before** any work that introduces
+  observable latency
+  ([nats-agent-sdk-docs@b1c6972](https://github.com/synadia-ai/nats-agent-sdk-docs/commit/b1c6972)).
+  `AgentService.#dispatchPrompt` now publishes the ack after a
+  successful envelope decode and before invoking the user-supplied
+  handler — so every TS agent built on `AgentService` (the reference
+  agent, `agents/open-agent`, any third-party harness) becomes
+  spec-compliant on upgrade with no code change. The ack is emitted
+  unconditionally; the `keepaliveIntervalS` option still controls only
+  the periodic mid-stream cadence (which remains a valid wire shape
+  for §6.6 inactivity-timer defense). Mirrors the parallel change in
+  `synadia-ai-agent-service` 0.4.0.
+
+  Wire-compatible: callers already accept arbitrary `status` chunks
+  (`@synadia-ai/agents` decodes them as `{type:"status", status:"ack"}`
+  events).
+
 ## [0.5.1] - 2026-05-04
 
 ### Changed

--- a/agent-sdk/typescript/src/service.ts
+++ b/agent-sdk/typescript/src/service.ts
@@ -563,13 +563,34 @@ export class AgentService {
 
     const response = new PromptResponse(msg, this.#options.nc);
 
-    // Per-request keep-alive: while the handler runs, emit ack chunks so
-    // callers using a stream inactivity timeout (§6.6) don't fire.
+    // §6.4: emit the mandatory leading `ack` status chunk as the first
+    // message on the reply subject, before the handler runs. Confirms
+    // request acceptance and resets the caller's inactivity timeout
+    // (§6.6) ahead of any latency the handler introduces (model
+    // warm-up, network round-trips). Also makes the stream observable
+    // from generic NATS tooling (`nats req --wait-for-empty`) which
+    // would otherwise time out on the gap between request receipt and
+    // the handler's first output. Mirrors the Python SDK's
+    // unconditional leading-ack emission.
+    const ack: StatusChunk = { type: "status", status: "ack" };
+    const ackBytes = encodeChunk(ack);
+    try {
+      msg.respond(ackBytes);
+    } catch {
+      // Best-effort, matching the keepalive loop and PromptResponse.send
+      // error-handling pattern: the handler will surface the same failure
+      // naturally if the reply subject is truly dead.
+    }
+
+    // Optional periodic keep-alive: while the handler runs, emit
+    // additional `ack` chunks so callers running long-tail work
+    // (§6.6 inactivity timer, 60s default) don't trip on a quiet
+    // model. The §6.4 spec mandates only the leading ack above;
+    // periodic acks remain a valid wire shape and stay in the SDK
+    // as additional defense.
     let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
     if (this.#keepaliveIntervalS !== null) {
       const intervalMs = this.#keepaliveIntervalS * 1000;
-      const ack: StatusChunk = { type: "status", status: "ack" };
-      const ackBytes = encodeChunk(ack);
       keepaliveTimer = setInterval(() => {
         try {
           msg.respond(ackBytes);

--- a/agent-sdk/typescript/test/integration/agent-service.test.ts
+++ b/agent-sdk/typescript/test/integration/agent-service.test.ts
@@ -90,6 +90,57 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     expect((lastStatus as { status: string }).status).toBe("done");
   });
 
+  it("emits the §6.4 mandatory leading `ack` as the first chunk before the handler runs", async () => {
+    // Block the handler so we can prove the ack is emitted EAGERLY — i.e.
+    // before any handler work. If the SDK only sent the ack via the
+    // setInterval keep-alive cadence, the first message wouldn't arrive
+    // until the handler produced its first response.
+    let releaseHandler: () => void;
+    const handlerCanProceed = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+
+    const service = startService();
+    service.onPrompt(async (_envelope, response) => {
+      await handlerCanProceed;
+      await response.send("late response");
+    });
+    await service.start();
+
+    const found = await client.discover({
+      timeoutMs: 1000,
+      filter: { agent: "svc-test", name: service.subject.name },
+    });
+    const remote = found[0]!;
+
+    const messages: StreamMessage[] = [];
+    const iter = (async () => {
+      for await (const m of await remote.prompt("hi")) messages.push(m);
+    })();
+
+    // try/finally: if an assertion below throws, we still release the
+    // suspended handler so the consumer iterator drains and the test
+    // framework can move on without hanging on a stuck handler.
+    try {
+      const deadline = Date.now() + 1500;
+      while (messages.length < 1 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(messages[0]).toEqual({ type: "status", status: "ack" });
+      expect(messages.some((m) => m.type === "response")).toBe(false);
+    } finally {
+      releaseHandler!();
+    }
+
+    // Handler released — verify the rest of the stream is as expected
+    // and ends on the synthetic `status:done`.
+    await iter;
+
+    expect(messages[0]).toEqual({ type: "status", status: "ack" });
+    expect(messages.some((m) => m.type === "response" && m.text === "late response")).toBe(true);
+    expect(messages.at(-1)).toEqual({ type: "status", status: "done" });
+  });
+
   it("decodes the §5.1 envelope and surfaces its prompt to the handler", async () => {
     let receivedPrompt: string | null = null;
     let receivedAttachmentCount = 0;


### PR DESCRIPTION
## Summary

TS-side counterpart to [PR #101](https://github.com/synadia-ai/synadia-agents/pull/101) (Python SDK, merged) — brings `@synadia-ai/agent-service` into parity with the §6.4 spec tightening ([nats-agent-sdk-docs@b1c6972](https://github.com/synadia-ai/nats-agent-sdk-docs/commit/b1c6972)), which requires an immediate `{"type":"status","data":"ack"}` chunk as the first message on the reply subject, before any latency-inducing handler work.

> **Rebased and rescoped.** This branch was rebased onto `main` after PRs #101 + #102 landed; the Python changes that lived in earlier revisions of this branch are now in main and have been dropped. What remains is the TS-only change.

## What changes

- `agent-sdk/typescript/src/service.ts` — `#dispatchPrompt` now publishes `encodeChunk({type:"status",status:"ack"})` synchronously after envelope decode and before invoking the handler. Comment block uses "leading ack" terminology for cross-SDK consistency with the Python side. The pre-existing periodic keep-alive interval is retained as §6.6 inactivity-timer defense; `keepaliveIntervalS` now controls only the periodic cadence, not the leading ack.
- `agent-sdk/typescript/test/integration/agent-service.test.ts` — new test `emits the §6.4 mandatory leading 'ack' as the first chunk before the handler runs`: handler blocks on a promise, the test asserts the ack lands before the handler is released. `try/finally` around the pre-release assertions guarantees the suspended handler is unblocked even on assertion failure.
- `agent-sdk/typescript/CHANGELOG.md` — `[Unreleased]` entry mirroring the Python SDK's `agent-sdk/python/CHANGELOG.md` shape.

## Wire compatibility

Fully compatible. Callers already decode arbitrary `status` chunks via `@synadia-ai/agents`. The only observable change is one extra `ack` event at the head of every stream, which clients have always accepted.

## Test plan

- [x] `agent-sdk/typescript` typecheck + eslint + prettier `--check` + 38 tests (37 existing + 1 new) all green against a local NATS broker
- [x] `client-sdk/typescript` 280 tests still pass — wire decode untouched
- [x] Verified the new test fails fast (assertion-error, not timeout) if the eager ack is removed from `#dispatchPrompt`
