### PR TITLE
Python SDK: §6.4 mandatory leading ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Both languages stay in lockstep on the wire format, validated by a cross-SDK int
        └─── streamed chunks ───────┘
 ```
 
-A request is plain UTF-8 text or a JSON envelope `{"prompt": "...", "attachments": [{"filename": "...", "content": "<base64>"}]}`. The agent streams typed JSON chunks on the reply subject — `{"type":"response","data":"..."}` for content, `{"type":"status","data":"ack"}` for keep-alive, `{"type":"query","data":{...}}` for mid-stream questions — and ends with an **empty-body, no-headers** terminator. Errors use the `Nats-Service-Error-Code` header (`400` client, `500` server).
+A request is plain UTF-8 text or a JSON envelope `{"prompt": "...", "attachments": [{"filename": "...", "content": "<base64>"}]}`. The agent streams typed JSON chunks on the reply subject — `{"type":"response","data":"..."}` for content, `{"type":"status","data":"ack"}` as the mandatory §6.4 leading chunk (and optionally again as periodic keep-alive), `{"type":"query","data":{...}}` for mid-stream questions — and ends with an **empty-body, no-headers** terminator. Errors use the `Nats-Service-Error-Code` header (`400` client, `500` server).
 
 Discovery is standard NATS micro:
 

--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -6,6 +6,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
+## [Unreleased]
+
+### Changed
+
+- **Leading `status=ack` chunk is now emitted unconditionally (§6.4).**
+  Spec §6.4 was sharpened to require that every prompt handler emit
+  exactly one `{"type":"status","data":"ack"}` chunk as the **first**
+  message on the reply subject, **before** any work that introduces
+  observable latency. `AgentService._on_prompt_request` now publishes
+  the ack after a successful envelope decode and before invoking the
+  user-supplied handler — so every Python agent in the repo
+  (reference agent, `demo_echo`, in-tree test handlers) becomes
+  spec-compliant on upgrade with no code change. The ack is emitted
+  regardless of `keepalive_interval_s`; passing `None` only disables
+  the periodic keep-alive cadence, not the leading ack. A malformed
+  envelope still produces `error(400) → terminator` with no
+  spurious ack — the ack lives after decode validation.
+
 ## [0.3.0] - 2026-05-04
 
 Restores wire-shape parity with the spec and TS SDK after the

--- a/agent-sdk/python/src/synadia_ai/agent_service/service.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/service.py
@@ -97,6 +97,11 @@ DEFAULT_ATTACHMENTS_OK = True
 # `{type:"status",data:"ack"}` periodically while a request is in flight. We
 # match that behaviour by default; agent authors who don't want it pass
 # `keepalive_interval_s=None`.
+#
+# Note: the §6.4-MUST *leading* ack is emitted unconditionally by
+# ``_on_prompt_request`` before the handler runs — it is independent of
+# this keep-alive cadence, and disabling keep-alive does NOT disable the
+# leading ack.
 DEFAULT_KEEPALIVE_INTERVAL_S: float = 30.0
 
 
@@ -416,6 +421,16 @@ class AgentService:
                 log.warning("rejecting malformed prompt on %s: %s", request.subject, exc)
                 await request.respond_error("400", _sanitize_error_desc(str(exc)))
                 return
+
+            # §6.4: emit the leading ack BEFORE any handler work so warm-up
+            # latency stays inside the §6.6 budget and the stream is observable
+            # to plain `nats req --wait-for-empty`. Best-effort, mirroring the
+            # terminator path below — if respond() fails, log and continue;
+            # the next send (handler chunk or terminator) will surface it.
+            try:
+                await request.respond(encode_chunk(StatusChunk(status="ack")))
+            except Exception:
+                log.exception("failed to emit leading ack on %s", request.subject)
 
             stream = PromptStream(request, self._nc)
             handler = self._prompt_handler

--- a/agent-sdk/python/src/synadia_ai/agent_service/service.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/service.py
@@ -203,13 +203,17 @@ class AgentService:
     session lives in the subject (token 5 — the ``session_name``); a
     worker that wants to serve N sessions registers N services.
 
-    ``keepalive_interval_s`` controls per-request keep-alive: while a
-    handler is running, the agent emits ``{"type":"status","data":"ack"}``
-    every ``keepalive_interval_s`` seconds so callers using a stream
-    inactivity timeout (the TS SDK default is 60 s) don't fire on slow
-    handlers. Defaults to 30 s, matching the TS reference harnesses.
-    Pass ``None`` to disable — for example when the handler emits its
-    own status chunks at a finer cadence.
+    ``keepalive_interval_s`` controls the per-request keep-alive
+    *cadence*: while a handler is running, the agent emits
+    ``{"type":"status","data":"ack"}`` every ``keepalive_interval_s``
+    seconds so callers using a stream inactivity timeout (the TS SDK
+    default is 60 s) don't fire on slow handlers. Defaults to 30 s,
+    matching the TS reference harnesses. Pass ``None`` to disable the
+    periodic cadence — for example when the handler emits its own
+    status chunks at a finer cadence. Note: the §6.4 *leading* ack
+    (emitted before the handler runs) is mandatory and fires
+    unconditionally regardless of this flag; ``None`` disables only
+    the periodic mid-stream cadence, not the leading ack.
 
     ``max_payload`` is honored up to the connected server's negotiated
     limit (``nc.max_payload``). If you pass a value *larger* than the

--- a/agent-sdk/python/tests/test_attachments_e2e.py
+++ b/agent-sdk/python/tests/test_attachments_e2e.py
@@ -28,6 +28,7 @@ from synadia_ai.agents import (
     Attachment,
     Envelope,
     ResponseChunk,
+    StatusChunk,
 )
 
 from synadia_ai.agent_service import AgentService, PromptStream
@@ -89,9 +90,9 @@ async def _run_roundtrip(
             found = await agents.discover(timeout=1.0)
             agent = next(a for a in found if a.prompt_subject == service.subject.inbox)
 
-            received: list[ResponseChunk] = []
+            received: list[ResponseChunk | StatusChunk] = []
             async for msg in agent.prompt(prompt_text, attachments=[attachment], timeout=5.0):
-                assert isinstance(msg, ResponseChunk), (
+                assert isinstance(msg, ResponseChunk | StatusChunk), (
                     f"unexpected chunk type: {type(msg).__name__}"
                 )
                 received.append(msg)
@@ -101,9 +102,11 @@ async def _run_roundtrip(
                 [json.loads(chunk.model_dump_json()) for chunk in received],
             )
 
-            # Exactly one ResponseChunk: summary text + one attachment.
-            assert len(received) == 1, f"expected 1 chunk, got {len(received)}"
-            chunk = received[0]
+            # The SDK emits a §6.4 leading ack before invoking the handler, so
+            # the stream is ack + the handler's single ResponseChunk.
+            responses = [c for c in received if isinstance(c, ResponseChunk)]
+            assert len(responses) == 1, f"expected 1 response chunk, got {len(responses)}"
+            chunk = responses[0]
             assert chunk.attachments is not None
             assert len(chunk.attachments) == 1
             received_att = chunk.attachments[0]

--- a/agent-sdk/python/tests/test_echo_e2e.py
+++ b/agent-sdk/python/tests/test_echo_e2e.py
@@ -27,6 +27,7 @@ from synadia_ai.agents import (
     Agents,
     Envelope,
     ResponseChunk,
+    StatusChunk,
 )
 from synadia_ai.agents.heartbeat import HeartbeatPayload
 
@@ -125,17 +126,26 @@ async def test_echo_agent_roundtrip(  # noqa: PLR0915 — integration test inten
             assert discovered.prompt_endpoint.max_payload_bytes == 1024 * 1024
             assert discovered.prompt_endpoint.attachments_ok is True
 
-            received: list[ResponseChunk] = []
+            received: list[ResponseChunk | StatusChunk] = []
             async for msg in discovered.prompt("hello world", timeout=5.0):
-                assert isinstance(msg, ResponseChunk), (
+                assert isinstance(msg, ResponseChunk | StatusChunk), (
                     f"unexpected chunk type: {type(msg).__name__}"
                 )
                 received.append(msg)
 
             # The iterator returning normally means the empty-payload terminator arrived (§6.5).
-            assert len(received) == 1, f"expected 1 chunk, got {len(received)}"
-            assert received[0].text == "hello world"
-            assert received[0].attachments is None
+            # The SDK auto-emits a §6.4 leading ack before the handler runs, so
+            # every spec-compliant prompt yields a StatusChunk first; the
+            # handler's response chunks follow.
+            responses = [c for c in received if isinstance(c, ResponseChunk)]
+            acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
+            assert len(acks) >= 1, f"expected leading ack chunk, got: {received!r}"
+            assert isinstance(received[0], StatusChunk) and received[0].status == "ack", (
+                f"first chunk must be the §6.4 leading ack, got: {received[0]!r}"
+            )
+            assert len(responses) == 1, f"expected 1 response chunk, got {len(responses)}"
+            assert responses[0].text == "hello world"
+            assert responses[0].attachments is None
             evidence.write_jsonl(
                 "chunks.jsonl",
                 [json.loads(chunk.model_dump_json()) for chunk in received],

--- a/agent-sdk/python/tests/test_error_completion_e2e.py
+++ b/agent-sdk/python/tests/test_error_completion_e2e.py
@@ -38,15 +38,23 @@ OWNER = "pytest"
 HEARTBEAT_INTERVAL_S = 30  # Long enough to never fire mid-test.
 
 
-async def _collect_replies(nc: NATSClient, subject: str, inbox: str) -> list[Msg]:
-    """Publish a prompt to `subject` and collect every reply that arrives.
+async def _collect_replies(
+    nc: NATSClient,
+    subject: str,
+    inbox: str,
+    payload: bytes = b"hi",
+) -> list[Msg]:
+    """Publish ``payload`` to ``subject`` and collect every reply that arrives.
 
     Stops once the §6.5 empty-body, no-headers terminator arrives — the
     list is always terminated by the terminator on a well-behaved agent.
+    Defaults to a bare-string request (`b"hi"`) which is promoted to
+    `{"prompt": "hi"}` per §5.3; pass an explicit ``payload`` (e.g. a
+    malformed JSON object) to drive the 400 path.
     """
     sub = await nc.subscribe(inbox)
     try:
-        await nc.publish(subject, b"hi", reply=inbox)
+        await nc.publish(subject, payload, reply=inbox)
         collected: list[Msg] = []
         deadline = asyncio.get_event_loop().time() + 1.0
         while asyncio.get_event_loop().time() < deadline:
@@ -157,24 +165,15 @@ async def test_malformed_envelope_emits_400_then_terminator(
     await service.start()
 
     try:
-        inbox = nc.new_inbox()
-        sub = await nc.subscribe(inbox)
-        try:
-            # Send JSON that passes the §5.3 "starts with {" test but lacks the
-            # required `prompt` field — the agent MUST reject with 400.
-            await nc.publish(service.subject.inbox, b'{"no_prompt":true}', reply=inbox)
-            collected = []
-            deadline = asyncio.get_event_loop().time() + 1.0
-            while asyncio.get_event_loop().time() < deadline:
-                try:
-                    msg = await sub.next_msg(timeout=0.3)
-                except TimeoutError:
-                    break
-                collected.append(msg)
-                if len(collected) >= 2 and msg.data == b"" and not msg.headers:
-                    break
-        finally:
-            await sub.unsubscribe()
+        # JSON that passes the §5.3 "starts with {" promotion check but lacks
+        # the required `prompt` field — the agent MUST reject with 400 before
+        # the handler runs and before any §6.4 leading ack would be emitted.
+        collected = await _collect_replies(
+            nc,
+            service.subject.inbox,
+            nc.new_inbox(),
+            payload=b'{"no_prompt":true}',
+        )
 
         evidence.write_jsonl(
             "wire.jsonl",
@@ -187,7 +186,12 @@ async def test_malformed_envelope_emits_400_then_terminator(
             ],
         )
 
-        assert len(collected) == 2
+        # Exactly 2 frames: §9.1 error frame + §6.5 terminator. NO leading
+        # ack — the ack lives after decode validation, and decode fails here.
+        assert len(collected) == 2, (
+            f"expected 2 frames (error + terminator); got {len(collected)}: "
+            f"{[(dict(m.headers or {}), m.data[:80]) for m in collected]!r}"
+        )
         error_msg, terminator = collected
         assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "400"
         assert terminator.data == b""

--- a/agent-sdk/python/tests/test_error_completion_e2e.py
+++ b/agent-sdk/python/tests/test_error_completion_e2e.py
@@ -1,11 +1,13 @@
 """End-to-end coverage of §9.3 error completion.
 
-An error-terminated stream MUST consist of two messages published to the
-reply subject: first an error-headered frame (§9.1), then the zero-byte
-headerless terminator (§6.5). This test provokes the error path from both
-sides — a malformed envelope (agent-side ``400``) and a handler exception
-(``500``) — then inspects the raw wire bytes captured on the reply inbox
-to confirm both messages are present in order.
+An error-terminated stream ends with an error-headered frame (§9.1)
+followed by the zero-byte headerless terminator (§6.5). On the handler-
+exception (``500``) path the SDK has already emitted a §6.4 leading ack
+before the handler ran, so the full wire shape is ``ack → error(500) →
+terminator``. On the malformed-envelope (``400``) path the decode fails
+before any ack would be emitted, so the wire is just ``error(400) →
+terminator``. This test provokes both paths and inspects the raw wire
+bytes captured on the reply inbox.
 
 The client-facing surface raises :class:`ProtocolError` on the error frame
 and does not re-raise when the trailing terminator arrives; the
@@ -15,6 +17,7 @@ subscription on the reply subject picks them up directly for assertions.
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -36,14 +39,15 @@ HEARTBEAT_INTERVAL_S = 30  # Long enough to never fire mid-test.
 
 
 async def _collect_replies(nc: NATSClient, subject: str, inbox: str) -> list[Msg]:
-    """Publish a prompt to `subject` and collect every reply that arrives."""
+    """Publish a prompt to `subject` and collect every reply that arrives.
+
+    Stops once the §6.5 empty-body, no-headers terminator arrives — the
+    list is always terminated by the terminator on a well-behaved agent.
+    """
     sub = await nc.subscribe(inbox)
     try:
         await nc.publish(subject, b"hi", reply=inbox)
         collected: list[Msg] = []
-        # Two messages expected per §9.3 (error frame + terminator); allow a
-        # generous window so flakiness from scheduler jitter doesn't mask the
-        # assertion failure we actually want.
         deadline = asyncio.get_event_loop().time() + 1.0
         while asyncio.get_event_loop().time() < deadline:
             try:
@@ -51,7 +55,7 @@ async def _collect_replies(nc: NATSClient, subject: str, inbox: str) -> list[Msg
             except TimeoutError:
                 break
             collected.append(msg)
-            if len(collected) >= 2 and msg.data == b"" and not msg.headers:
+            if msg.data == b"" and not msg.headers:
                 break
         return collected
     finally:
@@ -91,11 +95,22 @@ async def test_handler_exception_emits_error_then_terminator(
             ],
         )
 
-        # §9.3: two messages — error frame, then terminator.
-        assert len(messages) == 2, (
-            f"expected 2 wire messages (error + terminator); got {len(messages)}"
+        # §6.4 + §9.3: leading ack, then error frame, then terminator. The
+        # ack is emitted before the handler runs, so even a handler that
+        # raises immediately gets the leading-ack prefix on the wire.
+        assert len(messages) == 3, (
+            f"expected 3 wire messages (ack + error + terminator); got {len(messages)}: "
+            f"{[(dict(m.headers or {}), m.data[:80]) for m in messages]!r}"
         )
-        error_msg, terminator = messages
+        ack_msg, error_msg, terminator = messages
+
+        # First frame: §6.4 leading ack — no headers, status=ack payload.
+        assert not ack_msg.headers, (
+            f"leading ack MUST NOT carry NATS headers; saw {dict(ack_msg.headers or {})!r}"
+        )
+        assert json.loads(ack_msg.data) == {"type": "status", "data": "ack"}, (
+            f"first frame must be the §6.4 leading ack, got: {ack_msg.data!r}"
+        )
 
         # Error frame carries both service-error headers.
         error_headers = error_msg.headers or {}

--- a/agent-sdk/python/tests/test_keepalive_e2e.py
+++ b/agent-sdk/python/tests/test_keepalive_e2e.py
@@ -6,14 +6,23 @@ while a handler is running, the agent emits ``{"type":"status","data":"ack"}``
 every ``keepalive_interval_s`` so callers using a stream inactivity timeout
 don't fire on slow handlers.
 
+These tests focus on the **keep-alive cadence** — the periodic ack the
+loop emits while a handler is running. The SDK also emits a §6.4
+*leading* ack before the handler runs (covered separately by
+``test_leading_ack_e2e.py``); the leading ack is independent of the
+keep-alive flag and so every scenario here observes ≥1 ack
+unconditionally. Each test below normalises against that by counting
+acks beyond the leading one.
+
 Three integration scenarios:
 
-* **default-on, slow handler** — at least one ack appears in the streamed
-  chunks.
-* **disabled, slow handler** — no ack, even when the handler runs longer
-  than the (non-)interval.
-* **default-on, fast handler** — no ack (the loop's first emit is ``after``
-  the first ``asyncio.sleep``, so a sub-interval handler never trips it).
+* **default-on, slow handler** — multiple keep-alive acks appear in
+  addition to the leading ack.
+* **disabled, slow handler** — only the leading ack appears (the
+  keep-alive loop never runs).
+* **default-on, fast handler** — only the leading ack appears (the
+  handler completes within one interval, so the keep-alive loop's
+  first periodic emit never fires).
 
 Plus a unit test guarding the constructor's input validation.
 """
@@ -108,7 +117,10 @@ async def test_keepalive_emits_ack_during_slow_handler(
 
         acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
         responses = [c for c in received if isinstance(c, ResponseChunk)]
-        assert len(acks) >= 1, f"expected ≥1 keep-alive ack, saw chunks: {received!r}"
+        # 1 leading ack + ≥1 keep-alive ack (handler runs ~4 intervals).
+        assert len(acks) >= 2, (
+            f"expected ≥2 acks (leading + ≥1 keep-alive), saw chunks: {received!r}"
+        )
         assert any(r.text == "done" for r in responses), (
             f"expected the handler's final 'done' response, saw: {received!r}"
         )
@@ -117,8 +129,17 @@ async def test_keepalive_emits_ack_during_slow_handler(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_disabled_emits_no_ack(nc: NATSClient, evidence: EvidenceRecorder) -> None:
-    """`keepalive_interval_s=None` suppresses keep-alive even on slow handlers."""
+async def test_keepalive_disabled_emits_only_leading_ack(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """`keepalive_interval_s=None` suppresses the keep-alive loop entirely.
+
+    The SDK still emits the §6.4 *leading* ack before the handler runs —
+    that is unconditional and separate from the keep-alive cadence — so
+    a slow handler observed under this flag shows exactly one ack on the
+    wire (the leading one), with no further periodic acks regardless of
+    how long the handler takes.
+    """
     handler_duration = 0.3
 
     service = AgentService(
@@ -151,7 +172,14 @@ async def test_keepalive_disabled_emits_no_ack(nc: NATSClient, evidence: Evidenc
             [json.loads(chunk.model_dump_json()) for chunk in received],
         )
         acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
-        assert acks == [], f"expected no keep-alive acks when disabled, got: {acks!r}"
+        assert len(acks) == 1, (
+            f"expected exactly one ack (the leading one) with keep-alive disabled, "
+            f"got {len(acks)}: {acks!r}"
+        )
+        # And the leading ack must be the first chunk on the stream.
+        assert isinstance(received[0], StatusChunk) and received[0].status == "ack", (
+            f"first chunk must be the leading ack, got: {received[0]!r}"
+        )
     finally:
         await service.stop()
 
@@ -243,10 +271,17 @@ async def test_keepalive_no_ack_between_error_frame_and_terminator(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_skips_ack_for_fast_handler(
+async def test_keepalive_emits_only_leading_ack_for_fast_handler(
     nc: NATSClient,
 ) -> None:
-    """A handler that completes within one interval never trips the keep-alive."""
+    """A handler that completes within one interval never trips the keep-alive loop.
+
+    The leading §6.4 ack still fires (the SDK emits it unconditionally
+    before the handler runs), so the stream shows exactly one ack — but
+    the periodic keep-alive loop's first emit is gated behind
+    ``await asyncio.sleep(interval)`` and is cancelled when the handler
+    returns, so no additional ack appears.
+    """
     interval = 1.0  # well above the handler's duration
 
     async def fast_handler(envelope: Envelope, stream: PromptStream) -> None:
@@ -277,6 +312,9 @@ async def test_keepalive_skips_ack_for_fast_handler(
             await agents.close()
 
         acks = [c for c in received if isinstance(c, StatusChunk) and c.status == "ack"]
-        assert acks == [], f"fast handler must not emit any keep-alive acks, got: {acks!r}"
+        assert len(acks) == 1, (
+            f"fast handler must emit exactly one ack (the §6.4 leading one), "
+            f"got {len(acks)}: {acks!r}"
+        )
     finally:
         await service.stop()

--- a/agent-sdk/python/tests/test_keepalive_e2e.py
+++ b/agent-sdk/python/tests/test_keepalive_e2e.py
@@ -316,5 +316,15 @@ async def test_keepalive_emits_only_leading_ack_for_fast_handler(
             f"fast handler must emit exactly one ack (the §6.4 leading one), "
             f"got {len(acks)}: {acks!r}"
         )
+        # Pin ORDER: the §6.4 leading ack must be `frames[0]`. Without this,
+        # a regression that emitted the ack AFTER the response chunk would
+        # still pass the count assertion above but break the spec invariant
+        # that the ack is the first frame on the reply subject. The sibling
+        # `test_keepalive_disabled_emits_only_leading_ack` already pins this
+        # under `keepalive_interval_s=None`; this test extends the same
+        # invariant to the keep-alive-enabled config.
+        assert isinstance(received[0], StatusChunk) and received[0].status == "ack", (
+            f"first chunk must be the §6.4 leading ack, got: {received[0]!r}"
+        )
     finally:
         await service.stop()

--- a/agent-sdk/python/tests/test_leading_ack_e2e.py
+++ b/agent-sdk/python/tests/test_leading_ack_e2e.py
@@ -1,0 +1,222 @@
+"""End-to-end coverage of the §6.4 leading-ack requirement.
+
+Spec §6.4 (clarified 2026-05): agents MUST emit exactly one
+``{"type":"status","data":"ack"}`` chunk as the **first** message on the
+reply subject, before any ``response``/``query`` chunk and before any
+work that introduces observable latency. The ack confirms request
+receipt, resets the caller's §6.6 inactivity timeout ahead of any
+warm-up gap, and makes the stream observable to generic NATS tooling
+(``nats req --wait-for-empty``).
+
+Two integration scenarios:
+
+* **happy path** — a handler that emits one response chunk; the wire
+  trace shows ``status=ack`` first, then the handler's response, then
+  the §6.5 terminator.
+* **malformed envelope** — the 400 path runs before any ack would be
+  emitted, so a request that fails decode produces just ``error(400)``
+  + terminator with no ack frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from synadia_ai.agents import Envelope, ResponseChunk, StatusChunk
+from synadia_ai.agents.messages import decode_chunk
+
+from synadia_ai.agent_service import AgentService, PromptStream
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.aio.msg import Msg
+
+    from tests.harness.evidence import EvidenceRecorder
+
+
+AGENT = "test"
+OWNER = "pytest"
+# Long heartbeat — keeps the wire trace focused on the prompt/reply path.
+HEARTBEAT_INTERVAL_S = 30
+
+
+async def _drain_reply(
+    nc: NATSClient,
+    subject: str,
+    inbox: str,
+    payload: bytes,
+    timeout: float = 2.0,
+) -> list[Msg]:
+    """Publish ``payload`` to ``subject`` and collect every reply on ``inbox``.
+
+    Stops once the §6.5 empty-body, no-headers terminator arrives, so the
+    returned list always ends with the terminator on a well-behaved agent.
+    """
+    sub = await nc.subscribe(inbox)
+    try:
+        await nc.publish(subject, payload, reply=inbox)
+        collected: list[Msg] = []
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                msg = await sub.next_msg(timeout=0.5)
+            except TimeoutError:
+                break
+            collected.append(msg)
+            if msg.data == b"" and not msg.headers:
+                break
+        return collected
+    finally:
+        await sub.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_prompt_emits_leading_ack(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """§6.4: the FIRST frame on the reply subject MUST be ``status=ack``."""
+
+    async def _echo(envelope: Envelope, stream: PromptStream) -> None:
+        await stream.send(envelope.prompt)
+
+    service = AgentService(
+        agent=AGENT,
+        owner=OWNER,
+        session_name="leading-ack",
+        nc=nc,
+        heartbeat_interval_s=HEARTBEAT_INTERVAL_S,
+        # Disable the keep-alive loop — its acks are emitted AFTER the
+        # configured interval and so can't conflate with the leading ack
+        # under test. The leading-ack emit path is independent of this flag.
+        keepalive_interval_s=None,
+    )
+    service.on_prompt(_echo)
+    await service.start()
+
+    try:
+        frames = await _drain_reply(
+            nc, service.subject.inbox, nc.new_inbox(), b'{"prompt":"hello"}'
+        )
+        evidence.write_jsonl(
+            "frames.jsonl",
+            [
+                {
+                    "headers": dict(msg.headers or {}),
+                    "data_len": len(msg.data),
+                    "data_preview": msg.data[:200].decode("utf-8", errors="replace"),
+                }
+                for msg in frames
+            ],
+        )
+
+        # Expected wire shape: ack, response, terminator.
+        assert len(frames) == 3, (
+            f"expected 3 frames (ack + response + terminator); got {len(frames)}: "
+            f"{[(dict(m.headers or {}), m.data[:80]) for m in frames]!r}"
+        )
+
+        ack_msg, response_msg, terminator = frames
+
+        # First frame: the §6.4 leading ack.
+        ack_chunk = decode_chunk(ack_msg.data)
+        assert isinstance(ack_chunk, StatusChunk), (
+            f"first frame must be a StatusChunk; got {type(ack_chunk).__name__}: "
+            f"{ack_msg.data!r}"
+        )
+        assert ack_chunk.status == "ack", (
+            f"leading status chunk must carry status=ack; got status={ack_chunk.status!r}"
+        )
+        assert not ack_msg.headers, (
+            f"leading ack MUST NOT carry NATS headers; saw {dict(ack_msg.headers or {})!r}"
+        )
+
+        # Second frame: the handler's response.
+        response_chunk = decode_chunk(response_msg.data)
+        assert isinstance(response_chunk, ResponseChunk), (
+            f"second frame must be a ResponseChunk; got {type(response_chunk).__name__}"
+        )
+        assert response_chunk.text == "hello"
+
+        # Third frame: §6.5 terminator (empty body, no headers).
+        assert terminator.data == b""
+        assert not terminator.headers
+
+        # Sanity check the JSON wire shape literally — the evidence file is
+        # the human-readable trace, but pin the bytes here so a future refactor
+        # of `encode_chunk` can't silently shift the shape.
+        assert json.loads(ack_msg.data) == {"type": "status", "data": "ack"}
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_malformed_prompt_no_ack_before_400(
+    nc: NATSClient, evidence: EvidenceRecorder
+) -> None:
+    """§6.4 + §9.3: the leading ack lives AFTER decode validation.
+
+    A request that fails decode never reaches the handler, and so never
+    emits an ack. The wire is exactly ``error(400)`` + terminator. This
+    pins down that the SDK's leading-ack emit isn't moved above the
+    decode block by a future refactor — otherwise generic NATS tooling
+    would see a misleading "stream looks healthy" ack on a request that
+    the agent rejected.
+    """
+
+    async def _never_called(envelope: Envelope, stream: PromptStream) -> None:
+        raise AssertionError("handler MUST NOT run on malformed envelope")
+
+    service = AgentService(
+        agent=AGENT,
+        owner=OWNER,
+        session_name="leading-ack-400",
+        nc=nc,
+        heartbeat_interval_s=HEARTBEAT_INTERVAL_S,
+        keepalive_interval_s=None,
+    )
+    service.on_prompt(_never_called)
+    await service.start()
+
+    try:
+        # `{"no_prompt":true}` passes the §5.3 "starts with {" promotion check
+        # but lacks the required `prompt` field, so decode raises and the agent
+        # MUST short-circuit with 400 before any ack would be emitted.
+        frames = await _drain_reply(
+            nc, service.subject.inbox, nc.new_inbox(), b'{"no_prompt":true}'
+        )
+        evidence.write_jsonl(
+            "frames.jsonl",
+            [
+                {
+                    "headers": dict(msg.headers or {}),
+                    "data_len": len(msg.data),
+                    "data_preview": msg.data[:200].decode("utf-8", errors="replace"),
+                }
+                for msg in frames
+            ],
+        )
+
+        assert len(frames) == 2, (
+            f"expected 2 frames (error + terminator); got {len(frames)}: "
+            f"{[(dict(m.headers or {}), m.data[:80]) for m in frames]!r}"
+        )
+        error_msg, terminator = frames
+
+        # First frame: §9.1 error frame with 400.
+        assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "400"
+
+        # And critically: no ack snuck in before the error.
+        decoded = decode_chunk(error_msg.data) if error_msg.data else None
+        assert not isinstance(decoded, StatusChunk) or decoded.status != "ack", (
+            f"a 400-rejected request MUST NOT emit a leading ack; "
+            f"first frame decoded as: {decoded!r}"
+        )
+
+        # Second frame: §6.5 terminator.
+        assert terminator.data == b""
+        assert not terminator.headers
+    finally:
+        await service.stop()

--- a/agent-sdk/python/tests/test_leading_ack_e2e.py
+++ b/agent-sdk/python/tests/test_leading_ack_e2e.py
@@ -74,9 +74,7 @@ async def _drain_reply(
 
 
 @pytest.mark.asyncio
-async def test_prompt_emits_leading_ack(
-    nc: NATSClient, evidence: EvidenceRecorder
-) -> None:
+async def test_prompt_emits_leading_ack(nc: NATSClient, evidence: EvidenceRecorder) -> None:
     """§6.4: the FIRST frame on the reply subject MUST be ``status=ack``."""
 
     async def _echo(envelope: Envelope, stream: PromptStream) -> None:
@@ -123,8 +121,7 @@ async def test_prompt_emits_leading_ack(
         # First frame: the §6.4 leading ack.
         ack_chunk = decode_chunk(ack_msg.data)
         assert isinstance(ack_chunk, StatusChunk), (
-            f"first frame must be a StatusChunk; got {type(ack_chunk).__name__}: "
-            f"{ack_msg.data!r}"
+            f"first frame must be a StatusChunk; got {type(ack_chunk).__name__}: {ack_msg.data!r}"
         )
         assert ack_chunk.status == "ack", (
             f"leading status chunk must carry status=ack; got status={ack_chunk.status!r}"

--- a/agent-sdk/python/tests/test_leading_ack_e2e.py
+++ b/agent-sdk/python/tests/test_leading_ack_e2e.py
@@ -95,9 +95,33 @@ async def test_prompt_emits_leading_ack(nc: NATSClient, evidence: EvidenceRecord
     await service.start()
 
     try:
-        frames = await _drain_reply(
-            nc, service.subject.inbox, nc.new_inbox(), b'{"prompt":"hello"}'
-        )
+        # Inline publish+drain so we can capture the *latency* between request
+        # publish and the leading ack's arrival on the reply subject. The §6.4
+        # rationale is that the ack arrives "ahead of any warm-up gap" — a
+        # regression that wedges synchronous work between decode and the ack
+        # emit would still produce ack-first wire order but defeat the spec
+        # invariant. The latency assertion below is the guard for that case.
+        inbox = nc.new_inbox()
+        sub = await nc.subscribe(inbox)
+        try:
+            published_at = asyncio.get_event_loop().time()
+            await nc.publish(service.subject.inbox, b'{"prompt":"hello"}', reply=inbox)
+            first_msg = await sub.next_msg(timeout=2.0)
+            first_arrival = asyncio.get_event_loop().time()
+            frames = [first_msg]
+            deadline = published_at + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    msg = await sub.next_msg(timeout=0.5)
+                except TimeoutError:
+                    break
+                frames.append(msg)
+                if msg.data == b"" and not msg.headers:
+                    break
+        finally:
+            await sub.unsubscribe()
+
+        ack_latency_s = first_arrival - published_at
         evidence.write_jsonl(
             "frames.jsonl",
             [
@@ -108,6 +132,28 @@ async def test_prompt_emits_leading_ack(nc: NATSClient, evidence: EvidenceRecord
                 }
                 for msg in frames
             ],
+        )
+        evidence.write_json(
+            "ack-latency.json",
+            {
+                "published_at_s": published_at,
+                "first_arrival_s": first_arrival,
+                "ack_latency_s": ack_latency_s,
+                "budget_s": 0.5,
+            },
+        )
+
+        # §6.4 latency budget: the leading ack must reach the caller well
+        # within the warm-up gap it's meant to mask. 500 ms is generous —
+        # healthy local NATS round-trip is ~10 ms — but tight enough to
+        # catch a regression that adds synchronous work above the ack emit
+        # (e.g. cache warm-up, model preload, attachment fetch). CI flake
+        # risk at this bound is negligible.
+        assert ack_latency_s < 0.5, (
+            f"leading ack arrived {ack_latency_s * 1000:.1f} ms after publish; "
+            f"budget is 500 ms. §6.4 requires the ack to precede observable "
+            f"warm-up latency — a slow ack defeats the spec invariant even "
+            f"though wire ordering is still ack-first."
         )
 
         # Expected wire shape: ack, response, terminator.
@@ -202,12 +248,19 @@ async def test_malformed_prompt_no_ack_before_400(
         )
         error_msg, terminator = frames
 
-        # First frame: §9.1 error frame with 400.
+        # First frame: §9.1 error frame with 400. The combination of
+        # `len(frames) == 2` above and the error-code header here pins the
+        # §6.4 "no ack before 400" invariant — a regression that emitted a
+        # leading ack would shift the error frame to position 1 and break
+        # this header assertion (an ack chunk carries no NATS headers).
         assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "400"
 
-        # And critically: no ack snuck in before the error.
+        # Belt-and-braces: explicitly verify the first frame doesn't decode
+        # as a leading-ack StatusChunk. Redundant given the assertions above,
+        # but keeps the §6.4 invariant readable at the assertion level.
         decoded = decode_chunk(error_msg.data) if error_msg.data else None
-        assert not isinstance(decoded, StatusChunk) or decoded.status != "ack", (
+        is_leading_ack = isinstance(decoded, StatusChunk) and decoded.status == "ack"
+        assert not is_leading_ack, (
             f"a 400-rejected request MUST NOT emit a leading ack; "
             f"first frame decoded as: {decoded!r}"
         )

--- a/agent-sdk/python/tests/test_query_e2e.py
+++ b/agent-sdk/python/tests/test_query_e2e.py
@@ -27,6 +27,7 @@ from synadia_ai.agents import (
     Query,
     QueryTimeout,
     ResponseChunk,
+    StatusChunk,
 )
 
 from synadia_ai.agent_service import AgentService, PromptStream
@@ -42,7 +43,7 @@ OWNER = "pytest"
 HEARTBEAT_INTERVAL_S = 30  # Long enough that no beacon fires during the test.
 
 
-def _snapshot(msg: ResponseChunk | Query | Any) -> dict[str, object]:
+def _snapshot(msg: ResponseChunk | StatusChunk | Query | Any) -> dict[str, object]:
     """Render an async-iterator item to a JSON-safe dict for evidence capture."""
     if isinstance(msg, Query):
         return {
@@ -89,7 +90,7 @@ async def test_query_happy_path(nc: NATSClient, evidence: EvidenceRecorder) -> N
             found = await agents.discover(timeout=1.0)
             agent = next(a for a in found if a.prompt_subject == service.subject.inbox)
 
-            messages: list[ResponseChunk | Query | object] = []
+            messages: list[ResponseChunk | StatusChunk | Query | object] = []
             async for msg in agent.prompt("run it", timeout=5.0):
                 messages.append(msg)
                 if isinstance(msg, Query):
@@ -97,8 +98,13 @@ async def test_query_happy_path(nc: NATSClient, evidence: EvidenceRecorder) -> N
 
             evidence.write_jsonl("chunks.jsonl", [_snapshot(m) for m in messages])
 
-            assert len(messages) == 3, f"expected 3 yielded items, got {len(messages)}"
-            first, second, third = messages
+            # Filter out the SDK's §6.4 leading ack — the test cares about the
+            # handler's own emissions: "thinking…", the query, then "done".
+            payload = [m for m in messages if not isinstance(m, StatusChunk)]
+            assert len(payload) == 3, (
+                f"expected 3 non-status items, got {len(payload)}: {messages!r}"
+            )
+            first, second, third = payload
             assert isinstance(first, ResponseChunk)
             assert first.text == "thinking…"
 
@@ -147,7 +153,7 @@ async def test_query_concurrent_asks(nc: NATSClient, evidence: EvidenceRecorder)
             found = await agents.discover(timeout=1.0)
             agent = next(a for a in found if a.prompt_subject == service.subject.inbox)
 
-            messages: list[ResponseChunk | Query | object] = []
+            messages: list[ResponseChunk | StatusChunk | Query | object] = []
             queries: list[Query] = []
             async for msg in agent.prompt("kick off", timeout=5.0):
                 messages.append(msg)
@@ -205,7 +211,7 @@ async def test_query_timeout(nc: NATSClient, evidence: EvidenceRecorder) -> None
             found = await agents.discover(timeout=1.0)
             agent = next(a for a in found if a.prompt_subject == service.subject.inbox)
 
-            messages: list[ResponseChunk | Query | object] = []
+            messages: list[ResponseChunk | StatusChunk | Query | object] = []
             async for msg in agent.prompt("ping", timeout=5.0):
                 messages.append(msg)
                 # Deliberately do NOT reply — let the agent-side timeout fire.

--- a/agent-sdk/python/tests/test_reference_agent_e2e.py
+++ b/agent-sdk/python/tests/test_reference_agent_e2e.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from synadia_ai.agents import Agents, Attachment, ResponseChunk
+from synadia_ai.agents import Agents, Attachment, ResponseChunk, StatusChunk
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -134,15 +134,20 @@ async def test_reference_agent_echoes_prefix_and_saves_attachment(
             f"python reference agent not discovered; subjects={[a.prompt_subject for a in found]}"
         )
 
-        received: list[ResponseChunk] = []
+        received: list[ResponseChunk | StatusChunk] = []
         async for msg in discovered.prompt(
             "hello", attachments=[Attachment.from_bytes("note.txt", b"ping")], timeout=10.0
         ):
-            assert isinstance(msg, ResponseChunk), f"unexpected chunk type: {type(msg).__name__}"
+            assert isinstance(msg, ResponseChunk | StatusChunk), (
+                f"unexpected chunk type: {type(msg).__name__}"
+            )
             received.append(msg)
 
-        assert len(received) == 1
-        assert received[0].text == "py-ref: hello [received 1 attachment(s): note.txt]"
+        # The reference agent inherits the §6.4 leading ack from the SDK; the
+        # handler contributes a single ResponseChunk.
+        responses = [c for c in received if isinstance(c, ResponseChunk)]
+        assert len(responses) == 1
+        assert responses[0].text == "py-ref: hello [received 1 attachment(s): note.txt]"
 
         saved = save_dir / "note.txt"
         assert saved.exists(), (

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -6,6 +6,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
 the 0.x line is explicitly unstable per protocol spec §11.2.
 
+## [Unreleased]
+
+### Notes
+
+- **Spec §6.4 clarification — leading ack from spec-compliant agents.**
+  Spec §6.4 was sharpened: spec-compliant agents now emit exactly one
+  `{"type":"status","data":"ack"}` chunk as the **first** message on
+  the reply subject, before any `response`/`query` chunk. No
+  functional change in this package — `decode_chunk` already parses
+  the chunk into `StatusChunk(status="ack")`, the per-read inactivity
+  timeout in `Agent.prompt` naturally resets on every delivered chunk
+  (so the leading ack satisfies §6.6 with no special-case code), and
+  `StatusChunk`s are yielded to user code alongside `ResponseChunk` as
+  before. The sibling `synadia-ai-agent-service` has been updated to
+  emit the leading ack unconditionally; consumer code that filtered on
+  `ResponseChunk` already ignores ack chunks correctly. Tweaked
+  `examples/06-chat.py` so its "thinking…" spinner keeps spinning
+  through the leading ack rather than stopping prematurely.
+
 ## [0.7.0] - 2026-05-04
 
 Restores wire-shape parity with the spec and TS SDK after the

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -323,6 +323,34 @@ either guides them to success or frustrates them.
 
 ## Alignment milestones
 
+- **2026-05-11 - §6.4 leading-ack compliance (agent-sdk-only).** Spec
+  §6.4 was sharpened: every prompt handler MUST emit exactly one
+  `{"type":"status","data":"ack"}` chunk as the **first** message on
+  the reply subject, before any `response`/`query` chunk and before
+  any work that introduces observable latency. Three of three Python
+  agents in the repo (reference agent, `demo_echo`, in-tree test
+  handlers) treated ack as optional under the previous wording. Fixed
+  at a single chokepoint: `AgentService._on_prompt_request` now
+  publishes the ack unconditionally after a successful envelope
+  decode and before invoking the user handler, so every Python agent
+  becomes spec-compliant on upgrade with no per-agent code change.
+  The ack is independent of `keepalive_interval_s` — passing `None`
+  only disables the periodic keep-alive cadence, not the leading ack.
+  Malformed envelopes still produce `error(400) → terminator` with no
+  spurious ack (ack lives after decode validation). Client-sdk
+  unchanged — `decode_chunk` already parsed the chunk and the
+  per-read inactivity timeout naturally resets on every delivered
+  chunk; the `06-chat.py` spinner trigger was tweaked to wait for
+  the first `ResponseChunk`/`Query` rather than the leading
+  `StatusChunk` to avoid a visible silent gap. Test surface updated:
+  new `test_leading_ack_e2e.py` covers the wire-shape ordering and
+  the no-ack-before-400 invariant; existing
+  `test_keepalive_skips_ack_for_fast_handler` /
+  `test_keepalive_disabled_emits_no_ack` were rewritten to expect
+  exactly one ack (the leading one), not zero;
+  `test_handler_exception_emits_error_then_terminator` extended from
+  2 frames to 3 (ack + error + terminator). Pairs with a TS-side fix
+  shipped in parallel; protocol version stays at `"0.3"`.
 - **2026-05-03 - prompt-stream catch-up to TS PR #66 (`requestMany` +
   sentinel).** Python-side analogue of the TS reshape, mirroring TS's
   shape exactly: prompt streams ride a shared

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -250,8 +250,10 @@ the gap is, **why** it matters, and a hint at the **next step**.
    long-running handlers by default (`keepalive_interval_s=30.0`).
    This is extra wire traffic vs prior Python releases - quiet
    handlers that comfortably fit under the TS SDK's 60 s stream
-   inactivity timeout don't need it. No spec violation (§6.4 status
-   chunks are at the agent's discretion). Pass
-   `keepalive_interval_s=None` to disable. Next step: monitor for
-   integrator complaints; consider documenting "when to disable" as
-   the SDK matures.
+   inactivity timeout don't need it. The *periodic* mid-stream
+   cadence is at the agent's discretion (§6.4); the *leading* ack
+   (one chunk before the handler runs) is mandatory under v0.3 §6.4
+   and is emitted unconditionally. Pass `keepalive_interval_s=None`
+   to disable the periodic cadence only — the leading ack still
+   fires. Next step: monitor for integrator complaints; consider
+   documenting "when to disable" as the SDK matures.

--- a/client-sdk/python/examples/06-chat.py
+++ b/client-sdk/python/examples/06-chat.py
@@ -116,14 +116,19 @@ async def _run_turn(
     console.print(Text(f"  {agent_name}  ", style="bold green"), end="")
     thinking = console.status("agent is thinking…", spinner="dots")
     thinking.start()
-    first_chunk = True
+    first_visible_chunk = True
     try:
         stream = agent.prompt(text, timeout=timeout)
         async for msg in stream:
-            if first_chunk:
-                thinking.stop()
-                first_chunk = False
+            # Keep the spinner spinning through the §6.4 leading ack (and any
+            # mid-stream keep-alive acks) so the user sees "thinking…" until
+            # the agent's actual text starts arriving. Without this the
+            # spinner stops within milliseconds of `await stream.__aiter__()`,
+            # leaving a visible silent gap before the first response chunk.
             if isinstance(msg, ResponseChunk):
+                if first_visible_chunk:
+                    thinking.stop()
+                    first_visible_chunk = False
                 console.print(msg.text, end="", highlight=False)
                 if msg.attachments:
                     names = ", ".join(a.filename for a in msg.attachments)
@@ -139,19 +144,23 @@ async def _run_turn(
                 # A chat REPL is not the right place for interactive query
                 # handling — send a safe default so the agent's stream can
                 # finish. Users wanting query interaction should use
-                # `04-query-reply.py` instead.
+                # `04-query-reply.py` instead. Treat a query like a visible
+                # chunk so the spinner stops before we print the prompt.
+                if first_visible_chunk:
+                    thinking.stop()
+                    first_visible_chunk = False
                 console.print(
                     Text(f"\n  [agent asked: {msg.prompt}; replying 'ok']", style="yellow")
                 )
                 await msg.reply("ok")
     except asyncio.CancelledError:
-        if not first_chunk:
+        if not first_visible_chunk:
             console.print(Text("\n  [turn cancelled]", style="yellow"))
         else:
             console.print(Text("[turn cancelled]", style="yellow"))
         raise
     except NatsAgentError as err:
-        if not first_chunk:
+        if not first_visible_chunk:
             console.print()
         console.print(Text(f"  [{type(err).__name__}: {err}]", style="bold red"))
         return

--- a/client-sdk/python/examples/06-chat.py
+++ b/client-sdk/python/examples/06-chat.py
@@ -125,10 +125,10 @@ async def _run_turn(
             # the agent's actual text starts arriving. Without this the
             # spinner stops within milliseconds of `await stream.__aiter__()`,
             # leaving a visible silent gap before the first response chunk.
+            if first_visible_chunk and not isinstance(msg, StatusChunk):
+                thinking.stop()
+                first_visible_chunk = False
             if isinstance(msg, ResponseChunk):
-                if first_visible_chunk:
-                    thinking.stop()
-                    first_visible_chunk = False
                 console.print(msg.text, end="", highlight=False)
                 if msg.attachments:
                     names = ", ".join(a.filename for a in msg.attachments)
@@ -144,11 +144,7 @@ async def _run_turn(
                 # A chat REPL is not the right place for interactive query
                 # handling — send a safe default so the agent's stream can
                 # finish. Users wanting query interaction should use
-                # `04-query-reply.py` instead. Treat a query like a visible
-                # chunk so the spinner stops before we print the prompt.
-                if first_visible_chunk:
-                    thinking.stop()
-                    first_visible_chunk = False
+                # `04-query-reply.py` instead.
                 console.print(
                     Text(f"\n  [agent asked: {msg.prompt}; replying 'ok']", style="yellow")
                 )

--- a/client-sdk/python/tests/test_interop_e2e.py
+++ b/client-sdk/python/tests/test_interop_e2e.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from synadia_ai.agents import Agents, ResponseChunk
+from synadia_ai.agents import Agents, ResponseChunk, StatusChunk
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -195,16 +195,26 @@ async def test_python_client_prompts_ts_reference_agent(
         found = await agents.discover(timeout=3.0)
         discovered = next(a for a in found if a.prompt_subject == ts_reference_agent.prompt_subject)
 
-        received: list[ResponseChunk] = []
+        received: list[ResponseChunk | StatusChunk] = []
         async for msg in discovered.prompt("hello from python", timeout=10.0):
-            assert isinstance(msg, ResponseChunk), (
+            # Spec-compliant agents emit a §6.4 leading `status=ack` chunk
+            # before the handler's first response chunk. The TS reference
+            # agent was updated to do this in lockstep with the Python
+            # agent-sdk (parallel branch `sdk-mandatory-initial-ack`); pre-
+            # update it sent only ResponseChunks. Accept both, then filter
+            # responses for the content assertion so this test stays green
+            # across the cross-SDK rollout window.
+            assert isinstance(msg, ResponseChunk | StatusChunk), (
                 f"TS agent emitted unexpected chunk type: {type(msg).__name__}"
             )
             received.append(msg)
 
-        # The reference agent is hardcoded to emit exactly one response chunk.
-        assert len(received) == 1
-        assert received[0].text == "demo agent received your prompt."
+        # The reference agent is hardcoded to emit exactly one response chunk;
+        # the §6.4 leading ack (if present) is an SDK-level concern, not a
+        # property of the reference-agent handler under test here.
+        responses = [c for c in received if isinstance(c, ResponseChunk)]
+        assert len(responses) == 1, f"expected 1 response chunk, got: {received!r}"
+        assert responses[0].text == "demo agent received your prompt."
     finally:
         await agents.close()
 


### PR DESCRIPTION
## Summary

- Spec §6.4 was clarified: agents MUST emit exactly one `{"type":"status","data":"ack"}` chunk as the **first** message on the reply subject, before any `response`/`query` chunk and before any work that introduces observable latency. The ack resets the caller's §6.6 inactivity timeout ahead of any warm-up gap and makes the stream observable to generic NATS tooling (`nats req --wait-for-empty`).
- Implements the §6.4 invariant at a single chokepoint: `AgentService._on_prompt_request` now publishes the leading ack unconditionally after a successful envelope decode and before invoking the user handler. Every Python agent in the repo (reference agent, `demo_echo`, in-tree test handlers) becomes spec-compliant on upgrade with no per-agent code change.
- Leading ack is independent of `keepalive_interval_s` — passing `None` only disables the periodic keep-alive cadence. Malformed envelopes still produce `error(400) → terminator` with no spurious ack (ack lives after decode validation).

## Changes

- **agent-sdk**: 5-line edit to `service.py` inserting the ack between decode and handler; one comment-block tweak documenting the relationship to keep-alive.
- **agent-sdk tests**: new `test_leading_ack_e2e.py` covers the wire-shape ordering and the no-ack-before-400 invariant. Existing tests rewritten for the new invariant — see commit-by-commit history.
- **client-sdk**: no functional change. `06-chat.py` spinner trigger now waits for the first `ResponseChunk`/`Query` rather than the first chunk overall, so the "thinking…" spinner keeps spinning through the leading ack instead of stopping prematurely.
- **docs**: `CHANGELOG.md` entries on both packages + a 2026-05-11 alignment milestone in `client-sdk/python/CLAUDE.md`.

## Pairing with TS

This is the Python half. The TS half is being landed in parallel by Mario (branch `sdk-mandatory-initial-ack`). The client side of either SDK already tolerates ack absence, so the cross-SDK interop test stays green throughout the rollout — there's a brief asymmetry on the wire while only one SDK has shipped, but no regression.

## Test plan

- [x] `cd agent-sdk/python && uv run ruff check --no-cache .`
- [x] `cd agent-sdk/python && uv run ruff format --check .`
- [x] `cd agent-sdk/python && uv run mypy --no-incremental src tests examples`
- [x] `cd agent-sdk/python && uv run pytest -v` — 40 passed
- [x] `cd client-sdk/python && uv run ruff check --no-cache .`
- [x] `cd client-sdk/python && uv run mypy --no-incremental src tests examples`
- [x] `cd client-sdk/python && uv run pytest -v` — 212 passed (including `tests/test_interop_e2e.py` against the unchanged TS reference agent — confirms the client receive side tolerates ack absence in the asymmetric window before the TS fix lands)
- [x] Wire trace evidence: `agent-sdk/python/tests/_evidence/tests__test_leading_ack_e2e.py__test_prompt_emits_leading_ack/frames.jsonl` shows `status=ack` first, then the handler's response, then the §6.5 terminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)