### PR TITLE
release prep: 0.5.x patch wave (protocol rename)

### DIFF
--- a/agent-sdk/typescript/CHANGELOG.md
+++ b/agent-sdk/typescript/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-11
+
 ### Changed
 
+- **Protocol rename.** Every reference to "NATS Agent Protocol" in
+  this package's prose, package metadata, and source-file
+  headers/docstrings now reads **Synadia Agent Protocol for NATS**.
+  No API, wire shape, or protocol version (`0.3`) change.
 - **Leading `status=ack` chunk is now emitted unconditionally (§6.4).**
   Spec §6.4 was sharpened to require that every prompt handler emit
   exactly one `{"type":"status","data":"ack"}` chunk as the **first**

--- a/agent-sdk/typescript/package.json
+++ b/agent-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/agent-service",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Server-side TypeScript SDK for the Synadia Agent Protocol for NATS — host an agent (AgentService, ReferenceAgent, server-side helpers).",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -7,7 +7,7 @@
     "nats",
     "agent",
     "channel",
-    "nats-agent-protocol",
+    "synadia-agent-protocol",
     "synadia-agents"
   ],
   "license": "Apache-2.0",

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-channel",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Synadia Agent Protocol for NATS channel for OpenClaw. Makes every OpenClaw agent a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "openclaw",

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-pi-channel",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Synadia Agent Protocol for NATS channel for PI Agent. Makes every PI session a discoverable, spec-compliant agent on NATS.",
   "keywords": [
     "pi-package",

--- a/agents/pi/package.json
+++ b/agents/pi/package.json
@@ -8,7 +8,7 @@
     "nats",
     "agent",
     "channel",
-    "nats-agent-protocol",
+    "synadia-agent-protocol",
     "synadia-agents"
   ],
   "license": "Apache-2.0",

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-11
+
+### Changed
+
+- **Protocol rename.** Every reference to "NATS Agent Protocol" in
+  this package's prose, package metadata, and source-file
+  headers/docstrings now reads **Synadia Agent Protocol for NATS**.
+  No API, wire shape, or protocol version (`0.3`) change.
+
 ## [0.5.0] - 2026-05-04
 
 > Breaking: removes the `PromptStream.replySubject` getter from the

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/agents",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript SDK for the Synadia Agent Protocol for NATS — discover, prompt, and stream from AI agents over NATS.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/examples/claude-code-headless/CHANGELOG.md
+++ b/examples/claude-code-headless/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-11
+
+### Changed
+
+- **Protocol rename.** Every reference to "NATS Agent Protocol" in
+  this package's prose and package metadata now reads **Synadia Agent
+  Protocol for NATS**. No code, wire shape, or protocol version
+  (`0.3`) change.
+
 ## [0.5.3] - 2026-05-04
 
 ### Changed

--- a/examples/claude-code-headless/package.json
+++ b/examples/claude-code-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-claude-code-headless",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Headless NATS agent host that spawns, prompts, and stops Claude Code sessions as first-class Synadia Agent Protocol for NATS v0.3 instances. Each session registers as agents.prompt.cc-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",

--- a/examples/pi-headless/CHANGELOG.md
+++ b/examples/pi-headless/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-11
+
+### Changed
+
+- **Protocol rename.** Every reference to "NATS Agent Protocol" in
+  this package's prose and package metadata now reads **Synadia Agent
+  Protocol for NATS**. No code, wire shape, or protocol version
+  (`0.3`) change.
+
 ## [0.5.3] - 2026-05-04
 
 ### Changed

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/nats-pi-headless",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Headless NATS agent host that spawns, prompts, and stops PI coding-agent sessions as first-class Synadia Agent Protocol for NATS v0.3 instances. Each session registers as agents.prompt.pi-headless.<owner>.<session_id>; a small controller service adds verb-first spawn/stop/list endpoints.",
   "keywords": [
     "nats",


### PR DESCRIPTION
## Summary

Refreshes the npmjs.com descriptions of six `@synadia-ai/*` packages after the protocol-rename sweep in #103. No API, wire shape, or protocol version (`0.3`) changes ship here.

| Package | Old | New |
| --- | --- | --- |
| `@synadia-ai/agents` | 0.5.0 | **0.5.1** |
| `@synadia-ai/agent-service` | 0.5.1 | **0.5.2** † |
| `@synadia-ai/nats-channel` (openclaw) | 0.5.5 | **0.5.6** |
| `@synadia-ai/nats-pi-channel` | 0.5.2 | **0.5.3** |
| `@synadia-ai/nats-pi-headless` | 0.5.3 | **0.5.4** |
| `@synadia-ai/nats-claude-code-headless` | 0.5.3 | **0.5.4** |

† **`@synadia-ai/agent-service` 0.5.2 also rolls in the §6.4 leading-ack work** that was sitting in the CHANGELOG's `[Unreleased]` section (commit 5c297d2, mirrors `synadia-ai-agent-service` 0.4.0 on the Python side). If we'd rather mirror Python's minor bump instead, say the word and I'll re-cut as `0.6.0` — that'd just cascade through `devmode.sh off` writing `^0.6.0` to dependent pins.

## Notes

- `claude-channel-nats` (`agents/claude-code/`) is intentionally **not** in this wave per your earlier answer.
- `file:` links between consumers and SDK source are preserved on this branch — that's `main`'s default dev state. The local publish ladder flips them to `^semver` via `./devtools/devmode.sh off` before `npm publish` and flips back with `on` after, as documented in `README-DEV.md` §"Releasing the SDKs".

## Test plan

- [ ] CI green (lint + typecheck + tests on both SDKs)
- [ ] Reviewer bot has no findings
- [ ] After merge: run the local publish ladder on the mschallner machine — six user-gated `npm publish` invocations, then a follow-up `devmode.sh on` commit to restore the dev-default file: links on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)