### PR TITLE
agents/claude-code README: drop --dangerously-load-development-channels

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -16,7 +16,7 @@ message - the protocol's uniform end-of-stream signal.
 
 ## Prerequisites
 
-- [Bun](https://bun.sh) - the MCP server runs on Bun. Install with `curl -fsSL https://bun.sh/install | bash`.
+- [Bun](https://bun.sh) - the MCP server runs on Bun. Install with `curl -fsSL https://bun.sh/install | bash`, and make sure `bun` is on your `PATH`.
 - [NATS CLI](https://github.com/nats-io/natscli) - for managing contexts and testing.
 - A NATS server to connect to (local or remote) - the plugin defaults to `demo.nats.io`.
 
@@ -36,10 +36,10 @@ These are Claude Code commands - run `claude` to start a session first.
 /plugin install nats-channel@synadia-plugins
 ```
 
-**3. Launch with the channel flag.**
+**3. Launch Claude Code.**
 
 ```sh
-claude --dangerously-load-development-channels plugin:nats-channel@synadia-plugins
+claude
 ```
 
 By default, the server connects to `demo.nats.io` (no credentials required)


### PR DESCRIPTION
## Summary
- Claude Code v2.1.143+ no longer requires `--dangerously-load-development-channels` — `claude` on its own picks up the installed plugin, so the quick-setup command drops to just `claude`.
- Tighten the Bun prerequisite to call out that `bun` must be on `PATH` after install, in cleaner English than the original draft.

## Test plan
- [ ] Eyeball the rendered README on GitHub
- [ ] Verify on a fresh box: install plugin via `/plugin install nats-channel@synadia-plugins`, then run plain `claude` and confirm the MCP server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)