### PR TITLE
Add agent-sdk echo example + NATS context support in reference-agent

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -61,6 +61,26 @@ For the browser test client `examples/agent-web-ui` only the caller
 SDK matters (it doesn't host an agent), but the install dance is the
 same.
 
+## Running the SDK-side examples
+
+Both SDKs ship runnable example scripts next to the package source —
+useful as smoke targets while iterating on the SDK or as starting
+shapes for new agents:
+
+| Path | What it does |
+| --- | --- |
+| `client-sdk/typescript/examples/01-discover.ts` … `05-liveness.ts` | Caller-side demos against a running agent. |
+| `client-sdk/typescript/examples/_run-reference-agent.ts` | Spec-compliant `ReferenceAgent` to point the caller demos at. |
+| `agent-sdk/typescript/examples/01-echo.ts` | Minimal `AgentService` echo agent. |
+
+Each script supports `$NATS_CONTEXT`, `$NATS_URL`, or falls back to
+`nats://127.0.0.1:4222`. Run with:
+
+```sh
+bun client-sdk/typescript/examples/_run-reference-agent.ts
+bun agent-sdk/typescript/examples/01-echo.ts
+```
+
 ## Installing the agent plugins locally (PI, OpenClaw, Claude Code)
 
 `agents/pi/`, `agents/openclaw/`, and `agents/claude-code/` are

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ await service.stop();
 await nc.close();
 ```
 
+**Try it now:** [`agent-sdk/typescript/examples/01-echo.ts`](agent-sdk/typescript/examples/01-echo.ts) is this code packaged as a runnable script — `bun agent-sdk/typescript/examples/01-echo.ts` (with `$NATS_CONTEXT`, `$NATS_URL`, or localhost fallback).
+
 For full install, error handling, and longer examples see the per-package READMEs: caller — [`client-sdk/typescript/`](client-sdk/typescript/) · [`client-sdk/python/`](client-sdk/python/); host — [`agent-sdk/typescript/`](agent-sdk/typescript/) · [`agent-sdk/python/`](agent-sdk/python/).
 
 ## Examples

--- a/agent-sdk/README.md
+++ b/agent-sdk/README.md
@@ -45,6 +45,8 @@ await service.start();
 console.log(`listening on ${service.subject.prompt}`);
 ```
 
+**Try it now:** [`typescript/examples/01-echo.ts`](typescript/examples/01-echo.ts) is this code packaged as a runnable script — `bun typescript/examples/01-echo.ts` (with `$NATS_CONTEXT`, `$NATS_URL`, or localhost fallback).
+
 `AgentService` handles registration, the `prompt` and `status` endpoints, the heartbeat loop, the per-request keep-alive ack, the §6.5 stream terminator, and translates handler exceptions into 500s.
 
 **Python**

--- a/agent-sdk/typescript/README.md
+++ b/agent-sdk/typescript/README.md
@@ -45,6 +45,8 @@ await service.start();
 console.log(`listening on ${service.subject.prompt}`);
 ```
 
+**Try it now:** [`examples/01-echo.ts`](examples/01-echo.ts) is this same code packaged as a runnable script — `bun examples/01-echo.ts` (with `$NATS_CONTEXT`, `$NATS_URL`, or localhost fallback).
+
 `service.start()` is everything: it adds the `prompt` and `status` endpoints with the right queue groups, advertises the broker-derived `max_payload`, kicks off the heartbeat publisher (with an immediate first beat so discovery is prompt), and stays running until you call `service.stop()`.
 
 The matching caller-side code lives next to [`@synadia-ai/agents`](../../client-sdk/typescript/) — see its README for `discover()` / `prompt()`.

--- a/agent-sdk/typescript/examples/01-echo.ts
+++ b/agent-sdk/typescript/examples/01-echo.ts
@@ -1,16 +1,17 @@
-// Spin up a spec-compliant reference agent for local experimentation.
-// Companion to the `examples/*` scripts — run this in one terminal, then
-// invoke the demos in another.
+// Minimal echo agent — replies to every prompt with `echo: <prompt text>`.
+//
+// The shortest runnable demonstration of the `AgentService` host API.
+// Use this as a smoke target while iterating on a caller, or as a
+// starting shape when writing your own agent.
 //
 // Connection resolution:
 //   1. $NATS_CONTEXT — name of a NATS CLI context under ~/.config/nats/context/
 //   2. $NATS_URL     — raw URL (credentials in userinfo are honored)
 //   3. nats://127.0.0.1:4222
 
-import type { ServiceMsg } from "@nats-io/services";
 import { connect as natsConnect } from "@nats-io/transport-node";
 import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
-import { ReferenceAgent } from "@synadia-ai/agent-service/testing";
+import { AgentService } from "@synadia-ai/agent-service";
 
 async function main(): Promise<void> {
   const opts = process.env["NATS_CONTEXT"]
@@ -20,32 +21,25 @@ async function main(): Promise<void> {
       : { servers: "nats://127.0.0.1:4222" };
   const nc = await natsConnect(opts);
 
-  const agent = new ReferenceAgent({
+  const service = new AgentService({
     nc,
-    agent: "demo-agent",
+    agent: "echo",
     owner: process.env["USER"] ?? "anon",
-    name: "example",
-    description: "reference agent for @synadia-ai/agents examples",
-    maxPayload: "1MB",
-    attachmentsOk: true,
-    heartbeatIntervalS: 5,
-    promptHandler: (msg: ServiceMsg) => {
-      // Echo a tiny acknowledgement. Real agents produce actual inference.
-      msg.respond(
-        new TextEncoder().encode(
-          JSON.stringify({ type: "response", data: "demo agent received your prompt." }),
-        ),
-      );
-      msg.respond(""); // terminator
-    },
+    name: "main",
+    description: "Echo agent — replies with the prompt prefixed by 'echo: '",
   });
-  await agent.start();
-  console.log(`reference agent listening on ${agent.promptSubject}`);
+
+  service.onPrompt(async (envelope, response) => {
+    await response.send(`echo: ${envelope.prompt}`);
+  });
+
+  await service.start();
+  console.log(`echo agent listening on ${service.subject.prompt}`);
   console.log("press Ctrl+C to stop");
 
   const shutdown = async (): Promise<void> => {
     console.log("\nshutting down…");
-    await agent.stop();
+    await service.stop();
     await nc.close();
     process.exit(0);
   };
@@ -54,6 +48,6 @@ async function main(): Promise<void> {
 }
 
 void main().catch((err: unknown) => {
-  console.error("reference agent failed:", err);
+  console.error("echo agent failed:", err);
   process.exit(1);
 });

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -18,7 +18,7 @@ Counterpart to the caller-side numbered demos in
 
 # 2. Run an example. Connection resolution:
 #      $NATS_CONTEXT  >  $NATS_URL  >  nats://127.0.0.1:4222
-cd ../..   # agent-sdk/typescript
+cd ..   # agent-sdk/typescript
 NATS_CONTEXT=my-context bun examples/01-echo.ts
 # or:
 NATS_URL=tls://connect.ngs.global bun examples/01-echo.ts

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -1,0 +1,51 @@
+# `@synadia-ai/agent-service` examples
+
+Runnable host-side examples — minimal scripts that spin up an agent
+speaking the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).
+Counterpart to the caller-side numbered demos in
+[`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/).
+
+| Example                    | What it shows                                                           |
+| -------------------------- | ----------------------------------------------------------------------- |
+| [`01-echo.ts`](01-echo.ts) | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`. |
+
+## Run
+
+```sh
+# 1. Build both SDKs (caller first, then host).
+(cd ../../../client-sdk/typescript && bun install && bun run build)
+(cd ../../../agent-sdk/typescript  && bun install && bun run build)
+
+# 2. Run an example. Connection resolution:
+#      $NATS_CONTEXT  >  $NATS_URL  >  nats://127.0.0.1:4222
+cd ../..   # agent-sdk/typescript
+NATS_CONTEXT=my-context bun examples/01-echo.ts
+# or:
+NATS_URL=tls://connect.ngs.global bun examples/01-echo.ts
+# or:
+bun examples/01-echo.ts   # localhost fallback
+```
+
+You should see:
+
+```
+echo agent listening on agents.prompt.echo.<you>.main
+press Ctrl+C to stop
+```
+
+Drive it from another terminal with the caller-side
+[`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/)
+demos, or directly with the `nats` CLI:
+
+```sh
+nats req agents.prompt.echo.<you>.main "hello!" \
+  --replies=0 --reply-timeout=30s --timeout=60s
+```
+
+Output:
+
+```
+{"type":"status","data":"ack"}
+{"type":"response","data":"echo: hello!"}
+(empty terminator)
+```


### PR DESCRIPTION
## Summary

- New **`agent-sdk/typescript/examples/`** directory with **`01-echo.ts`** — a minimal `AgentService` echo agent that replies `echo: <prompt>`. Host-side counterpart to the caller-side numbered demos in `client-sdk/typescript/examples/`. Includes its own `README.md`.
- **`_run-reference-agent.ts`** now resolves its NATS connection from `\$NATS_CONTEXT` (NATS CLI context) first, then `\$NATS_URL`, then `nats://127.0.0.1:4222`. Same resolution pattern is used by the new echo example.
- The echo example is mentioned in:
  - the root `README.md` (next to the host-side quickstart),
  - `agent-sdk/README.md` (next to the TypeScript quickstart),
  - `agent-sdk/typescript/README.md` (next to the 30-second quickstart),
  - `README-DEV.md` (new "Running the SDK-side examples" subsection listing both runnable scripts).

Motivation: the existing `_run-reference-agent.ts` only supported `\$NATS_URL`, which makes pointing it at NGS / a remote NATS awkward. And the agent-sdk had no runnable example next to its source — the closest one was a 5-line README snippet you had to copy into a fresh file before running.

## Test plan

- [x] `bun run typecheck` passes in both `client-sdk/typescript/` and `agent-sdk/typescript/`
- [x] `bun run lint` passes in both
- [x] `bun run format:check` passes in both
- [ ] Manual smoke: \`NATS_CONTEXT=<your-context> bun agent-sdk/typescript/examples/01-echo.ts\` → reachable on \`agents.prompt.echo.\$USER.main\`, replies \`echo: hello!\` to a CLI prompt
- [ ] Manual smoke: \`NATS_CONTEXT=<your-context> bun client-sdk/typescript/examples/_run-reference-agent.ts\` → reachable on \`agents.prompt.demo-agent.\$USER.example\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)