### PR TITLE
client-sdk/typescript: release 0.5.2

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,14 +13,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-26
+
 ### Added
 
-- `withAgentReconnectDefaults(opts)` and `AGENT_RECONNECT_DEFAULTS` —
+- `withAgentReconnectDefaults(opts?)` and `AGENT_RECONNECT_DEFAULTS` —
   opinionated reconnect defaults for agent runtimes:
   `maxReconnectAttempts: -1`, `reconnectTimeWait: 2000`,
   `reconnectJitter: 200`, `waitOnFirstConnect: true`. Pure transform
   that fills in only the fields the caller left undefined, so explicit
-  `0` / `false` overrides survive untouched. See
+  `0` / `false` overrides survive untouched. `opts` defaults to `{}`
+  for parity with `connect()`'s no-argument form. See
   [#121](https://github.com/synadia-ai/synadia-agents/issues/121).
 
 ### Behavior notes

--- a/client-sdk/typescript/package.json
+++ b/client-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synadia-ai/agents",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript SDK for the Synadia Agent Protocol for NATS — discover, prompt, and stream from AI agents over NATS.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Release-prep for `@synadia-ai/agents` 0.5.2:

- Bump `client-sdk/typescript/package.json` 0.5.1 → 0.5.2.
- Promote `[Unreleased]` → `[0.5.2] - 2026-05-26` in CHANGELOG.

Headline change (added in [#123](https://github.com/synadia-ai/synadia-agents/pull/123)): the new `withAgentReconnectDefaults(opts?)` helper + `AGENT_RECONNECT_DEFAULTS` constant. Opt-in resilient reconnect defaults for agent runtimes — see [#121](https://github.com/synadia-ai/synadia-agents/issues/121).

## After merge

1. Locally: `./devtools/devmode.sh off` — flips `agents/pi`, `agents/openclaw`, `examples/pi-headless` to `^0.5.2`. This opens the release-mode window on main; close it ASAP per [memory `feedback_minimize_release_mode_on_main`].
2. **User-gated:** `npm publish` from `client-sdk/typescript/` (identity `mschallner`).
3. Bump `@synadia-ai/nats-pi-channel` 0.5.4 → 0.5.5 and publish — user can then `pi install npm:@synadia-ai/nats-pi-channel@0.5.5` and run the manual end-to-end scenarios.
4. Same for `@synadia-ai/nats-channel` (openclaw) and `@synadia-ai/nats-pi-headless`.
5. `./devtools/devmode.sh on` + flip-back commit.
6. Separate PR3 for `agents/claude-code` adoption with `^0.5.2` from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)