### PR TITLE
docs: cross-link standalone Hermes NATS Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Each subtree has its own `README.md` and the index READMEs (`client-sdk/README.m
 
 </details>
 
+## See also
+
+- **Hermes NATS Gateway:** [`synadia-ai/hermes-nats-gateway`](https://github.com/synadia-ai/hermes-nats-gateway) — the standalone, out-of-tree Hermes plugin that puts [Hermes Agent](https://github.com/NousResearch/hermes-agent) on NATS. Install it with `hermes plugins install synadia-ai/hermes-nats-gateway`; no upstream fork required.
+
 ## License
 
 Apache-2.0 across this monorepo — see each package's `LICENSE` file.


### PR DESCRIPTION
## Summary
Adds a "See also" entry to the top-level README pointing at [`synadia-ai/hermes-nats-gateway`](https://github.com/synadia-ai/hermes-nats-gateway) — the out-of-tree Hermes plugin (now installable via `hermes plugins install`).

Docs-only. Draft per monorepo workflow; merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)