### PR TITLE
client-sdk/typescript: add withAgentReconnectDefaults helper (#121)

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `withAgentReconnectDefaults(opts)` and `AGENT_RECONNECT_DEFAULTS` —
+  opinionated reconnect defaults for agent runtimes:
+  `maxReconnectAttempts: -1`, `reconnectTimeWait: 2000`,
+  `reconnectJitter: 200`, `waitOnFirstConnect: true`. Pure transform
+  that fills in only the fields the caller left undefined, so explicit
+  `0` / `false` overrides survive untouched. See
+  [#121](https://github.com/synadia-ai/synadia-agents/issues/121).
+
+### Behavior notes
+
+- The new helper is opt-in. Existing callers that go straight to
+  `connect()` without wrapping their options keep the upstream
+  nats.js defaults (~20s reconnect budget, then `close`).
+- `waitOnFirstConnect: true` means `connect()` retries through a
+  server that is unreachable at startup. Misconfigured URLs or TLS
+  cert paths now manifest as a stuck "reconnecting…" UI rather than
+  an immediate throw — desirable for agent runtimes, surprising for
+  short-lived clients. Callers who want the throw-fast behavior
+  should pass `waitOnFirstConnect: false` explicitly (the helper
+  preserves it).
+
 ## [0.5.1] - 2026-05-11
 
 ### Changed

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -73,13 +73,30 @@ Both error types extend `ValidationError` → `NatsAgentError`. See [Error handl
 
 ## What's in the box
 
-| API                                                              | Purpose                                                     |
-| ---------------------------------------------------------------- | ----------------------------------------------------------- |
-| `new Agents({ nc, ... })`                                        | Construct from a caller-owned `NatsConnection`.             |
-| `agents.discover({filter?, timeoutMs?})`                         | Return a live `Agent[]`; auto subscribe-before-ping (§8.5). |
-| `agent.prompt(text, {attachments, signal, inactivityTimeoutMs})` | Return a `PromptStream`.                                    |
-| `agents.liveness(id)` / `onHeartbeat(id, cb)` / `ping(id)`       | Heartbeat tracking and on-demand ping.                      |
-| `agents.close()`                                                 | Tear down SDK state; aborts all in-flight streams.          |
+| API                                                              | Purpose                                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `new Agents({ nc, ... })`                                        | Construct from a caller-owned `NatsConnection`.                                      |
+| `agents.discover({filter?, timeoutMs?})`                         | Return a live `Agent[]`; auto subscribe-before-ping (§8.5).                          |
+| `agent.prompt(text, {attachments, signal, inactivityTimeoutMs})` | Return a `PromptStream`.                                                             |
+| `agents.liveness(id)` / `onHeartbeat(id, cb)` / `ping(id)`       | Heartbeat tracking and on-demand ping.                                               |
+| `agents.close()`                                                 | Tear down SDK state; aborts all in-flight streams.                                   |
+| `loadContextOptions(name)` / `parseNatsUrl(url)`                 | Bridge `nats` CLI context files / URLs into `NodeConnectionOptions` for `connect()`. |
+| `withAgentReconnectDefaults(opts?)`                              | Opt-in resilient reconnect defaults for agent runtimes — see below. Pure transform.  |
+
+### Resilient reconnect defaults
+
+`@nats-io/transport-node` gives up after ~10 reconnect attempts (~20 seconds) by default, which is too aggressive for an agent process that's supposed to outlive laptop sleeps and intermittent broker reachability. Wrap your options with `withAgentReconnectDefaults` to keep retrying indefinitely (and to retry from the very first connect attempt, instead of throwing if the broker is down at startup):
+
+```ts
+import { connect } from "@nats-io/transport-node";
+import { withAgentReconnectDefaults } from "@synadia-ai/agents";
+
+const nc = await connect(withAgentReconnectDefaults({ servers: "nats://localhost:4222" }));
+```
+
+The helper merges defaults into caller-provided options, preserving any field the caller explicitly set (including `0` and `false`). The defaults — `maxReconnectAttempts: -1`, `reconnectTimeWait: 2000`, `reconnectJitter: 200`, `waitOnFirstConnect: true` — are also exported as `AGENT_RECONNECT_DEFAULTS` for introspection or selective override.
+
+When you adopt these defaults, also handle the terminal `close` status event in your `for await (const s of nc.status())` loop — it still fires on repeated identical auth errors and on explicit `nc.close()` / `nc.drain()`, and a stuck "reconnecting…" UI on a truly dead connection is worse than an honest "disconnected" one.
 
 Subpath exports:
 

--- a/client-sdk/typescript/src/connect-defaults.ts
+++ b/client-sdk/typescript/src/connect-defaults.ts
@@ -1,0 +1,87 @@
+// Opinionated reconnect defaults for agent runtimes.
+//
+// `@nats-io/transport-node`'s defaults — `maxReconnectAttempts: 10`,
+// `reconnectTimeWait: 2000ms`, `reconnectJitter: 100ms`,
+// `waitOnFirstConnect: false` — fit short-lived clients well, but an
+// agent process is supposed to *stay reachable* through laptop sleep,
+// flaky home networks, and broker maintenance windows. The defaults
+// here flip the polarity: never give up on reconnects, and keep trying
+// from the very first attempt even if the server is unreachable at
+// startup.
+//
+// Pure transform, no I/O. Designed to compose with the existing
+// per-harness `connect()` pipelines:
+//
+//     import { connect } from "@nats-io/transport-node";
+//     import { withAgentReconnectDefaults } from "@synadia-ai/agents";
+//     const nc = await connect(withAgentReconnectDefaults(opts));
+//
+// Background: synadia-ai/synadia-agents#121.
+
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+
+/**
+ * Reconnect-related defaults applied by {@link withAgentReconnectDefaults}.
+ * Exported so callers can introspect / log / override individual values
+ * without duplicating the literals.
+ *
+ * Field-by-field rationale:
+ *   - `maxReconnectAttempts: -1`  — never give up. Agents are
+ *     supposed to come back when the broker does.
+ *   - `reconnectTimeWait: 2000`   — matches the upstream default; pinned
+ *     so a future upstream change doesn't silently shift it.
+ *   - `reconnectJitter: 200`      — modest bump from the upstream 100ms
+ *     to spread the herd a little more on broker recovery.
+ *   - `waitOnFirstConnect: true`  — `connect()` retries through a
+ *     server that is unreachable at startup, instead of throwing
+ *     immediately. Means an operator-misconfigured URL / cert path now
+ *     manifests as a stuck "reconnecting…" UI rather than a fast crash.
+ *
+ * Not pinned here (intentional):
+ *   - `reconnect: true`           — already the upstream default.
+ *   - `reconnectJitterTLS`        — upstream 1000ms default is generous
+ *     enough; no need to over-specify.
+ */
+export const AGENT_RECONNECT_DEFAULTS: Readonly<Partial<NodeConnectionOptions>> = Object.freeze({
+  maxReconnectAttempts: -1,
+  reconnectTimeWait: 2000,
+  reconnectJitter: 200,
+  waitOnFirstConnect: true,
+});
+
+/**
+ * Return a new options object with {@link AGENT_RECONNECT_DEFAULTS}
+ * applied as fallbacks: any field the caller has set (including `0`
+ * and `false`) is preserved. The input is never mutated.
+ *
+ * Use this at the connect call site:
+ *
+ *     const nc = await connect(withAgentReconnectDefaults(opts));
+ *
+ * Residual `close` paths even with `maxReconnectAttempts: -1`:
+ *   - repeated identical auth errors — nats.js' `ignoreAuthErrorAbort`
+ *     defaults to `false` and we don't override it.
+ *   - explicit `nc.close()` / `nc.drain()`.
+ *
+ * Callers should still handle the `close` status case in their
+ * `for await (const s of nc.status())` loop so the UI reflects an
+ * actually-dead connection (rather than continuing to say
+ * "reconnecting…").
+ */
+export function withAgentReconnectDefaults(opts: NodeConnectionOptions): NodeConnectionOptions {
+  // Spread to a fresh object so callers that mutate the result (e.g.
+  // `opts.name = "pi-${owner}"` in agents/pi) don't accidentally write
+  // through to the caller's original object.
+  const out: NodeConnectionOptions = { ...opts };
+  // Iterate over the defaults' keys and fill in only where the caller
+  // left a hole. Explicit `=== undefined` check (not falsy) so a
+  // caller's `maxReconnectAttempts: 0` ("no reconnect at all") survives.
+  for (const k of Object.keys(AGENT_RECONNECT_DEFAULTS) as Array<
+    keyof typeof AGENT_RECONNECT_DEFAULTS
+  >) {
+    if (out[k] === undefined) {
+      (out as Record<string, unknown>)[k] = AGENT_RECONNECT_DEFAULTS[k];
+    }
+  }
+  return out;
+}

--- a/client-sdk/typescript/src/connect-defaults.ts
+++ b/client-sdk/typescript/src/connect-defaults.ts
@@ -68,7 +68,9 @@ export const AGENT_RECONNECT_DEFAULTS: Readonly<Partial<NodeConnectionOptions>> 
  * actually-dead connection (rather than continuing to say
  * "reconnecting…").
  */
-export function withAgentReconnectDefaults(opts: NodeConnectionOptions): NodeConnectionOptions {
+export function withAgentReconnectDefaults(
+  opts: NodeConnectionOptions = {},
+): NodeConnectionOptions {
   // Spread to a fresh object so callers that mutate the result (e.g.
   // `opts.name = "pi-${owner}"` in agents/pi) don't accidentally write
   // through to the caller's original object.

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -133,6 +133,9 @@ export { newInbox } from "./internal/inbox.js";
 // NATS CLI context loader + URL parser (both produce NodeConnectionOptions)
 export { loadContextOptions, parseNatsUrl } from "./context.js";
 
+// Opinionated reconnect defaults for agent runtimes — see #121.
+export { AGENT_RECONNECT_DEFAULTS, withAgentReconnectDefaults } from "./connect-defaults.js";
+
 // Version metadata
 export {
   SDK_PROTOCOL_VERSION,

--- a/client-sdk/typescript/test/unit/connect-defaults.test.ts
+++ b/client-sdk/typescript/test/unit/connect-defaults.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_RECONNECT_DEFAULTS,
+  withAgentReconnectDefaults,
+} from "../../src/connect-defaults.js";
+
+describe("AGENT_RECONNECT_DEFAULTS", () => {
+  it("is frozen", () => {
+    expect(Object.isFrozen(AGENT_RECONNECT_DEFAULTS)).toBe(true);
+  });
+
+  it("matches the documented values", () => {
+    expect(AGENT_RECONNECT_DEFAULTS).toEqual({
+      maxReconnectAttempts: -1,
+      reconnectTimeWait: 2000,
+      reconnectJitter: 200,
+      waitOnFirstConnect: true,
+    });
+  });
+});
+
+describe("withAgentReconnectDefaults", () => {
+  it("fills in every default on empty input", () => {
+    const out = withAgentReconnectDefaults({});
+    expect(out.maxReconnectAttempts).toBe(-1);
+    expect(out.reconnectTimeWait).toBe(2000);
+    expect(out.reconnectJitter).toBe(200);
+    expect(out.waitOnFirstConnect).toBe(true);
+  });
+
+  it("preserves a caller-set numeric override", () => {
+    const out = withAgentReconnectDefaults({ maxReconnectAttempts: 5 });
+    expect(out.maxReconnectAttempts).toBe(5);
+  });
+
+  it("preserves a caller-set 0 (must not be clobbered by -1)", () => {
+    // `0` is the explicit "no reconnect at all" choice — falsy check would
+    // overwrite it with -1 and silently change the caller's intent.
+    const out = withAgentReconnectDefaults({ maxReconnectAttempts: 0 });
+    expect(out.maxReconnectAttempts).toBe(0);
+  });
+
+  it("preserves a caller-set false (must not be clobbered by true)", () => {
+    const out = withAgentReconnectDefaults({ waitOnFirstConnect: false });
+    expect(out.waitOnFirstConnect).toBe(false);
+  });
+
+  it("preserves caller-set reconnectTimeWait and reconnectJitter", () => {
+    const out = withAgentReconnectDefaults({
+      reconnectTimeWait: 500,
+      reconnectJitter: 50,
+    });
+    expect(out.reconnectTimeWait).toBe(500);
+    expect(out.reconnectJitter).toBe(50);
+  });
+
+  it("returns a fresh object — never mutates the input", () => {
+    const input = {};
+    const out = withAgentReconnectDefaults(input);
+    expect(out).not.toBe(input);
+    expect(Object.keys(input)).toEqual([]);
+  });
+
+  it("passes unrelated fields through untouched", () => {
+    const input = {
+      name: "pi-channel",
+      servers: ["nats://example:4222"],
+      token: "secret",
+      inboxPrefix: "_INBOX.agents",
+    };
+    const out = withAgentReconnectDefaults(input);
+    expect(out.name).toBe("pi-channel");
+    expect(out.servers).toEqual(["nats://example:4222"]);
+    expect(out.token).toBe("secret");
+    expect(out.inboxPrefix).toBe("_INBOX.agents");
+    // Defaults still applied alongside.
+    expect(out.maxReconnectAttempts).toBe(-1);
+  });
+
+  it("mixes caller overrides with defaults", () => {
+    const out = withAgentReconnectDefaults({
+      maxReconnectAttempts: 10, // override
+      // reconnectTimeWait left unset → default
+      reconnectJitter: 0, // explicit 0 preserved
+      // waitOnFirstConnect left unset → default
+    });
+    expect(out.maxReconnectAttempts).toBe(10);
+    expect(out.reconnectTimeWait).toBe(2000);
+    expect(out.reconnectJitter).toBe(0);
+    expect(out.waitOnFirstConnect).toBe(true);
+  });
+});

--- a/client-sdk/typescript/test/unit/connect-defaults.test.ts
+++ b/client-sdk/typescript/test/unit/connect-defaults.test.ts
@@ -28,6 +28,15 @@ describe("withAgentReconnectDefaults", () => {
     expect(out.waitOnFirstConnect).toBe(true);
   });
 
+  it("fills in every default when called with no argument", () => {
+    // Parity with `connect()` — both can be called without arguments.
+    const out = withAgentReconnectDefaults();
+    expect(out.maxReconnectAttempts).toBe(-1);
+    expect(out.reconnectTimeWait).toBe(2000);
+    expect(out.reconnectJitter).toBe(200);
+    expect(out.waitOnFirstConnect).toBe(true);
+  });
+
   it("preserves a caller-set numeric override", () => {
     const out = withAgentReconnectDefaults({ maxReconnectAttempts: 5 });
     expect(out.maxReconnectAttempts).toBe(5);


### PR DESCRIPTION
## Summary

- Adds `withAgentReconnectDefaults(opts)` and `AGENT_RECONNECT_DEFAULTS` to `@synadia-ai/agents`. Pure transform that fills resilient reconnect defaults into a caller's `NodeConnectionOptions`, preserving any explicit override (including `0` / `false`).
- Defaults: `maxReconnectAttempts: -1` (never give up), `reconnectTimeWait: 2000`, `reconnectJitter: 200`, `waitOnFirstConnect: true` (retry through startup too).
- CHANGELOG entry under `[Unreleased]`. No version bump in this PR.

## Why

[#121](https://github.com/synadia-ai/synadia-agents/issues/121) — `@nats-io/transport-node`'s defaults (10 attempts / ~20s) give up too fast for an agent process that's supposed to outlive laptop sleeps and intermittent broker reachability. While reproducing the issue locally we also noticed that starting an agent while the server is down fails immediately with no retry; `waitOnFirstConnect: true` is the second half of the fix.

Helper is opt-in — existing callers that don't wrap their opts keep upstream behavior.

## Scope discipline

This PR is the SDK helper only. The four downstream sites — `agents/pi`, `agents/openclaw`, `agents/claude-code`, `examples/pi-headless` — adopt the helper and add `case "close"` to their status loops in a separate follow-up PR. We will **not** publish to npm until that PR has been verified end-to-end locally (dev-cycle pattern with `./devtools/devmode.sh`).

Deferred to a later PR: context-file `reconnect` block + env-var overrides for deployer-level tuning.

## Test plan

- [x] `bun run check` (typecheck + lint + format + 290 tests including 10 new) green locally.
- [x] Unit tests cover: empty input fills all defaults; explicit `0` / `false` preserved; output is a fresh object (no input mutation); unrelated fields (`name`, `servers`, `token`, `inboxPrefix`) pass through; `AGENT_RECONNECT_DEFAULTS` is frozen.
- [ ] CI matrix (Node 20/22/24, Bun 1.2/latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)