### PR TITLE
release prep: python 0.7.1 + agent-service 0.4.1 (protocol rename)

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -8,6 +8,16 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-12
+
+### Changed
+
+- **Protocol name** — package metadata, module docstring, and README
+  updated to "Synadia Agent Protocol for NATS" (was: "NATS Agent
+  Protocol"). Renamed in PR #103. No wire format, public identifier,
+  or behavior change — protocol version stays `"0.3"`, leading-ack
+  semantics from 0.4.0 unchanged.
+
 ## [0.4.0] - 2026-05-11
 
 ### Changed

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agent-service"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python agent-host SDK for the Synadia Agent Protocol for NATS — register and serve spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/agent-sdk/python/uv.lock
+++ b/agent-sdk/python/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agent-service"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },
@@ -416,7 +416,7 @@ dev = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "../../client-sdk/python" }
 dependencies = [
     { name = "nats-py" },

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -8,6 +8,16 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-12
+
+### Changed
+
+- **Protocol name** — package metadata, module docstrings, README,
+  CONTRIBUTING, and `docs/protocol-mapping.md` updated to "Synadia
+  Agent Protocol for NATS" (was: "NATS Agent Protocol"). Renamed in
+  PR #103. No wire format, public identifier, exception class, or
+  behavior change — protocol version stays `"0.3"`.
+
 ### Notes
 
 - **Spec §6.4 clarification — leading ack from spec-compliant agents.**

--- a/client-sdk/python/pyproject.toml
+++ b/client-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-agents"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python client SDK for the Synadia Agent Protocol for NATS — discover and prompt spec-compliant agents over NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/client-sdk/python/uv.lock
+++ b/client-sdk/python/uv.lock
@@ -413,7 +413,7 @@ wheels = [
 
 [[package]]
 name = "synadia-ai-agents"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary

- Bumps `synadia-ai-agents` 0.7.0 → **0.7.1** and `synadia-ai-agent-service` 0.4.0 → **0.4.1** so PyPI metadata and shipped docstrings reflect the "Synadia Agent Protocol for NATS" rename from PR #103.
- Mirrors TS PR #104 (`release prep: 0.5.x patch wave (protocol rename)`) on the Python side — that PR explicitly skipped the two Python `pyproject.toml` files and CHANGELOGs.
- **Docs-only**: no wire format, no public identifier, no exception class, no behavior change. Protocol version stays `"0.3"`. The `agent-sdk` dependency floor (`synadia-ai-agents>=0.7`) is intentionally not tightened — `>=0.7` already accepts `0.7.1` and the rename is cosmetic.

The client-sdk 0.7.1 entry also ships the §6.4 leading-ack documentation note that has been sitting in `[Unreleased]` since PR #100 — it belongs in the first release after it landed.

## Test plan

- [x] `uv run ruff check --no-cache .` — clean in both subtrees
- [x] `uv run ruff format --check .` — clean in both subtrees
- [x] `uv run mypy --no-incremental src tests examples` — clean in both subtrees
- [x] `uv run pytest` — 212 passed (client-sdk), 40 passed (agent-sdk); cross-SDK interop test ran (not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)