### PR TITLE
docs+code: rename spec-repo URL to synadia-agent-sdk-docs

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"308086e8-05f7-43ea-9d32-2b9fede04c29","pid":798879,"procStart":"69212141","acquiredAt":1778527099775}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"308086e8-05f7-43ea-9d32-2b9fede04c29","pid":798879,"procStart":"69212141","acquiredAt":1778527099775}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       checkout_mode: base
       review_focus: |
         Additionally focus on:
-        - Synadia Agent Protocol for NATS compliance (spec: https://github.com/synadia-ai/nats-agent-sdk-docs).
+        - Synadia Agent Protocol for NATS compliance (spec: https://github.com/synadia-ai/synadia-agent-sdk-docs).
         - Cross-SDK wire compatibility between client-sdk/typescript and client-sdk/python — anything that changes the wire shape must keep both SDKs interoperable.
         - Attachment handling: base64 validation (strict RFC 4648), filename safety (no absolute paths, no ".." traversal, no NUL bytes), and path safety in per-agent staging directories.
         - Public API stability in @synadia-ai/agents (TypeScript) and synadia-ai-agents (Python). Call out breaking changes explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ view: layout, subject namespace, wire shape, quickstart. Read it before
 making changes that touch user-visible surface.
 
 The protocol spec is **not vendored here**. Canonical source:
-[`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs)
+[`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs)
 — always link to the GitHub URL when reasoning about wire shape. Local
 `docs/protocol-mapping.md` files inside each SDK translate spec → impl;
 they are not the spec itself.
@@ -147,7 +147,7 @@ subtree affects another. Before finishing a change, walk the list:
     Python is a hard requirement; the interop test catches drift.
   - Update every agent harness that hard-codes the protocol version
     string.
-  - Re-read the spec at `synadia-ai/nats-agent-sdk-docs` — the spec
+  - Re-read the spec at `synadia-ai/synadia-agent-sdk-docs` — the spec
     doc, not the local `protocol-mapping.md`, is the source of truth.
 - **Touched an agent harness** (`agents/*`)?
   - Update its README if user-visible config / subject layout changed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synadia Agents
 
-**SDKs and ready-to-run agent plugins for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs).**
+**SDKs and ready-to-run agent plugins for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).**
 
 The Synadia Agent Protocol for NATS lets any AI agent — Claude Code, OpenClaw, PI, Hermes, or your own — register itself as a NATS micro service named `agents`, and be discovered, prompted, and streamed from by any caller speaking the same wire format. This repo is the home of the official **caller** and **host** SDKs (TypeScript and Python — see [SDKs](#sdks) below), plus pre-built channel plugins that put popular AI harnesses on NATS without writing code.
 
@@ -57,7 +57,7 @@ nats sub 'agents.hb.*.*.*'
 
 To prompt an agent directly from the CLI (no SDK), pass three flags — `--replies=0 --reply-timeout=30s --timeout=60s`. The full CLI cookbook (prompts, attachments, status, control-plane, gotchas) lives at [`docs/using-nats-cli.md`](docs/using-nats-cli.md).
 
-Full spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>.
+Full spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>.
 
 ## Quickstart
 

--- a/agent-sdk/README.md
+++ b/agent-sdk/README.md
@@ -107,4 +107,4 @@ The wire is the contract — agents written with any host SDK can be driven by a
 
 </details>
 
-Full protocol spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>
+Full protocol spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>

--- a/agent-sdk/python/CLAUDE.md
+++ b/agent-sdk/python/CLAUDE.md
@@ -43,7 +43,7 @@ discovery. (This rule originated in the client-sdk's `AgentService`
 and travels with it into this package.)
 
 **The protocol spec is the source of truth.** Canonical location:
-[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+[`synadia-ai/synadia-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md).
 The §12 implementation checklist is what "compliant" means; the §3
 service-registration rules and §6/§7/§8 emission rules are the
 load-bearing parts for *this* SDK specifically.

--- a/agent-sdk/python/README.md
+++ b/agent-sdk/python/README.md
@@ -1,6 +1,6 @@
 # synadia-ai-agent-service
 
-Python **agent-host** SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+Python **agent-host** SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md).
 Embed `AgentService` in a Python agent harness (Hermes-style,
 claude-code, openclaw, pi, …) to register a spec-compliant agent on a
 NATS bus.
@@ -77,7 +77,7 @@ for cross-SDK interop.
   layout.
 - [`synadia-ai-agents`](../../client-sdk/python/) — the client surface
   this package depends on.
-- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
   — wire-level source of truth.
 - [`CHANGELOG.md`](CHANGELOG.md) — release notes.
 - [`CLAUDE.md`](CLAUDE.md) — project context and engineering

--- a/agent-sdk/python/src/synadia_ai/agent_service/__init__.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/__init__.py
@@ -1,6 +1,6 @@
 """Python agent-host SDK for the Synadia Agent Protocol for NATS.
 
-See https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md
+See https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md
 for the wire spec; the §12 implementation checklist is what
 ``AgentService`` enforces.
 

--- a/agent-sdk/typescript/CHANGELOG.md
+++ b/agent-sdk/typescript/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   exactly one `{"type":"status","data":"ack"}` chunk as the **first**
   message on the reply subject, **before** any work that introduces
   observable latency
-  ([nats-agent-sdk-docs@b1c6972](https://github.com/synadia-ai/nats-agent-sdk-docs/commit/b1c6972)).
+  ([synadia-agent-sdk-docs@b1c6972](https://github.com/synadia-ai/synadia-agent-sdk-docs/commit/b1c6972)).
   `AgentService.#dispatchPrompt` now publishes the ack after a
   successful envelope decode and before invoking the user-supplied
   handler — so every TS agent built on `AgentService` (the reference

--- a/agent-sdk/typescript/README.md
+++ b/agent-sdk/typescript/README.md
@@ -1,6 +1,6 @@
 # @synadia-ai/agent-service
 
-**Server-side TypeScript SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs).** Host an agent — register the `agents` micro service, serve the `prompt` and `status` endpoints, publish heartbeats, and stream typed chunks back to callers.
+**Server-side TypeScript SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).** Host an agent — register the `agents` micro service, serve the `prompt` and `status` endpoints, publish heartbeats, and stream typed chunks back to callers.
 
 Pairs with [`@synadia-ai/agents`](../../client-sdk/typescript/) (the caller-side SDK). Agent harness authors install both — caller imports stay on `@synadia-ai/agents` (subjects, envelope types, errors), host imports come from `@synadia-ai/agent-service` (`AgentService`, `ReferenceAgent`, server-side wire helpers). The two packages release in lockstep.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -67,4 +67,4 @@ Caller-side constraints (rejected with `400`): `content` must be strict RFC 4648
 
 Per-agent configuration, install instructions, and troubleshooting live in each subdirectory README.
 
-Full protocol spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>
+Full protocol spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -1,7 +1,7 @@
 # NATS Channel for Claude Code
 
 Connect Claude Code to NATS messaging as a spec-compliant
-[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.3 agent
+[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) v0.3 agent
 (verb-first subjects + `status` endpoint).
 
 The MCP server registers an `agents` micro service, exposes a

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * NATS channel for Claude Code — spec-compliant agent for the
- * Synadia Agent Protocol for NATS v0.3 (see https://github.com/synadia-ai/nats-agent-sdk-docs).
+ * Synadia Agent Protocol for NATS v0.3 (see https://github.com/synadia-ai/synadia-agent-sdk-docs).
  *
  * Self-contained MCP server that registers as an `agents` micro service,
  * exposes a `prompt` endpoint on agents.prompt.cc.<owner>.<name>, publishes

--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -6,7 +6,7 @@
 > is planned but not yet filed (needs a catch-up rebase first), so the
 > install below clones the fork directly.
 
-NATS gateway for [Hermes Agent](https://github.com/NousResearch/hermes-agent), implementing the **[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs) v0.3**.
+NATS gateway for [Hermes Agent](https://github.com/NousResearch/hermes-agent), implementing the **[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) v0.3**.
 
 Hermes is a self-improving coding agent with a CLI, a TUI, and a messaging gateway sharing one agent core. With the NATS gateway enabled, each running Hermes instance becomes a discoverable, addressable, streaming agent on NATS. Callers using any SDK that speaks the protocol — e.g. [`synadia-ai-agents`](../../client-sdk/python) (Python; import root `synadia_ai.agents`) or [`@synadia-ai/agents`](../../client-sdk/typescript) (TypeScript) — can enumerate running Hermes instances, prompt them (with attachments), and stream responses back.
 
@@ -337,7 +337,7 @@ Cross-machine collisions are deliberately allowed — the protocol permits multi
 
 ## Wire protocol (summary)
 
-Full spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>. Quick reference:
+Full spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>. Quick reference:
 
 - **Request**: plain UTF-8 text OR JSON `{"prompt":"…","attachments":[{"filename":"…","content":"<base64>"},…]}`. Attachment `content` must be RFC 4648 §4 base64 (standard alphabet, padded, no URL-safe variant, no whitespace). Under v0.3 the envelope no longer carries a `session` field — the session IS the subject's 5th token.
 - **Response**: typed chunks on the reply subject — `{"type":"status","data":"ack"}` (accepted / keep-alive), `{"type":"response","data":"<text>"}` (content), `{"type":"query","data":{…}}` (mid-stream approval).
@@ -372,4 +372,4 @@ Current deferrals (candidates for future phases, not bugs):
 - **Hermes user guide for the NATS channel:** [`website/docs/user-guide/messaging/nats.md`](https://github.com/synadia-ai/hermes-agent/blob/nats-gateway/website/docs/user-guide/messaging/nats.md) in the fork — deep dive on configuration, subject layout, multiple sessions via profiles, attachments, full troubleshooting table.
 - **Architecture & design:** [`docs/nats-gateway-design.md`](https://github.com/synadia-ai/hermes-agent/blob/nats-gateway/docs/nats-gateway-design.md) — protocol↔adapter mapping, streaming model, approval hook, failure modes, and §17 retrospective lessons (including the v0.3 migration addenda).
 - **Adapter source:** [`gateway/platforms/nats.py`](https://github.com/synadia-ai/hermes-agent/blob/nats-gateway/gateway/platforms/nats.py).
-- **Protocol spec:** <https://github.com/synadia-ai/nats-agent-sdk-docs>
+- **Protocol spec:** <https://github.com/synadia-ai/synadia-agent-sdk-docs>

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -1,6 +1,6 @@
 # @synadia-ai/nats-channel
 
-NATS channel plugin for [OpenClaw](https://openclaw.ai). Every configured OpenClaw agent becomes discoverable, addressable, and streamable over NATS — anyone running a [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs) client (e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) or [`synadia-ai-agents`](../../client-sdk/python)) can find your agent, prompt it, and stream the reply back.
+NATS channel plugin for [OpenClaw](https://openclaw.ai). Every configured OpenClaw agent becomes discoverable, addressable, and streamable over NATS — anyone running a [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) client (e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) or [`synadia-ai-agents`](../../client-sdk/python)) can find your agent, prompt it, and stream the reply back.
 
 ## Install
 
@@ -292,7 +292,7 @@ The plugin pulls `@synadia-ai/agents` (caller-side primitives) and `@synadia-ai/
 ## See also
 
 - Sibling channel plugins: [`pi`](../pi) (PI Agent), [`claude-code`](../claude-code) (Claude Code).
-- The wire-level protocol behind it all: [`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs).
+- The wire-level protocol behind it all: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).
 
 ## License
 

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -1,6 +1,6 @@
 # @synadia-ai/nats-pi-channel
 
-NATS channel extension for [PI Agent](https://github.com/badlogic/pi-mono). Every running PI session becomes discoverable, addressable, and streamable over NATS — anyone with a [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs) client (e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) or [`synadia-ai-agents`](../../client-sdk/python)) can find your session, prompt it, and stream the reply back.
+NATS channel extension for [PI Agent](https://github.com/badlogic/pi-mono). Every running PI session becomes discoverable, addressable, and streamable over NATS — anyone with a [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) client (e.g. [`@synadia-ai/agents`](../../client-sdk/typescript) or [`synadia-ai-agents`](../../client-sdk/python)) can find your session, prompt it, and stream the reply back.
 
 ## Install
 
@@ -227,7 +227,7 @@ Deliberate deferrals:
 ## See also
 
 - Sibling channel plugins: [`openclaw`](../openclaw) (OpenClaw), [`claude-code`](../claude-code) (Claude Code).
-- The wire-level protocol behind it all: [`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs).
+- The wire-level protocol behind it all: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).
 
 ## License
 

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -2,7 +2,7 @@
  * Synadia Agent Protocol for NATS channel for PI Agent.
  *
  * Implements the Synadia Agent Protocol for NATS v0.3 (see
- * `https://github.com/synadia-ai/nats-agent-sdk-docs`). Every PI session becomes a
+ * `https://github.com/synadia-ai/synadia-agent-sdk-docs`). Every PI session becomes a
  * spec-compliant agent instance: discoverable via `$SRV.PING/INFO`,
  * addressable at `agents.prompt.pi.{owner}.{name}`, emitting typed response
  * chunks and a periodic heartbeat on `agents.hb.pi.{owner}.{name}`.

--- a/client-sdk/README.md
+++ b/client-sdk/README.md
@@ -92,4 +92,4 @@ The wire is the contract - agents can be driven by any SDK interchangeably.
 
 </details>
 
-Full protocol spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>
+Full protocol spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>

--- a/client-sdk/python/.github/ISSUE_TEMPLATE/bug.md
+++ b/client-sdk/python/.github/ISSUE_TEMPLATE/bug.md
@@ -36,5 +36,5 @@ artifact for the team to look at. Attach or paste relevant lines.
 ## Which protocol section (if applicable)
 
 If this is a wire-shape disagreement, which section of the
-[canonical spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+[canonical spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
 are you reading the SDK against? Paste the exact sentence.

--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -432,7 +432,7 @@ separately:
   version string and use raw `@nats-io/*` to publish heartbeats / serve
   prompts; each picks up the new subject layout independently.
 - **The protocol spec** at
-  [`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs)
+  [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs)
   gains the v0.3 verb-first subject hierarchy (§2), the `status`
   endpoint section, and the bumped `metadata.protocol_version`.
 - **Root-level `README.md`** and any monorepo-wide docs that show the

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -19,7 +19,7 @@ under a generic `pysdk` value - that would pollute the subject namespace
 and break `agent`-scoped discovery.
 
 **The protocol spec is the source of truth.** Canonical location:
-[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+[`synadia-ai/synadia-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md).
 This subdir does not keep a copy — always read the canonical. The
 implementation checklist in §12 is what "compliant" means.
 

--- a/client-sdk/python/CONTRIBUTING.md
+++ b/client-sdk/python/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for wanting to contribute! This project is the Python SDK for the
 Synadia Agent Protocol for NATS; the wire spec at
-[`synadia-ai/nats-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+[`synadia-ai/synadia-agent-sdk-docs/core-protocol.md`](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
 is the source of truth, and [`docs/protocol-mapping.md`](docs/protocol-mapping.md)
 shows how every SDK call maps to a spec section. When in doubt about
 what the code should do, check the spec.
@@ -104,7 +104,7 @@ Docs-only and pure-refactor PRs are the only exception.
 ### Protocol spec
 
 If you find the implementation contradicts the
-[canonical spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md),
+[canonical spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md),
 the implementation is wrong - open an issue or PR against the code.
 
 If you find the spec is ambiguous and the TS SDK at
@@ -114,7 +114,7 @@ fix. The interop test at `tests/test_interop_e2e.py` catches drifts that
 actually break cross-implementation talk.
 
 If you believe the spec itself is wrong, open an issue in the
-[`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs)
+[`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs)
 repo first; the SDK follows the spec.
 
 ## Reporting bugs and requesting features

--- a/client-sdk/python/README.md
+++ b/client-sdk/python/README.md
@@ -1,6 +1,6 @@
 # synadia-ai-agents
 
-Python **client** SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md).
+Python **client** SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md).
 Discover protocol-compliant agents over NATS and prompt them with
 streamed typed responses.
 
@@ -178,9 +178,9 @@ nats sub  "agents.hb.demo.alice.worker-1"                # watch heartbeats
 
 ## Documentation
 
-- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
   - the wire contract (source of truth, lives in
-  [`synadia-ai/nats-agent-sdk-docs`](https://github.com/synadia-ai/nats-agent-sdk-docs)).
+  [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs)).
 - [`docs/protocol-mapping.md`](docs/protocol-mapping.md) - every SDK call
   mapped to its spec section; for auditors and other-SDK implementers.
 - [`examples/README.md`](examples/README.md) - tour of the runnable

--- a/client-sdk/python/docs/protocol-mapping.md
+++ b/client-sdk/python/docs/protocol-mapping.md
@@ -1,7 +1,7 @@
 # Protocol mapping
 
 Every SDK call mapped to its section in the
-[Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+[Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
 (spec target: v0.3 verb-first wire). Intended for implementers of other
 SDKs and for reviewers auditing this one. The Python SDK currently ships
 **ahead** of the spec text — see "Open questions flagged upstream" below

--- a/client-sdk/python/examples/README.md
+++ b/client-sdk/python/examples/README.md
@@ -115,5 +115,5 @@ point `04` at an agent whose handler calls `stream.ask(...)`.
 
 - [Root README](../README.md) - conceptual quickstarts for the two
   personas (agent author, client author).
-- [Protocol spec](https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md)
+- [Protocol spec](https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md)
   - wire-level source of truth.

--- a/client-sdk/python/src/synadia_ai/agents/__init__.py
+++ b/client-sdk/python/src/synadia_ai/agents/__init__.py
@@ -1,6 +1,6 @@
 """Python SDK for the Synadia Agent Protocol for NATS.
 
-See https://github.com/synadia-ai/nats-agent-sdk-docs/blob/main/core-protocol.md
+See https://github.com/synadia-ai/synadia-agent-sdk-docs/blob/main/core-protocol.md
 for the wire spec.
 
 Public API entry points:

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -302,7 +302,7 @@ example in the monorepo to v0.3:
 - **READMEs + CLAUDE.md** across the monorepo update their subject
   layouts (root, `agents/README.md`, `examples/README.md`, every
   per-agent and per-example README).
-- **Spec docs** at `synadia-ai/nats-agent-sdk-docs` get the v0.3
+- **Spec docs** at `synadia-ai/synadia-agent-sdk-docs` get the v0.3
   verb-first subject hierarchy + `status` endpoint section in a
   follow-up PR.
 

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -1,6 +1,6 @@
 # @synadia-ai/agents
 
-**Caller-side TypeScript SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs).** Discover, prompt, and stream from AI agents over NATS.
+**Caller-side TypeScript SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).** Discover, prompt, and stream from AI agents over NATS.
 
 - **Catch errors before they hit the wire.** Oversized payloads and unsupported attachments are validated locally against the agent's advertised limits — and against the caller's own `nc.info.max_payload`, so the smaller of the two binds (a caller behind a smaller-cap broker fails fast instead of waiting for `MAX_PAYLOAD_VIOLATION`).
 - **Stream responses with `for await`.** Prompts return typed chunks (`response`, `status`, `query`) you iterate asynchronously.

--- a/client-sdk/typescript/docs/getting-started.md
+++ b/client-sdk/typescript/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-`@synadia-ai/agents` is the TypeScript client SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs). This guide walks through the complete flow: connecting, discovering agents, prompting one with attachments, and handling the three protocol-defined failure modes locally.
+`@synadia-ai/agents` is the TypeScript client SDK for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs). This guide walks through the complete flow: connecting, discovering agents, prompting one with attachments, and handling the three protocol-defined failure modes locally.
 
 ## Prerequisites
 
@@ -198,4 +198,4 @@ The underlying transport (`@nats-io/transport-node`) is explicitly supported on 
 
 - [`docs/protocol-mapping.md`](./protocol-mapping.md) - every SDK call mapped to its spec section.
 - [`examples/`](../examples) - 5 runnable scripts covering each major feature.
-- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/nats-agent-sdk-docs) - the authoritative wire contract.
+- [Synadia Agent Protocol for NATS spec](https://github.com/synadia-ai/synadia-agent-sdk-docs) - the authoritative wire contract.

--- a/docs/using-nats-cli.md
+++ b/docs/using-nats-cli.md
@@ -2,7 +2,7 @@
 
 A practical guide to driving a **Synadia Agent Protocol for NATS** agent from the [`nats` CLI](https://github.com/nats-io/natscli) — no SDK required. Useful for smoke-testing your own agent, poking at a third-party one, or reproducing a wire-shape bug without writing code.
 
-The protocol is fully documented at <https://github.com/synadia-ai/nats-agent-sdk-docs>. This doc shows the CLI commands that map to each protocol surface.
+The protocol is fully documented at <https://github.com/synadia-ai/synadia-agent-sdk-docs>. This doc shows the CLI commands that map to each protocol surface.
 
 ## Prereqs
 
@@ -145,7 +145,7 @@ The `cc-headless` controller has the same three verbs. See `examples/pi-headless
 
 ## See also
 
-- The protocol spec: <https://github.com/synadia-ai/nats-agent-sdk-docs>
+- The protocol spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>
 - Per-agent READMEs with agent-specific subject layouts: `agents/{pi,openclaw,claude-code,open-agent}/README.md`
 - Headless examples with control-plane endpoints: `examples/{pi,claude-code}-headless/README.md`
 - SDK-driven equivalents: `client-sdk/typescript/examples/`, `client-sdk/python/examples/`

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -6,7 +6,7 @@ stream responses back, and — when a [`pi-headless`](../pi-headless) or
 [`claude-code-headless`](../claude-code-headless) controller is online — spawn,
 prompt, and manage sessions from the browser.
 
-Primary use: manually poking at the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/nats-agent-sdk-docs)
+Primary use: manually poking at the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs)
 implementations - [`pi`](../../agents/pi), [`claude-code`](../../agents/claude-code),
 [`openclaw`](../../agents/openclaw), [`hermes`](../../agents/hermes),
 [`pi-headless`](../pi-headless), and the SDK's own reference agent.


### PR DESCRIPTION
## Summary

Updates every reference to the protocol spec repo from `github.com/synadia-ai/nats-agent-sdk-docs` to `github.com/synadia-ai/synadia-agent-sdk-docs` across 30 files. The old slug still redirects, so this is a cosmetic completeness sweep — but it lines the in-repo links up with the canonical URL.

Mechanical 1:1 replacement. No behaviour change, no wire shape change, no protocol version (`0.3`) change.

## Files touched

READMEs, CHANGELOGs, root + per-package CLAUDE.md, source-file headers in two TS / two Python files, the `.github/workflows/claude.yml` review prompt, a Python bug-report issue template, and the new `docs/using-nats-cli.md` cookbook.

## Test plan

- [ ] Reviewer bot has no findings
- [ ] CI green (typecheck, lint, tests) — prose-only diff, no code paths touched
- [ ] Spot-check one rendered README on GitHub to confirm the new link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)