### PR TITLE
release(agent-sdk/python): cut 0.4.0 — §6.4 mandatory leading ack

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -8,6 +8,8 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-11
+
 ### Changed
 
 - **Leading `status=ack` chunk is now emitted unconditionally (§6.4).**

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agent-service"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python agent-host SDK for the NATS Agent Protocol — register and serve spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/agent-sdk/python/uv.lock
+++ b/agent-sdk/python/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agent-service"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary

Cuts `synadia-ai-agent-service` **0.4.0** to ship the §6.4 mandatory leading-ack behavior landed in #101.

- `agent-sdk/python/pyproject.toml`: `0.3.0` → `0.4.0`
- `agent-sdk/python/CHANGELOG.md`: existing `[Unreleased]` §6.4 entry moves under a versioned `[0.4.0] - 2026-05-11` heading
- `agent-sdk/python/uv.lock`: refreshed by `uv lock` to match

## Why minor (not patch)

The agent now emits an additional wire-observable `status=ack` chunk as the first message on every prompt reply, before the handler runs. Any agent author who was counting chunks sees one more — observable behavior change on the wire, so minor under semver's 0.x discipline (per the CHANGELOG header).

Invariants confirmed in #101:
- Leading ack is independent of `keepalive_interval_s` — passing `None` disables only the periodic cadence, not the leading ack
- Malformed envelope still produces `error(400) → terminator` with **no** spurious ack — the ack lives after decode validation

## Scope check

`grep -rn "0\.3\.0"` across `agent-sdk/python/` confirms `pyproject.toml` is the single source of truth — `src/synadia_ai/agent_service/service.py` resolves the version at runtime via `importlib.metadata.version("synadia-ai-agent-service")`. No README refs, no `__version__` constant, no other call-sites. Remaining `0.3.0` matches in `CHANGELOG.md` / `CLAUDE.md` are historical (prior release heading, milestone log) — correctly untouched.

Dependency floor `synadia-ai-agents>=0.7` is unchanged — #101 didn't introduce a new client-sdk surface dependency (`StatusChunk` + `encode_chunk` were already exported).

## Client-sdk

No companion release on `synadia-ai-agents` — PR #101's `client-sdk/python/**` changes were all docs / example / test, no `src/` change. The `[Unreleased]` entry sitting in `client-sdk/python/CHANGELOG.md` will ride on the next functional change.

## Test plan

- [x] `cd agent-sdk/python && uv lock` — clean refresh, only the project's self-version line changed
- [x] CI on this branch — same matrix as #101 (ruff / mypy / pytest across py3.11/3.12/3.13)

## After merge

Tag `python-agent-service-v0.4.0` on the resulting main commit; the `release-python-agent-service.yml` workflow fires on tag push and publishes to PyPI via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)