### PR TITLE
agents/claude-code README: note bun must be on PATH

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -16,7 +16,7 @@ message - the protocol's uniform end-of-stream signal.
 
 ## Prerequisites
 
-- [Bun](https://bun.sh) - the MCP server runs on Bun. Install with `curl -fsSL https://bun.sh/install | bash`.
+- [Bun](https://bun.sh) - the MCP server runs on Bun. Install with `curl -fsSL https://bun.sh/install | bash`, and make sure `bun` is on your `PATH`.
 - [NATS CLI](https://github.com/nats-io/natscli) - for managing contexts and testing.
 - A NATS server to connect to (local or remote) - the plugin defaults to `demo.nats.io`.
 


### PR DESCRIPTION
## Summary
- One-line tweak to the Bun prerequisite in `agents/claude-code/README.md`: after the install one-liner, call out that `bun` must be on `PATH`. The installer drops the binary in `~/.bun/bin` but doesn't always wire up the shell — without this note the MCP launch fails confusingly.

Scoped intentionally tight: the `--dangerously-load-development-channels` flag is still required for plugin messaging to actually flow, so that part stays as-is.

## Test plan
- [ ] Eyeball the rendered README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)