### PR TITLE
Add DeerFlow NATS channel

### DIFF
--- a/.github/workflows/release-python-deerflow.yml
+++ b/.github/workflows/release-python-deerflow.yml
@@ -1,0 +1,97 @@
+name: Release — agents/deerflow
+
+# Publishes synadia-ai-nats-deerflow-channel to PyPI when a tag matching
+# `python-deerflow-v*` is pushed. The tag prefix keeps this package's
+# releases distinct from the monorepo's client-sdk (`python-v*`) and
+# agent-service (`python-agent-service-v*`) releases. Verification runs
+# before publishing and the publish job uses PyPI trusted publishing.
+#
+# Before the first release, register a pending publisher on PyPI for:
+#   project: synadia-ai-nats-deerflow-channel
+#   owner: synadia-ai
+#   repo: synadia-agents
+#   workflow: release-python-deerflow.yml
+#   environment: pypi
+
+on:
+  push:
+    tags:
+      - "python-deerflow-v*"
+
+concurrency:
+  group: release-python-deerflow-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: agents/deerflow
+
+jobs:
+  verify:
+    name: Verify (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "agents/deerflow/uv.lock"
+          python-version: ${{ matrix.python-version }}
+
+      - run: uv sync --all-extras
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run mypy src tests
+      - run: uv run pytest -v
+
+  publish:
+    name: Publish to PyPI
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write  # softprops/action-gh-release creates the tag's GitHub Release
+      id-token: write  # required for PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "agents/deerflow/uv.lock"
+          python-version: "3.11"
+
+      - name: Build sdist + wheel
+        run: |
+          uv build
+          ls -lh dist/
+
+      - name: Verify tag matches pyproject version
+        run: |
+          # Strip the `python-deerflow-v` monorepo prefix before comparing.
+          TAG_VERSION="${GITHUB_REF_NAME#python-deerflow-v}"
+          PKG_VERSION="$(uv run python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::tag python-deerflow-v$TAG_VERSION does not match pyproject version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Tag and pyproject.toml both at $PKG_VERSION."
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: agents/deerflow/dist/
+
+      - name: Attach artifacts to GitHub release
+        if: success()
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            agents/deerflow/dist/*.whl
+            agents/deerflow/dist/*.tar.gz
+          generate_release_notes: true

--- a/agent-sdk/python/src/synadia_ai/agent_service/service.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/service.py
@@ -437,7 +437,7 @@ class AgentService:
                     self._effective_max_payload_value,
                 )
                 await request.respond_error(
-                    "413",
+                    "400",
                     _sanitize_error_desc(
                         f"prompt payload exceeds max_payload {self._effective_max_payload_value}"
                     ),

--- a/agent-sdk/python/src/synadia_ai/agent_service/service.py
+++ b/agent-sdk/python/src/synadia_ai/agent_service/service.py
@@ -250,6 +250,7 @@ class AgentService:
         self._description = description or f"{agent} agent {self.subject.session_name}"
         self._heartbeat_interval_s = heartbeat_interval_s
         self._max_payload = max_payload
+        self._effective_max_payload_value = max_payload
         self._attachments_ok = attachments_ok
         self._keepalive_interval_s = keepalive_interval_s
         self._prompt_handler: PromptHandler | None = None
@@ -303,6 +304,7 @@ class AgentService:
         # Resolve and clamp ``max_payload`` against the server's negotiated
         # limit (§2.1). See ``_effective_max_payload`` for the rule.
         max_payload_str = self._effective_max_payload()
+        self._effective_max_payload_value = max_payload_str
 
         # §3.2: metadata.session matches the 5th subject token. For session-
         # less harnesses (e.g. openclaw) the spec allows omitting the field
@@ -426,6 +428,32 @@ class AgentService:
                 await request.respond_error("400", _sanitize_error_desc(str(exc)))
                 return
 
+            max_payload_bytes = parse_human_bytes(self._effective_max_payload_value)
+            if len(request.data) > max_payload_bytes:
+                log.warning(
+                    "rejecting oversized prompt on %s: %d bytes exceeds %s",
+                    request.subject,
+                    len(request.data),
+                    self._effective_max_payload_value,
+                )
+                await request.respond_error(
+                    "413",
+                    _sanitize_error_desc(
+                        f"prompt payload exceeds max_payload {self._effective_max_payload_value}"
+                    ),
+                )
+                return
+            if envelope.attachments and not self._attachments_ok:
+                log.warning(
+                    "rejecting attachments on %s: endpoint advertised attachments_ok=false",
+                    request.subject,
+                )
+                await request.respond_error(
+                    "400",
+                    _sanitize_error_desc("attachments are not supported by this endpoint"),
+                )
+                return
+
             # §6.4: emit the leading ack BEFORE any handler work so warm-up
             # latency stays inside the §6.6 budget and the stream is observable
             # to plain `nats req --wait-for-empty`. Best-effort, mirroring the
@@ -449,6 +477,15 @@ class AgentService:
 
             try:
                 await handler(envelope, stream)
+            except ProtocolError as exc:
+                log.warning(
+                    "prompt handler rejected protocol input on %s: %s",
+                    request.subject,
+                    exc,
+                )
+                await _stop_keepalive(keepalive_task)
+                keepalive_task = None
+                await request.respond_error("400", _sanitize_error_desc(str(exc)))
             except Exception as exc:
                 log.exception("prompt handler raised on %s", request.subject)
                 # Stop keep-alive BEFORE the §9 error frame so the keepalive

--- a/agent-sdk/python/tests/test_error_completion_e2e.py
+++ b/agent-sdk/python/tests/test_error_completion_e2e.py
@@ -267,7 +267,7 @@ async def test_max_payload_rejects_before_ack(nc: NATSClient) -> None:
 
         assert len(collected) == 2
         error_msg, terminator = collected
-        assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "413"
+        assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "400"
         assert terminator.data == b""
         assert not terminator.headers
     finally:

--- a/agent-sdk/python/tests/test_error_completion_e2e.py
+++ b/agent-sdk/python/tests/test_error_completion_e2e.py
@@ -21,7 +21,7 @@ import json
 from typing import TYPE_CHECKING
 
 import pytest
-from synadia_ai.agents import Agents, Envelope
+from synadia_ai.agents import Agents, Envelope, encode
 from synadia_ai.agents.errors import ProtocolError
 
 from synadia_ai.agent_service import AgentService, PromptStream
@@ -194,6 +194,80 @@ async def test_malformed_envelope_emits_400_then_terminator(
         )
         error_msg, terminator = collected
         assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "400"
+        assert terminator.data == b""
+        assert not terminator.headers
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_attachments_false_rejects_before_ack(nc: NATSClient) -> None:
+    """Server-side capability enforcement: attachments_ok=false returns 400 before handler."""
+
+    async def _never_called(envelope: Envelope, stream: PromptStream) -> None:
+        raise AssertionError("handler MUST NOT run when attachments_ok=false")
+
+    service = AgentService(
+        agent=AGENT,
+        owner=OWNER,
+        session_name="no-attachments",
+        nc=nc,
+        heartbeat_interval_s=HEARTBEAT_INTERVAL_S,
+        attachments_ok=False,
+    )
+    service.on_prompt(_never_called)
+    await service.start()
+
+    try:
+        collected = await _collect_replies(
+            nc,
+            service.subject.inbox,
+            nc.new_inbox(),
+            payload=b'{"prompt":"hi","attachments":[{"filename":"x.txt","content":"aGk="}]}',
+        )
+
+        assert len(collected) == 2
+        error_msg, terminator = collected
+        headers = error_msg.headers or {}
+        assert headers.get("Nats-Service-Error-Code") == "400"
+        assert "attachments" in headers.get("Nats-Service-Error", "")
+        assert terminator.data == b""
+        assert not terminator.headers
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_max_payload_rejects_before_ack(nc: NATSClient) -> None:
+    """Agent-side lower max_payload override is enforced before the handler runs."""
+
+    async def _never_called(envelope: Envelope, stream: PromptStream) -> None:
+        raise AssertionError("handler MUST NOT run on oversized prompt")
+
+    service = AgentService(
+        agent=AGENT,
+        owner=OWNER,
+        session_name="tiny-payload",
+        nc=nc,
+        heartbeat_interval_s=HEARTBEAT_INTERVAL_S,
+        max_payload="32B",
+    )
+    service.on_prompt(_never_called)
+    await service.start()
+
+    try:
+        payload = encode(Envelope(prompt="this payload is definitely larger than thirty-two bytes"))
+        assert len(payload) > 32
+        collected = await _collect_replies(
+            nc,
+            service.subject.inbox,
+            nc.new_inbox(),
+            payload=payload,
+        )
+
+        assert len(collected) == 2
+        error_msg, terminator = collected
+        assert (error_msg.headers or {}).get("Nats-Service-Error-Code") == "413"
         assert terminator.data == b""
         assert not terminator.headers
     finally:

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,6 +15,7 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 | `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | server-negotiated | true |
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 | `open-agent/`       | `open-agent` | [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) | `agents.prompt.open-agent.<owner>.<session>` | server-negotiated | false |
+| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated | false |
 
 `max_payload` is read from the NATS connection's `INFO` block at startup and advertised verbatim, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and the agents track it.
 
@@ -31,6 +32,7 @@ Every agent registers a NATS micro service called `agents` with an endpoint name
 - **`claude-code/`** - ships as a Claude Code plugin (`/plugin install`). Two permission modes: `terminal` (prompt locally) or `query` (relay as a `query` chunk over NATS). Attachments stage at `~/.claude/channels/nats/attachments/<request_id>/`, cleaned on reply completion.
 - **`open-agent/`** - inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents). Vendors `packages/agent` verbatim and ships a `LocalSandbox` so the harness runs without a Vercel account; first agent in the repo built directly on `AgentService` from `@synadia-ai/agent-service`. The companion [`../examples/open-agent-vercel/`](../examples/open-agent-vercel/) swaps in `@vercel/sandbox` to prove the sandbox seam is interchangeable. v1 is single-process / single-session (one bridge handles one `(owner, session)` pair).
 - **`hermes/`** - full Hermes Agent (CLI + TUI + messaging gateway). Unlike the others, each gateway registers **one** identity and multiplexes conversations via the envelope's optional `session` field (§5.1); subject stays stable per instance. Images route through Hermes's `vision_analyze` tool so the model actually sees them. Currently installed from [`synadia-ai/hermes-agent`, branch `nats-gateway`](https://github.com/synadia-ai/hermes-agent/tree/nats-gateway) - upstream PR pending.
+- **`deerflow/`** - external Python wrapper around a running DeerFlow Gateway. Built on `synadia-ai-agent-service`, advertises `attachments_ok=false`, streams Gateway SSE responses as protocol chunks, and bridges DeerFlow clarification requests to protocol `query` chunks.
 
 When an agent accepts attachments, it decodes them to disk and prepends the absolute paths to the prompt text like so:
 

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -1,78 +1,277 @@
 # DeerFlow NATS Channel
 
-External channel wrapper that exposes a running DeerFlow instance as a Synadia Agent Protocol host on NATS.
+Expose a running [DeerFlow](https://deerflow.tech/) Gateway as a spec-compliant [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) host.
 
-This package is specifically about the **Synadia Agent Protocol for NATS**. It does not provide generic NATS tools, KV/Object Store helpers, raw JetStream access, or a DeerFlow fork.
+Every running wrapper instance registers one DeerFlow session as a NATS micro service. Synadia Agent Protocol clients can discover it, prompt it, stream responses, and answer DeerFlow clarification requests over protocol `query` chunks.
+
+This package is deliberately narrow: it is a **Synadia Agent Protocol channel wrapper for DeerFlow**. It is not a generic NATS toolkit, a JetStream/KV/Object Store helper, an MCP tool pack, or a DeerFlow fork.
 
 ## Install
 
-```shell
+### From a package index
+
+```bash
 pip install synadia-ai-nats-deerflow-channel
 ```
 
-For local development from this monorepo:
+Or run without keeping a project-local install:
 
-```shell
-cd agents/deerflow
-uv sync
-uv run deerflow-nats-channel doctor
+```bash
+uvx --from synadia-ai-nats-deerflow-channel deerflow-nats-channel doctor \
+  --owner acme \
+  --session research \
+  --nats-context prod \
+  --deerflow-url http://localhost:2026
 ```
 
-## Run
+### Editable from this monorepo
 
-Start DeerFlow normally, then run the channel wrapper:
+```bash
+git clone git@github.com:synadia-ai/synadia-agents.git
+cd synadia-agents/agents/deerflow
+uv sync
+uv run deerflow-nats-channel doctor \
+  --owner acme \
+  --session research \
+  --nats-url nats://127.0.0.1:4222
+```
 
-```shell
-NATS_CONTEXT=prod \
-DEERFLOW_URL=http://localhost:2026 \
-NATS_OWNER=rene \
-NATS_AGENT_NAME=deerflow \
+If you prefer plain pip during local development:
+
+```bash
+cd synadia-agents/agents/deerflow
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+deerflow-nats-channel doctor --owner acme --session research --nats-url nats://127.0.0.1:4222
+```
+
+## Prerequisites
+
+- A reachable NATS server, or a NATS CLI context created with `nats context add`.
+- A running DeerFlow Gateway. The wrapper expects the Gateway HTTP API, including `/health` and `/api/threads/{session}/runs/stream`.
+- Python 3.11+.
+
+## Quickstart: env-first
+
+For operators, environment variables are the cleanest path. Keep credentials in your NATS context or process environment; keep committed config files boring.
+
+```bash
+# Pick exactly one NATS connection path:
+export NATS_CONTEXT=prod
+# — or —
+export NATS_URL=nats://127.0.0.1:4222
+
+export NATS_OWNER=acme
+export NATS_AGENT_NAME=research
+export DEERFLOW_URL=http://localhost:2026
+
+# Optional. Defaults to df, giving agents.prompt.df.<owner>.<session>.
+export NATS_AGENT_TOKEN=df
+
+deerflow-nats-channel doctor
 deerflow-nats-channel start
 ```
 
-The wrapper registers DeerFlow as:
+The wrapper registers subjects in the v0.3 verb-first layout:
 
 ```text
-agents.prompt.df.<owner>.<session>
-agents.status.df.<owner>.<session>
-agents.hb.df.<owner>.<session>
+agents.prompt.<agent>.<owner>.<session>
+agents.status.<agent>.<owner>.<session>
+agents.hb.<agent>.<owner>.<session>
 ```
 
-Only `prompt` calls DeerFlow. Status and heartbeat are wrapper-owned protocol liveness concerns.
+With the quickstart defaults above, callers use:
+
+```text
+agents.prompt.df.acme.research
+agents.status.df.acme.research
+agents.hb.df.acme.research
+```
+
+Only `prompt` forwards work to DeerFlow. `status` and `hb` are wrapper-owned protocol liveness surfaces.
 
 ## Configuration
 
-Config resolution order:
+Effective precedence is:
 
 1. CLI flags
 2. Environment variables
-3. Channel config file
-4. Defaults
+3. TOML config file
+4. Built-in defaults
 
-Default config file path:
+Default config path:
 
 ```text
 ~/.config/synadia/deerflow-channel/config.toml
 ```
 
-Example:
+`deerflow-nats-channel configure` prints the resolved config path. It does not write secrets or mutate the file for you.
 
-```toml
+```bash
+mkdir -p "$(dirname "$(deerflow-nats-channel configure)")"
+cat > "$(deerflow-nats-channel configure)" <<'TOML'
+# ~/.config/synadia/deerflow-channel/config.toml
+# Prefer NATS_CONTEXT/NATS_URL and NATS_OWNER in the environment for deployments.
 nats_context = "prod"
-deerflow_url = "http://localhost:2026"
-owner = "rene"
-session = "deerflow"
+owner = "acme"
+session = "research"
 agent = "df"
+deerflow_url = "http://localhost:2026"
+TOML
 ```
 
-Secrets should live in NATS CLI contexts, credentials files, or environment variables. Do not put secrets in DeerFlow config or commit them here.
+### Config file reference
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `agent` | no | `df` | Synadia Agent Protocol type token. It becomes the third token in `agents.prompt.<agent>.<owner>.<session>`. Keep it lowercase and subject-safe. |
+| `owner` | yes | — | Operator/account namespace. It becomes the fourth subject token. |
+| `session` | no | `default` | DeerFlow thread/session name and fifth subject token. Stable names make the wrapper easy to address. |
+| `deerflow_url` | no | `http://localhost:2026` | Base URL for the DeerFlow Gateway. |
+| `nats_context` | one NATS target required | — | NATS CLI context name. Recommended for NGS/managed NATS because credentials stay in the NATS context. |
+| `nats_url` | one NATS target required | — | Raw NATS server URL. Useful for local development. |
+
+### Environment variables
+
+| Variable | Sets | Notes |
+| --- | --- | --- |
+| `NATS_AGENT_TOKEN` | `agent` | Preferred env name for the protocol type token. |
+| `DEERFLOW_NATS_AGENT` | `agent` | DeerFlow-specific alias. Used only when `NATS_AGENT_TOKEN` is unset. |
+| `NATS_OWNER` | `owner` | Preferred owner env var. |
+| `DEERFLOW_NATS_OWNER` | `owner` | DeerFlow-specific alias. Used only when `NATS_OWNER` is unset. |
+| `NATS_AGENT_NAME` | `session` | Preferred session env var for sibling channel consistency. |
+| `NATS_SESSION` | `session` | Alias. Used only when `NATS_AGENT_NAME` is unset. |
+| `DEERFLOW_URL` | `deerflow_url` | DeerFlow Gateway base URL. |
+| `NATS_CONTEXT` | `nats_context` | NATS CLI context. Prefer this over raw URLs in production. |
+| `NATS_URL` | `nats_url` | Direct NATS server URL. |
+
+### CLI flags
+
+All commands accept the same config overrides:
+
+```bash
+deerflow-nats-channel doctor \
+  --config-file ~/.config/synadia/deerflow-channel/config.toml \
+  --agent df \
+  --owner acme \
+  --session research \
+  --deerflow-url http://localhost:2026 \
+  --nats-context prod
+```
+
+Use flags for one-off smoke checks. Use env vars or TOML for services.
 
 ## Commands
 
-```shell
-deerflow-nats-channel doctor
-deerflow-nats-channel start
-deerflow-nats-channel configure
+| Command | Purpose |
+| --- | --- |
+| `deerflow-nats-channel configure` | Print the resolved config file path. Handy in shell scripts; intentionally non-mutating. |
+| `deerflow-nats-channel doctor` | Print a JSON report with resolved non-secret config, subject names, required-field checks, and DeerFlow `/health` reachability. |
+| `deerflow-nats-channel start` | Start the long-running Synadia Agent Protocol host. |
+
+Example doctor output:
+
+```json
+{
+  "ok": true,
+  "checks": {
+    "agent_token_shape": true,
+    "deerflow_reachable": true,
+    "deerflow_url_shape": true,
+    "nats_target_configured": true,
+    "owner_configured": true
+  },
+  "config": {
+    "agent": "df",
+    "owner": "acme",
+    "session": "research",
+    "prompt_subject": "agents.prompt.df.acme.research",
+    "status_subject": "agents.status.df.acme.research",
+    "heartbeat_subject": "agents.hb.df.acme.research"
+  },
+  "messages": []
+}
 ```
 
-`doctor` verifies configuration and reports shallow DeerFlow Gateway reachability via `/health`. `start` hosts the Synadia Agent Protocol wrapper; only `prompt` forwards to DeerFlow's LangGraph-compatible `/api/threads/{session}/runs/stream` SSE endpoint. Status and heartbeat remain wrapper-owned protocol liveness concerns.
+`doctor` treats `owner`, NATS target, URL shape, and agent-token shape as start gates. DeerFlow reachability is reported so operators see the problem early, but the structural config can still be valid while DeerFlow is temporarily restarting.
+
+## Verify over NATS
+
+Start the wrapper, then from another shell:
+
+```bash
+# Discover registered agent services.
+nats req '$SRV.INFO.agents' '' --replies=0 --timeout=2s
+
+# Watch protocol heartbeats.
+nats sub 'agents.hb.*.*.*'
+
+# Prompt directly with plain text.
+nats req agents.prompt.df.acme.research "Summarize the current workspace" \
+  --wait-for-empty \
+  --reply-timeout 30s \
+  --timeout 180s
+```
+
+`--wait-for-empty` matters: protocol responses stream as typed chunks and end with an empty terminator message. `--reply-timeout 30s` avoids the NATS CLI giving up between the initial ack and DeerFlow's first content chunk.
+
+## Talk to DeerFlow from Python
+
+```python
+import asyncio
+
+from nats.aio.client import Client as NATS
+from synadia_ai.agents import Agents
+
+async def main() -> None:
+    nc = NATS()
+    await nc.connect("nats://127.0.0.1:4222")
+    agents = Agents(nc=nc)
+
+    [agent] = await agents.discover(filter={"agent": "df"})
+    async for msg in await agent.prompt("What can you do?"):
+        if msg.type == "response":
+            print(msg.text, end="")
+
+    await nc.close()
+
+asyncio.run(main())
+```
+
+## Runtime behavior
+
+- The wrapper uses `AgentService` from `synadia-ai-agent-service`.
+- `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP.
+- DeerFlow SSE `messages`/`updates` events are normalized into protocol response chunks.
+- DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer is sent back to the same DeerFlow thread as the next user message.
+- A single wrapper instance serves one `(agent, owner, session)` identity. Run multiple processes for multiple exposed DeerFlow sessions.
+
+## Troubleshooting
+
+- **`owner is not configured; set NATS_OWNER or pass --owner`** — set `NATS_OWNER`, `DEERFLOW_NATS_OWNER`, `owner = "..."`, or `--owner`. The owner is required because it is part of the protocol subject.
+- **`set NATS_CONTEXT or NATS_URL before starting the channel`** — configure one NATS target. Prefer `NATS_CONTEXT` for authenticated deployments.
+- **`agent token must be lowercase alphanumeric plus hyphen`** — use a subject-safe token such as `df` or `deerflow`. Do not use spaces, dots, or uppercase.
+- **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.
+- **NATS CLI receives only an ack or exits early** — include both `--wait-for-empty` and a generous `--reply-timeout`, e.g. `30s`.
+- **No discovery responses** — confirm the wrapper is still running, check `NATS_CONTEXT`/`NATS_URL`, then query `$SRV.INFO.agents` on the same NATS account the wrapper uses.
+- **Prompt hangs during a clarification** — DeerFlow asked for human input and the caller must support protocol `query` chunks. Use an SDK caller that handles `query`, or avoid DeerFlow flows that require clarification.
+- **Local dev imports the wrong SDK version** — from `agents/deerflow`, run `uv sync`; the local `pyproject.toml` maps `synadia-ai-agents` and `synadia-ai-agent-service` to the monorepo SDK paths via `[tool.uv.sources]`.
+
+## Limitations
+
+- Text prompts only; inline attachments are not accepted by the DeerFlow wrapper yet.
+- The wrapper fronts DeerFlow Gateway HTTP/SSE. It does not embed DeerFlow Harness directly.
+- `configure` is intentionally minimal in this phase: it prints the target config path instead of running an interactive wizard.
+- No generic NATS tools are exposed to DeerFlow. This is inbound protocol hosting, not a NATS toolbox.
+
+## See also
+
+- Sibling channel plugins: [`pi`](../pi), [`openclaw`](../openclaw), [`claude-code`](../claude-code), and [`hermes`](../hermes).
+- Python caller SDK: [`../../client-sdk/python`](../../client-sdk/python).
+- Python host SDK: [`../../agent-sdk/python`](../../agent-sdk/python).
+- Wire protocol: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).
+
+## License
+
+Apache-2.0

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -131,6 +131,9 @@ TOML
 | `deerflow_url` | no | `http://localhost:2026` | Base URL for the DeerFlow Gateway. |
 | `nats_context` | one NATS target required | — | NATS CLI context name. Recommended for NGS/managed NATS because credentials stay in the NATS context. |
 | `nats_url` | one NATS target required | — | Raw NATS server URL. Useful for local development. |
+| `deerflow_timeout_s` | no | `60` | HTTP connect/read timeout for DeerFlow Gateway health and stream calls. |
+| `query_timeout_s` | no | `300` | Seconds to wait for a caller reply to a DeerFlow clarification query before failing the stream. |
+| `max_payload` | no | `1MB` | Prompt endpoint `max_payload` metadata. The host rejects larger payloads with a protocol error and clamps to the NATS server limit when needed. |
 
 ### Environment variables
 
@@ -145,6 +148,9 @@ TOML
 | `DEERFLOW_URL` | `deerflow_url` | DeerFlow Gateway base URL. |
 | `NATS_CONTEXT` | `nats_context` | NATS CLI context. Prefer this over raw URLs in production. |
 | `NATS_URL` | `nats_url` | Direct NATS server URL. |
+| `DEERFLOW_TIMEOUT_S` | `deerflow_timeout_s` | Positive number of seconds for DeerFlow HTTP calls. |
+| `DEERFLOW_QUERY_TIMEOUT_S` | `query_timeout_s` | Positive number of seconds to wait for clarification replies. |
+| `DEERFLOW_MAX_PAYLOAD` | `max_payload` | Human byte string such as `256KB`, `1MB`, or `2MB`. |
 
 ### CLI flags
 
@@ -157,6 +163,9 @@ deerflow-nats-channel doctor \
   --owner acme \
   --session research \
   --deerflow-url http://localhost:2026 \
+  --deerflow-timeout-s 60 \
+  --query-timeout-s 300 \
+  --max-payload 1MB \
   --nats-context prod
 ```
 
@@ -242,7 +251,9 @@ asyncio.run(main())
 ## Runtime behavior
 
 - The wrapper uses `AgentService` from `synadia-ai-agent-service`.
-- `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP.
+- `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP. The host also rejects attachment-bearing prompt envelopes and clarification replies server-side, so non-validating callers get a protocol error instead of forwarding binary data into DeerFlow.
+- `max_payload` defaults to `1MB`; the protocol host advertises it, clamps it to the connected NATS server limit when needed, and rejects oversized prompt envelopes before the DeerFlow handler runs.
+- DeerFlow HTTP calls use `deerflow_timeout_s` (default `60`). Clarification replies use `query_timeout_s` (default `300`) and fail the stream if the caller does not answer in time.
 - DeerFlow SSE `messages`/`updates` events are normalized into protocol response chunks.
 - DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer is sent back to the same DeerFlow thread as the next user message.
 - A single wrapper instance serves one `(agent, owner, session)` identity. Run multiple processes for multiple exposed DeerFlow sessions.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -274,7 +274,8 @@ asyncio.run(main())
 - `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP. The host also rejects attachment-bearing prompt envelopes and clarification replies server-side, so non-validating callers get a protocol error instead of forwarding binary data into DeerFlow.
 - `max_payload` defaults to `1MB`; the protocol host advertises it, clamps it to the connected NATS server limit when needed, and rejects oversized prompt envelopes before the DeerFlow handler runs.
 - DeerFlow HTTP calls use `deerflow_timeout_s` (default `60`). Clarification replies use `query_timeout_s` (default `300`) and fail the stream if the caller does not answer in time.
-- When `deerflow_username` and `deerflow_password` are configured, the wrapper logs into DeerFlow once via `/api/v1/auth/login/local`, stores the returned `access_token`/`csrf_token` cookies, and sends `X-CSRF-Token` automatically on Gateway stream POSTs. Manual `deerflow_cookie`/`deerflow_csrf_token` exists only as a debug fallback.
+- When `deerflow_username` and `deerflow_password` are configured, the wrapper logs into DeerFlow via `/api/v1/auth/login/local`, stores the returned `access_token`/`csrf_token` cookies, and sends `X-CSRF-Token` automatically on Gateway stream POSTs. Manual `deerflow_cookie`/`deerflow_csrf_token` exists only as a debug fallback.
+- Before each prompt, the wrapper idempotently ensures the configured DeerFlow thread exists via `POST /api/threads`, so operators do not need to pre-create the session in the Web UI.
 - DeerFlow SSE `messages`/`updates` events are normalized into protocol response chunks.
 - DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer is sent back to the same DeerFlow thread as the next user message.
 - A single wrapper instance serves one `(agent, owner, session)` identity. Run multiple processes for multiple exposed DeerFlow sessions.
@@ -286,6 +287,7 @@ asyncio.run(main())
 - **`agent token must be lowercase alphanumeric plus hyphen`** — use a subject-safe token such as `df` or `deerflow`. Do not use spaces, dots, or uppercase.
 - **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.
 - **`403: CSRF token missing. Include X-CSRF-Token header.`** — configure `DEERFLOW_USERNAME` and `DEERFLOW_PASSWORD` so the wrapper can log into DeerFlow and send CSRF headers automatically. If you are debugging manually, provide both `DEERFLOW_COOKIE='access_token=...; csrf_token=...'` and `DEERFLOW_CSRF_TOKEN=...`.
+- **`404: Thread ... not found`** — upgrade/reinstall the wrapper. Current versions create the configured DeerFlow thread automatically before streaming; older editable installs required the thread to already exist.
 - **NATS CLI receives only an ack or exits early** — include both `--wait-for-empty` and a generous `--reply-timeout`, e.g. `30s`.
 - **No discovery responses** — confirm the wrapper is still running, check `NATS_CONTEXT`/`NATS_URL`, then query `$SRV.INFO.agents` on the same NATS account the wrapper uses.
 - **Prompt hangs during a clarification** — DeerFlow asked for human input and the caller must support protocol `query` chunks. Use an SDK caller that handles `query`, or avoid DeerFlow flows that require clarification.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -75,4 +75,4 @@ deerflow-nats-channel start
 deerflow-nats-channel configure
 ```
 
-`doctor` currently verifies configuration resolution and performs shallow local checks. Protocol hosting and the real DeerFlow bridge are implemented in later phases.
+`doctor` verifies configuration and reports shallow DeerFlow Gateway reachability via `/health`. `start` hosts the Synadia Agent Protocol wrapper; only `prompt` forwards to DeerFlow's LangGraph-compatible `/api/threads/{session}/runs/stream` SSE endpoint. Status and heartbeat remain wrapper-owned protocol liveness concerns.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -1,0 +1,78 @@
+# DeerFlow NATS Channel
+
+External channel wrapper that exposes a running DeerFlow instance as a Synadia Agent Protocol host on NATS.
+
+This package is specifically about the **Synadia Agent Protocol for NATS**. It does not provide generic NATS tools, KV/Object Store helpers, raw JetStream access, or a DeerFlow fork.
+
+## Install
+
+```shell
+pip install synadia-ai-nats-deerflow-channel
+```
+
+For local development from this monorepo:
+
+```shell
+cd agents/deerflow
+uv sync
+uv run deerflow-nats-channel doctor
+```
+
+## Run
+
+Start DeerFlow normally, then run the channel wrapper:
+
+```shell
+NATS_CONTEXT=prod \
+DEERFLOW_URL=http://localhost:2026 \
+NATS_OWNER=rene \
+NATS_AGENT_NAME=deerflow \
+deerflow-nats-channel start
+```
+
+The wrapper registers DeerFlow as:
+
+```text
+agents.prompt.df.<owner>.<session>
+agents.status.df.<owner>.<session>
+agents.hb.df.<owner>.<session>
+```
+
+Only `prompt` calls DeerFlow. Status and heartbeat are wrapper-owned protocol liveness concerns.
+
+## Configuration
+
+Config resolution order:
+
+1. CLI flags
+2. Environment variables
+3. Channel config file
+4. Defaults
+
+Default config file path:
+
+```text
+~/.config/synadia/deerflow-channel/config.toml
+```
+
+Example:
+
+```toml
+nats_context = "prod"
+deerflow_url = "http://localhost:2026"
+owner = "rene"
+session = "deerflow"
+agent = "df"
+```
+
+Secrets should live in NATS CLI contexts, credentials files, or environment variables. Do not put secrets in DeerFlow config or commit them here.
+
+## Commands
+
+```shell
+deerflow-nats-channel doctor
+deerflow-nats-channel start
+deerflow-nats-channel configure
+```
+
+`doctor` currently verifies configuration resolution and performs shallow local checks. Protocol hosting and the real DeerFlow bridge are implemented in later phases.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -143,8 +143,8 @@ TOML
 | `deerflow_password` | no | — | DeerFlow local-login password. Prefer the `DEERFLOW_PASSWORD` environment variable over TOML for real deployments. Redacted from `doctor` output. |
 | `deerflow_cookie` | no | — | Debug fallback only: raw Cookie header for DeerFlow Gateway calls, e.g. `access_token=...; csrf_token=...`. Prefer automatic login. Redacted from `doctor` output. |
 | `deerflow_csrf_token` | no | — | Debug fallback only: explicit CSRF token sent as `X-CSRF-Token`. Prefer automatic login. Redacted from `doctor` output. |
-| `nats_context` | one NATS target required | — | NATS CLI context name. Recommended for NGS/managed NATS because credentials stay in the NATS context. |
-| `nats_url` | one NATS target required | — | Raw NATS server URL. Useful for local development. |
+| `nats_context` | no | — | NATS CLI context name. Recommended for NGS/managed NATS because credentials stay in the NATS context. If neither `nats_context` nor `nats_url` is set, the wrapper uses the currently selected NATS CLI context. |
+| `nats_url` | no | — | Raw NATS server URL. Useful for local development. If unset, `nats_context` or the current NATS CLI context is used. |
 | `deerflow_timeout_s` | no | `60` | HTTP connect/read timeout for DeerFlow Gateway health and stream calls. |
 | `query_timeout_s` | no | `300` | Seconds to wait for a caller reply to a DeerFlow clarification query before failing the stream. |
 | `max_payload` | no | `1MB` | Prompt endpoint `max_payload` metadata. The host rejects larger payloads with a protocol error and clamps to the NATS server limit when needed. |
@@ -182,7 +182,6 @@ deerflow-nats-channel doctor \
   --session research \
   --deerflow-url http://localhost:2026 \
   --deerflow-username operator@example.com \
-  --deerflow-password 'change-me' \
   --deerflow-timeout-s 60 \
   --query-timeout-s 300 \
   --max-payload 1MB \
@@ -209,6 +208,7 @@ Example doctor output:
     "deerflow_reachable": true,
     "deerflow_url_shape": true,
     "nats_target_configured": true,
+    "nats_target_valid": true,
     "owner_configured": true
   },
   "config": {
@@ -223,7 +223,7 @@ Example doctor output:
 }
 ```
 
-`doctor` treats `owner`, NATS target, URL shape, and agent-token shape as start gates. DeerFlow reachability is reported so operators see the problem early, but the structural config can still be valid while DeerFlow is temporarily restarting.
+`doctor` treats `owner`, NATS target validity, URL shape, and agent-token shape as start gates. If no explicit NATS target is configured, `doctor` validates the currently selected NATS CLI context, matching `start`. DeerFlow reachability is reported so operators see the problem early, but the structural config can still be valid while DeerFlow is temporarily restarting.
 
 ## Verify over NATS
 

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -40,9 +40,10 @@ If you prefer plain pip during local development:
 
 ```bash
 cd synadia-agents/agents/deerflow
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
-pip install -e .
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e .
 deerflow-nats-channel doctor --owner acme --session research --nats-url nats://127.0.0.1:4222
 ```
 
@@ -65,6 +66,11 @@ export NATS_URL=nats://127.0.0.1:4222
 export NATS_OWNER=acme
 export NATS_AGENT_NAME=research
 export DEERFLOW_URL=http://localhost:2026
+
+# Preferred for current DeerFlow Gateway auth: the wrapper logs in once,
+# stores access_token/csrf_token cookies, and sends X-CSRF-Token itself.
+export DEERFLOW_USERNAME=operator@example.com
+export DEERFLOW_PASSWORD='change-me'
 
 # Optional. Defaults to df, giving agents.prompt.df.<owner>.<session>.
 export NATS_AGENT_TOKEN=df
@@ -118,6 +124,10 @@ owner = "acme"
 session = "research"
 agent = "df"
 deerflow_url = "http://localhost:2026"
+# Optional but recommended when DeerFlow auth is enabled.
+deerflow_username = "operator@example.com"
+# Prefer DEERFLOW_PASSWORD env for real deployments; shown here for field shape only.
+deerflow_password = "change-me"
 TOML
 ```
 
@@ -129,6 +139,10 @@ TOML
 | `owner` | yes | — | Operator/account namespace. It becomes the fourth subject token. |
 | `session` | no | `default` | DeerFlow thread/session name and fifth subject token. Stable names make the wrapper easy to address. |
 | `deerflow_url` | no | `http://localhost:2026` | Base URL for the DeerFlow Gateway. |
+| `deerflow_username` | no | — | DeerFlow local-login username/email. When set with `deerflow_password`, the wrapper logs in via `/api/v1/auth/login/local` and uses returned session/CSRF cookies automatically. |
+| `deerflow_password` | no | — | DeerFlow local-login password. Prefer the `DEERFLOW_PASSWORD` environment variable over TOML for real deployments. Redacted from `doctor` output. |
+| `deerflow_cookie` | no | — | Debug fallback only: raw Cookie header for DeerFlow Gateway calls, e.g. `access_token=...; csrf_token=...`. Prefer automatic login. Redacted from `doctor` output. |
+| `deerflow_csrf_token` | no | — | Debug fallback only: explicit CSRF token sent as `X-CSRF-Token`. Prefer automatic login. Redacted from `doctor` output. |
 | `nats_context` | one NATS target required | — | NATS CLI context name. Recommended for NGS/managed NATS because credentials stay in the NATS context. |
 | `nats_url` | one NATS target required | — | Raw NATS server URL. Useful for local development. |
 | `deerflow_timeout_s` | no | `60` | HTTP connect/read timeout for DeerFlow Gateway health and stream calls. |
@@ -146,6 +160,10 @@ TOML
 | `NATS_AGENT_NAME` | `session` | Preferred session env var for sibling channel consistency. |
 | `NATS_SESSION` | `session` | Alias. Used only when `NATS_AGENT_NAME` is unset. |
 | `DEERFLOW_URL` | `deerflow_url` | DeerFlow Gateway base URL. |
+| `DEERFLOW_USERNAME` | `deerflow_username` | DeerFlow local-login username/email for automatic Gateway session login. |
+| `DEERFLOW_PASSWORD` | `deerflow_password` | DeerFlow local-login password for automatic Gateway session login. Prefer env over config files. Redacted from `doctor` output. |
+| `DEERFLOW_COOKIE` | `deerflow_cookie` | Debug fallback raw Cookie header. Prefer `DEERFLOW_USERNAME`/`DEERFLOW_PASSWORD`. Redacted from `doctor` output. |
+| `DEERFLOW_CSRF_TOKEN` | `deerflow_csrf_token` | Debug fallback CSRF token sent as `X-CSRF-Token`. Prefer automatic login. Redacted from `doctor` output. |
 | `NATS_CONTEXT` | `nats_context` | NATS CLI context. Prefer this over raw URLs in production. |
 | `NATS_URL` | `nats_url` | Direct NATS server URL. |
 | `DEERFLOW_TIMEOUT_S` | `deerflow_timeout_s` | Positive number of seconds for DeerFlow HTTP calls. |
@@ -163,6 +181,8 @@ deerflow-nats-channel doctor \
   --owner acme \
   --session research \
   --deerflow-url http://localhost:2026 \
+  --deerflow-username operator@example.com \
+  --deerflow-password 'change-me' \
   --deerflow-timeout-s 60 \
   --query-timeout-s 300 \
   --max-payload 1MB \
@@ -254,6 +274,7 @@ asyncio.run(main())
 - `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP. The host also rejects attachment-bearing prompt envelopes and clarification replies server-side, so non-validating callers get a protocol error instead of forwarding binary data into DeerFlow.
 - `max_payload` defaults to `1MB`; the protocol host advertises it, clamps it to the connected NATS server limit when needed, and rejects oversized prompt envelopes before the DeerFlow handler runs.
 - DeerFlow HTTP calls use `deerflow_timeout_s` (default `60`). Clarification replies use `query_timeout_s` (default `300`) and fail the stream if the caller does not answer in time.
+- When `deerflow_username` and `deerflow_password` are configured, the wrapper logs into DeerFlow once via `/api/v1/auth/login/local`, stores the returned `access_token`/`csrf_token` cookies, and sends `X-CSRF-Token` automatically on Gateway stream POSTs. Manual `deerflow_cookie`/`deerflow_csrf_token` exists only as a debug fallback.
 - DeerFlow SSE `messages`/`updates` events are normalized into protocol response chunks.
 - DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer is sent back to the same DeerFlow thread as the next user message.
 - A single wrapper instance serves one `(agent, owner, session)` identity. Run multiple processes for multiple exposed DeerFlow sessions.
@@ -264,6 +285,7 @@ asyncio.run(main())
 - **`set NATS_CONTEXT or NATS_URL before starting the channel`** — configure one NATS target. Prefer `NATS_CONTEXT` for authenticated deployments.
 - **`agent token must be lowercase alphanumeric plus hyphen`** — use a subject-safe token such as `df` or `deerflow`. Do not use spaces, dots, or uppercase.
 - **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.
+- **`403: CSRF token missing. Include X-CSRF-Token header.`** — configure `DEERFLOW_USERNAME` and `DEERFLOW_PASSWORD` so the wrapper can log into DeerFlow and send CSRF headers automatically. If you are debugging manually, provide both `DEERFLOW_COOKIE='access_token=...; csrf_token=...'` and `DEERFLOW_CSRF_TOKEN=...`.
 - **NATS CLI receives only an ack or exits early** — include both `--wait-for-empty` and a generous `--reply-timeout`, e.g. `30s`.
 - **No discovery responses** — confirm the wrapper is still running, check `NATS_CONTEXT`/`NATS_URL`, then query `$SRV.INFO.agents` on the same NATS account the wrapper uses.
 - **Prompt hangs during a clarification** — DeerFlow asked for human input and the caller must support protocol `query` chunks. Use an SDK caller that handles `query`, or avoid DeerFlow flows that require clarification.

--- a/agents/deerflow/examples/config.toml
+++ b/agents/deerflow/examples/config.toml
@@ -1,0 +1,17 @@
+# Example config for deerflow-nats-channel.
+# Default path: ~/.config/synadia/deerflow-channel/config.toml
+# Prefer NATS_CONTEXT/NATS_URL and NATS_OWNER in the environment for deployments.
+
+# NATS CLI context name. Recommended because credentials stay in NATS config.
+nats_context = "prod"
+
+# Alternative for local development when no context is configured.
+# nats_url = "nats://127.0.0.1:4222"
+
+# Protocol identity: agents.prompt.<agent>.<owner>.<session>
+agent = "df"
+owner = "acme"
+session = "research"
+
+# DeerFlow Gateway base URL.
+deerflow_url = "http://localhost:2026"

--- a/agents/deerflow/examples/config.toml
+++ b/agents/deerflow/examples/config.toml
@@ -15,3 +15,8 @@ session = "research"
 
 # DeerFlow Gateway base URL.
 deerflow_url = "http://localhost:2026"
+
+# Hardening defaults. Tune for deployment size/latency.
+deerflow_timeout_s = 60
+query_timeout_s = 300
+max_payload = "1MB"

--- a/agents/deerflow/examples/env.example
+++ b/agents/deerflow/examples/env.example
@@ -1,0 +1,18 @@
+# DeerFlow NATS Channel env-first operator config.
+# Keep NATS credentials in the named NATS CLI context, not in this file.
+
+# Pick one connection path.
+NATS_CONTEXT=prod
+# NATS_URL=nats://127.0.0.1:4222
+
+# Required protocol identity.
+NATS_OWNER=acme
+
+# Stable DeerFlow session/thread and fifth protocol subject token.
+NATS_AGENT_NAME=research
+
+# Optional protocol type token. Defaults to df.
+NATS_AGENT_TOKEN=df
+
+# DeerFlow Gateway base URL.
+DEERFLOW_URL=http://localhost:2026

--- a/agents/deerflow/examples/env.example
+++ b/agents/deerflow/examples/env.example
@@ -16,3 +16,8 @@ NATS_AGENT_TOKEN=df
 
 # DeerFlow Gateway base URL.
 DEERFLOW_URL=http://localhost:2026
+
+# Hardening defaults. Tune for deployment size/latency.
+DEERFLOW_TIMEOUT_S=60
+DEERFLOW_QUERY_TIMEOUT_S=300
+DEERFLOW_MAX_PAYLOAD=1MB

--- a/agents/deerflow/pyproject.toml
+++ b/agents/deerflow/pyproject.toml
@@ -1,0 +1,89 @@
+[project]
+name = "synadia-ai-nats-deerflow-channel"
+version = "0.1.0"
+description = "DeerFlow channel wrapper for the Synadia Agent Protocol for NATS"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Synadia" }]
+keywords = ["nats", "agents", "deerflow", "ai", "streaming"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Networking",
+    "Typing :: Typed",
+]
+dependencies = [
+    "httpx>=0.27",
+    "nats-py>=2.7",
+    "pydantic>=2.5",
+    "synadia-ai-agent-service>=0.4.1",
+    "synadia-ai-agents>=0.7.1",
+]
+
+[project.scripts]
+deerflow-nats-channel = "synadia_ai.nats_deerflow_channel.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/synadia-ai/synadia-agents/tree/main/agents/deerflow"
+Repository = "https://github.com/synadia-ai/synadia-agents"
+Issues = "https://github.com/synadia-ai/synadia-agents/issues"
+
+[tool.uv.sources]
+synadia-ai-agents = { path = "../../client-sdk/python", editable = true }
+synadia-ai-agent-service = { path = "../../agent-sdk/python", editable = true }
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.5",
+    "mypy>=1.10",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/synadia_ai"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "PL", "RUF"]
+ignore = [
+    "PLR0913",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["PLR2004"]
+
+[tool.mypy]
+strict = true
+python_version = "3.11"
+mypy_path = "src"
+namespace_packages = true
+explicit_package_bases = true
+packages = ["synadia_ai.nats_deerflow_channel"]
+plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = "nats.*"
+ignore_missing_imports = true
+implicit_reexport = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/__init__.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/__init__.py
@@ -1,0 +1,7 @@
+"""DeerFlow channel wrapper for the Synadia Agent Protocol for NATS."""
+
+from __future__ import annotations
+
+from .config import ChannelConfig, resolve_config
+
+__all__ = ["ChannelConfig", "resolve_config"]

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -59,10 +59,6 @@ def _add_config_flags(parser: argparse.ArgumentParser) -> None:
         "--deerflow-username",
         help="DeerFlow local-login email/username; enables automatic session login",
     )
-    parser.add_argument(
-        "--deerflow-password",
-        help="DeerFlow local-login password; prefer DEERFLOW_PASSWORD env var",
-    )
 
 
 def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
@@ -80,7 +76,6 @@ def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
         deerflow_cookie=args.deerflow_cookie,
         deerflow_csrf_token=args.deerflow_csrf_token,
         deerflow_username=args.deerflow_username,
-        deerflow_password=args.deerflow_password,
     )
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from pathlib import Path
 
 from .config import ChannelConfig, resolve_config
 from .doctor import run_doctor
+from .host import run_channel
 
 
 def _add_config_flags(parser: argparse.ArgumentParser) -> None:
@@ -70,8 +72,11 @@ def main(argv: list[str] | None = None) -> int:
         if not report.ok:
             print(report.to_json(), file=sys.stderr)
             return 1
-        print("start is not implemented yet; Phase 2 adds the protocol host", file=sys.stderr)
-        return 2
+        try:
+            asyncio.run(run_channel(config))
+        except KeyboardInterrupt:
+            return 130
+        return 0
 
     parser.error(f"unknown command: {args.command}")
     return 2

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -44,6 +44,25 @@ def _add_config_flags(parser: argparse.ArgumentParser) -> None:
         "--max-payload",
         help="Advertised prompt max_payload metadata; default: 1MB, clamped by NATS server",
     )
+    parser.add_argument(
+        "--deerflow-cookie",
+        help=(
+            "Cookie header for authenticated DeerFlow Gateway calls; "
+            "may include access_token and csrf_token"
+        ),
+    )
+    parser.add_argument(
+        "--deerflow-csrf-token",
+        help="CSRF token sent as X-CSRF-Token for DeerFlow Gateway POST calls",
+    )
+    parser.add_argument(
+        "--deerflow-username",
+        help="DeerFlow local-login email/username; enables automatic session login",
+    )
+    parser.add_argument(
+        "--deerflow-password",
+        help="DeerFlow local-login password; prefer DEERFLOW_PASSWORD env var",
+    )
 
 
 def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
@@ -58,6 +77,10 @@ def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
         deerflow_timeout_s=args.deerflow_timeout_s,
         query_timeout_s=args.query_timeout_s,
         max_payload=args.max_payload,
+        deerflow_cookie=args.deerflow_cookie,
+        deerflow_csrf_token=args.deerflow_csrf_token,
+        deerflow_username=args.deerflow_username,
+        deerflow_password=args.deerflow_password,
     )
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -12,6 +12,16 @@ from .doctor import run_doctor
 from .host import run_channel
 
 
+def _positive_float(value: str) -> float:
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive number") from exc
+    if result <= 0:
+        raise argparse.ArgumentTypeError("must be > 0")
+    return result
+
+
 def _add_config_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--config-file", type=Path, help="Path to channel TOML config")
     parser.add_argument("--agent", help="Synadia Agent Protocol token; default: df")
@@ -20,6 +30,20 @@ def _add_config_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--deerflow-url", help="DeerFlow Gateway URL")
     parser.add_argument("--nats-context", help="NATS CLI context name")
     parser.add_argument("--nats-url", help="Direct NATS server URL")
+    parser.add_argument(
+        "--deerflow-timeout-s",
+        type=_positive_float,
+        help="HTTP connect/read timeout for DeerFlow Gateway calls; default: 60",
+    )
+    parser.add_argument(
+        "--query-timeout-s",
+        type=_positive_float,
+        help="Seconds to wait for protocol query replies to DeerFlow clarifications; default: 300",
+    )
+    parser.add_argument(
+        "--max-payload",
+        help="Advertised prompt max_payload metadata; default: 1MB, clamped by NATS server",
+    )
 
 
 def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
@@ -31,6 +55,9 @@ def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
         deerflow_url=args.deerflow_url,
         nats_context=args.nats_context,
         nats_url=args.nats_url,
+        deerflow_timeout_s=args.deerflow_timeout_s,
+        query_timeout_s=args.query_timeout_s,
+        max_payload=args.max_payload,
     )
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -1,0 +1,81 @@
+"""Command-line entry point for the DeerFlow NATS channel."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .config import ChannelConfig, resolve_config
+from .doctor import run_doctor
+
+
+def _add_config_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config-file", type=Path, help="Path to channel TOML config")
+    parser.add_argument("--agent", help="Synadia Agent Protocol token; default: df")
+    parser.add_argument("--owner", help="Protocol owner token")
+    parser.add_argument("--session", help="Protocol session name; default: default")
+    parser.add_argument("--deerflow-url", help="DeerFlow Gateway URL")
+    parser.add_argument("--nats-context", help="NATS CLI context name")
+    parser.add_argument("--nats-url", help="Direct NATS server URL")
+
+
+def _resolve_from_args(args: argparse.Namespace) -> ChannelConfig:
+    return resolve_config(
+        config_file=args.config_file,
+        agent=args.agent,
+        owner=args.owner,
+        session=args.session,
+        deerflow_url=args.deerflow_url,
+        nats_context=args.nats_context,
+        nats_url=args.nats_url,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="deerflow-nats-channel",
+        description="Expose DeerFlow as a Synadia Agent Protocol host on NATS.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor = subparsers.add_parser("doctor", help="Check resolved configuration")
+    _add_config_flags(doctor)
+
+    start = subparsers.add_parser("start", help="Start the channel wrapper")
+    _add_config_flags(start)
+
+    configure = subparsers.add_parser("configure", help="Print the default config location")
+    _add_config_flags(configure)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = _resolve_from_args(args)
+
+    if args.command == "doctor":
+        report = run_doctor(config)
+        print(report.to_json())
+        return 0 if report.ok else 1
+
+    if args.command == "configure":
+        print(config.config_file)
+        return 0
+
+    if args.command == "start":
+        report = run_doctor(config)
+        if not report.ok:
+            print(report.to_json(), file=sys.stderr)
+            return 1
+        print("start is not implemented yet; Phase 2 adds the protocol host", file=sys.stderr)
+        return 2
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
@@ -1,0 +1,136 @@
+"""Configuration resolution for the DeerFlow NATS channel."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+DEFAULT_AGENT = "df"
+DEFAULT_SESSION = "default"
+DEFAULT_DEERFLOW_URL = "http://localhost:2026"
+DEFAULT_CONFIG_PATH = Path("~/.config/synadia/deerflow-channel/config.toml")
+
+
+@dataclass(frozen=True)
+class ChannelConfig:
+    """Resolved channel configuration.
+
+    `agent` is the Synadia Agent Protocol token, not the DeerFlow runtime name.
+    The MVP uses `df` so subjects stay compact and recognisable.
+    """
+
+    agent: str = DEFAULT_AGENT
+    owner: str | None = None
+    session: str = DEFAULT_SESSION
+    deerflow_url: str = DEFAULT_DEERFLOW_URL
+    nats_context: str | None = None
+    nats_url: str | None = None
+    config_file: Path | None = None
+
+    @property
+    def subject_prefix(self) -> str:
+        """Return the protocol subject suffix without the verb."""
+        owner = self.owner or "<owner>"
+        return f"{self.agent}.{owner}.{self.session}"
+
+    def redacted_dict(self) -> dict[str, str | None]:
+        """Return printable non-secret configuration."""
+        return {
+            "agent": self.agent,
+            "owner": self.owner,
+            "session": self.session,
+            "deerflow_url": self.deerflow_url,
+            "nats_context": self.nats_context,
+            "nats_url": self.nats_url,
+            "config_file": str(self.config_file) if self.config_file else None,
+            "prompt_subject": f"agents.prompt.{self.subject_prefix}",
+            "status_subject": f"agents.status.{self.subject_prefix}",
+            "heartbeat_subject": f"agents.hb.{self.subject_prefix}",
+        }
+
+
+def default_config_path() -> Path:
+    """Return the conventional Synadia channel config path."""
+    return DEFAULT_CONFIG_PATH.expanduser()
+
+
+def load_config_file(path: Path) -> dict[str, Any]:
+    """Load a TOML config file if present."""
+    if not path.exists():
+        return {}
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"config file {path} did not contain a TOML table")
+    return data
+
+
+def _optional_str(data: dict[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"config key {key!r} must be a string")
+    value = value.strip()
+    return value or None
+
+
+def _env(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _apply_file(config: ChannelConfig, data: dict[str, Any], path: Path) -> ChannelConfig:
+    return replace(
+        config,
+        agent=_optional_str(data, "agent") or config.agent,
+        owner=_optional_str(data, "owner") or config.owner,
+        session=_optional_str(data, "session") or config.session,
+        deerflow_url=_optional_str(data, "deerflow_url") or config.deerflow_url,
+        nats_context=_optional_str(data, "nats_context") or config.nats_context,
+        nats_url=_optional_str(data, "nats_url") or config.nats_url,
+        config_file=path,
+    )
+
+
+def _apply_env(config: ChannelConfig) -> ChannelConfig:
+    return replace(
+        config,
+        agent=_env("NATS_AGENT_TOKEN") or _env("DEERFLOW_NATS_AGENT") or config.agent,
+        owner=_env("NATS_OWNER") or _env("DEERFLOW_NATS_OWNER") or config.owner,
+        session=_env("NATS_AGENT_NAME") or _env("NATS_SESSION") or config.session,
+        deerflow_url=_env("DEERFLOW_URL") or config.deerflow_url,
+        nats_context=_env("NATS_CONTEXT") or config.nats_context,
+        nats_url=_env("NATS_URL") or config.nats_url,
+    )
+
+
+def resolve_config(
+    *,
+    config_file: Path | None = None,
+    agent: str | None = None,
+    owner: str | None = None,
+    session: str | None = None,
+    deerflow_url: str | None = None,
+    nats_context: str | None = None,
+    nats_url: str | None = None,
+) -> ChannelConfig:
+    """Resolve config as CLI flags → env vars → config file → defaults."""
+    path = config_file or default_config_path()
+    config = _apply_file(ChannelConfig(config_file=path), load_config_file(path), path)
+    config = _apply_env(config)
+    return replace(
+        config,
+        agent=agent or config.agent,
+        owner=owner or config.owner,
+        session=session or config.session,
+        deerflow_url=deerflow_url or config.deerflow_url,
+        nats_context=nats_context or config.nats_context,
+        nats_url=nats_url or config.nats_url,
+    )

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
@@ -34,6 +34,10 @@ class ChannelConfig:
     deerflow_timeout_s: float = DEFAULT_DEERFLOW_TIMEOUT_S
     query_timeout_s: float = DEFAULT_QUERY_TIMEOUT_S
     max_payload: str = DEFAULT_MAX_PAYLOAD
+    deerflow_cookie: str | None = None
+    deerflow_csrf_token: str | None = None
+    deerflow_username: str | None = None
+    deerflow_password: str | None = None
     config_file: Path | None = None
 
     @property
@@ -54,6 +58,10 @@ class ChannelConfig:
             "deerflow_timeout_s": str(self.deerflow_timeout_s),
             "query_timeout_s": str(self.query_timeout_s),
             "max_payload": self.max_payload,
+            "deerflow_cookie": "[REDACTED]" if self.deerflow_cookie else None,
+            "deerflow_csrf_token": "[REDACTED]" if self.deerflow_csrf_token else None,
+            "deerflow_username": self.deerflow_username,
+            "deerflow_password": "[REDACTED]" if self.deerflow_password else None,
             "config_file": str(self.config_file) if self.config_file else None,
             "prompt_subject": f"agents.prompt.{self.subject_prefix}",
             "status_subject": f"agents.status.{self.subject_prefix}",
@@ -133,6 +141,11 @@ def _apply_file(config: ChannelConfig, data: dict[str, Any], path: Path) -> Chan
         or config.deerflow_timeout_s,
         query_timeout_s=_optional_positive_float(data, "query_timeout_s") or config.query_timeout_s,
         max_payload=_optional_str(data, "max_payload") or config.max_payload,
+        deerflow_cookie=_optional_str(data, "deerflow_cookie") or config.deerflow_cookie,
+        deerflow_csrf_token=_optional_str(data, "deerflow_csrf_token")
+        or config.deerflow_csrf_token,
+        deerflow_username=_optional_str(data, "deerflow_username") or config.deerflow_username,
+        deerflow_password=_optional_str(data, "deerflow_password") or config.deerflow_password,
         config_file=path,
     )
 
@@ -146,10 +159,13 @@ def _apply_env(config: ChannelConfig) -> ChannelConfig:
         deerflow_url=_env("DEERFLOW_URL") or config.deerflow_url,
         nats_context=_env("NATS_CONTEXT") or config.nats_context,
         nats_url=_env("NATS_URL") or config.nats_url,
-        deerflow_timeout_s=_env_positive_float("DEERFLOW_TIMEOUT_S")
-        or config.deerflow_timeout_s,
+        deerflow_timeout_s=_env_positive_float("DEERFLOW_TIMEOUT_S") or config.deerflow_timeout_s,
         query_timeout_s=_env_positive_float("DEERFLOW_QUERY_TIMEOUT_S") or config.query_timeout_s,
         max_payload=_env("DEERFLOW_MAX_PAYLOAD") or config.max_payload,
+        deerflow_cookie=_env("DEERFLOW_COOKIE") or config.deerflow_cookie,
+        deerflow_csrf_token=_env("DEERFLOW_CSRF_TOKEN") or config.deerflow_csrf_token,
+        deerflow_username=_env("DEERFLOW_USERNAME") or config.deerflow_username,
+        deerflow_password=_env("DEERFLOW_PASSWORD") or config.deerflow_password,
     )
 
 
@@ -165,6 +181,10 @@ def resolve_config(
     deerflow_timeout_s: float | None = None,
     query_timeout_s: float | None = None,
     max_payload: str | None = None,
+    deerflow_cookie: str | None = None,
+    deerflow_csrf_token: str | None = None,
+    deerflow_username: str | None = None,
+    deerflow_password: str | None = None,
 ) -> ChannelConfig:
     """Resolve config as CLI flags → env vars → config file → defaults."""
     path = config_file or default_config_path()
@@ -181,4 +201,8 @@ def resolve_config(
         deerflow_timeout_s=deerflow_timeout_s or config.deerflow_timeout_s,
         query_timeout_s=query_timeout_s or config.query_timeout_s,
         max_payload=max_payload or config.max_payload,
+        deerflow_cookie=deerflow_cookie or config.deerflow_cookie,
+        deerflow_csrf_token=deerflow_csrf_token or config.deerflow_csrf_token,
+        deerflow_username=deerflow_username or config.deerflow_username,
+        deerflow_password=deerflow_password or config.deerflow_password,
     )

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
@@ -11,6 +11,9 @@ from typing import Any
 DEFAULT_AGENT = "df"
 DEFAULT_SESSION = "default"
 DEFAULT_DEERFLOW_URL = "http://localhost:2026"
+DEFAULT_DEERFLOW_TIMEOUT_S = 60.0
+DEFAULT_QUERY_TIMEOUT_S = 300.0
+DEFAULT_MAX_PAYLOAD = "1MB"
 DEFAULT_CONFIG_PATH = Path("~/.config/synadia/deerflow-channel/config.toml")
 
 
@@ -28,6 +31,9 @@ class ChannelConfig:
     deerflow_url: str = DEFAULT_DEERFLOW_URL
     nats_context: str | None = None
     nats_url: str | None = None
+    deerflow_timeout_s: float = DEFAULT_DEERFLOW_TIMEOUT_S
+    query_timeout_s: float = DEFAULT_QUERY_TIMEOUT_S
+    max_payload: str = DEFAULT_MAX_PAYLOAD
     config_file: Path | None = None
 
     @property
@@ -45,6 +51,9 @@ class ChannelConfig:
             "deerflow_url": self.deerflow_url,
             "nats_context": self.nats_context,
             "nats_url": self.nats_url,
+            "deerflow_timeout_s": str(self.deerflow_timeout_s),
+            "query_timeout_s": str(self.query_timeout_s),
+            "max_payload": self.max_payload,
             "config_file": str(self.config_file) if self.config_file else None,
             "prompt_subject": f"agents.prompt.{self.subject_prefix}",
             "status_subject": f"agents.status.{self.subject_prefix}",
@@ -78,12 +87,37 @@ def _optional_str(data: dict[str, Any], key: str) -> str | None:
     return value or None
 
 
+def _optional_positive_float(data: dict[str, Any], key: str) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"config key {key!r} must be a positive number")
+    result = float(value)
+    if result <= 0:
+        raise ValueError(f"config key {key!r} must be > 0")
+    return result
+
+
 def _env(name: str) -> str | None:
     value = os.environ.get(name)
     if value is None:
         return None
     value = value.strip()
     return value or None
+
+
+def _env_positive_float(name: str) -> float | None:
+    value = _env(name)
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise ValueError(f"environment variable {name} must be a positive number") from exc
+    if result <= 0:
+        raise ValueError(f"environment variable {name} must be > 0")
+    return result
 
 
 def _apply_file(config: ChannelConfig, data: dict[str, Any], path: Path) -> ChannelConfig:
@@ -95,6 +129,10 @@ def _apply_file(config: ChannelConfig, data: dict[str, Any], path: Path) -> Chan
         deerflow_url=_optional_str(data, "deerflow_url") or config.deerflow_url,
         nats_context=_optional_str(data, "nats_context") or config.nats_context,
         nats_url=_optional_str(data, "nats_url") or config.nats_url,
+        deerflow_timeout_s=_optional_positive_float(data, "deerflow_timeout_s")
+        or config.deerflow_timeout_s,
+        query_timeout_s=_optional_positive_float(data, "query_timeout_s") or config.query_timeout_s,
+        max_payload=_optional_str(data, "max_payload") or config.max_payload,
         config_file=path,
     )
 
@@ -108,6 +146,10 @@ def _apply_env(config: ChannelConfig) -> ChannelConfig:
         deerflow_url=_env("DEERFLOW_URL") or config.deerflow_url,
         nats_context=_env("NATS_CONTEXT") or config.nats_context,
         nats_url=_env("NATS_URL") or config.nats_url,
+        deerflow_timeout_s=_env_positive_float("DEERFLOW_TIMEOUT_S")
+        or config.deerflow_timeout_s,
+        query_timeout_s=_env_positive_float("DEERFLOW_QUERY_TIMEOUT_S") or config.query_timeout_s,
+        max_payload=_env("DEERFLOW_MAX_PAYLOAD") or config.max_payload,
     )
 
 
@@ -120,6 +162,9 @@ def resolve_config(
     deerflow_url: str | None = None,
     nats_context: str | None = None,
     nats_url: str | None = None,
+    deerflow_timeout_s: float | None = None,
+    query_timeout_s: float | None = None,
+    max_payload: str | None = None,
 ) -> ChannelConfig:
     """Resolve config as CLI flags → env vars → config file → defaults."""
     path = config_file or default_config_path()
@@ -133,4 +178,7 @@ def resolve_config(
         deerflow_url=deerflow_url or config.deerflow_url,
         nats_context=nats_context or config.nats_context,
         nats_url=nats_url or config.nats_url,
+        deerflow_timeout_s=deerflow_timeout_s or config.deerflow_timeout_s,
+        query_timeout_s=query_timeout_s or config.query_timeout_s,
+        max_payload=max_payload or config.max_payload,
     )

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from urllib.parse import urljoin, urlparse
 
 import httpx
+from synadia_ai.agents import NatsContextError, load_context_options, parse_nats_url
 
 from .config import ChannelConfig
 
@@ -52,6 +53,31 @@ def _check_deerflow_reachable(
     return HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX
 
 
+def _check_nats_target(config: ChannelConfig) -> tuple[bool, str | None]:
+    if config.nats_url:
+        try:
+            options = parse_nats_url(config.nats_url)
+            servers = options.get("servers", [])
+        except (NatsContextError, ValueError) as exc:
+            return False, f"NATS_URL is invalid: {exc}"
+        if not servers or any(
+            any(ch.isspace() for ch in server)
+            or urlparse(server).scheme not in {"nats", "tls", "ws", "wss"}
+            for server in servers
+        ):
+            return False, "NATS_URL is invalid: expected nats://, tls://, ws://, or wss:// URL"
+        return True, None
+
+    context = config.nats_context or "current"
+    try:
+        load_context_options(context)
+    except NatsContextError as exc:
+        if config.nats_context:
+            return False, f"NATS context {config.nats_context!r} could not be loaded: {exc}"
+        return False, f"default NATS context could not be loaded: {exc}"
+    return True, None
+
+
 def run_doctor(
     config: ChannelConfig,
     *,
@@ -71,8 +97,9 @@ def run_doctor(
         messages.append("deerflow_url must be an http(s) URL")
 
     checks["nats_target_configured"] = bool(config.nats_context or config.nats_url)
-    if not checks["nats_target_configured"]:
-        messages.append("set NATS_CONTEXT or NATS_URL before starting the channel")
+    checks["nats_target_valid"], nats_target_error = _check_nats_target(config)
+    if nats_target_error:
+        messages.append(nats_target_error)
 
     checks["agent_token_shape"] = (
         config.agent.replace("-", "").isalnum() and config.agent.lower() == config.agent
@@ -91,7 +118,7 @@ def run_doctor(
         for name in (
             "owner_configured",
             "deerflow_url_shape",
-            "nats_target_configured",
+            "nats_target_valid",
             "agent_token_shape",
         )
     )

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
+
+import httpx
 
 from .config import ChannelConfig
+
+HTTP_OK_MIN = 200
+HTTP_OK_MAX = 300
 
 
 @dataclass(frozen=True)
@@ -29,8 +34,30 @@ class DoctorReport:
         )
 
 
-def run_doctor(config: ChannelConfig) -> DoctorReport:
-    """Run shallow Phase 1 checks without opening network connections."""
+def _health_url(config: ChannelConfig) -> str:
+    return urljoin(config.deerflow_url.rstrip("/") + "/", "health")
+
+
+def _check_deerflow_reachable(
+    config: ChannelConfig,
+    *,
+    transport: httpx.BaseTransport | None = None,
+    timeout: float = 2.0,
+) -> bool:
+    try:
+        with httpx.Client(transport=transport, timeout=timeout) as client:
+            response = client.get(_health_url(config))
+    except httpx.HTTPError:
+        return False
+    return HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX
+
+
+def run_doctor(
+    config: ChannelConfig,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> DoctorReport:
+    """Run shallow checks, including DeerFlow Gateway health reachability."""
     checks: dict[str, bool] = {}
     messages: list[str] = []
 
@@ -53,5 +80,19 @@ def run_doctor(config: ChannelConfig) -> DoctorReport:
     if not checks["agent_token_shape"]:
         messages.append("agent token must be lowercase alphanumeric plus hyphen")
 
-    ok = all(checks.values())
+    checks["deerflow_reachable"] = False
+    if checks["deerflow_url_shape"]:
+        checks["deerflow_reachable"] = _check_deerflow_reachable(config, transport=transport)
+        if not checks["deerflow_reachable"]:
+            messages.append(f"DeerFlow Gateway is not reachable at {_health_url(config)}")
+
+    ok = all(
+        checks[name]
+        for name in (
+            "owner_configured",
+            "deerflow_url_shape",
+            "nats_target_configured",
+            "agent_token_shape",
+        )
+    )
     return DoctorReport(ok=ok, checks=checks, config=config.redacted_dict(), messages=messages)

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
@@ -1,0 +1,57 @@
+"""Doctor checks for the DeerFlow NATS channel."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from .config import ChannelConfig
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    ok: bool
+    checks: dict[str, bool]
+    config: dict[str, str | None]
+    messages: list[str]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "ok": self.ok,
+                "checks": self.checks,
+                "config": self.config,
+                "messages": self.messages,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+
+def run_doctor(config: ChannelConfig) -> DoctorReport:
+    """Run shallow Phase 1 checks without opening network connections."""
+    checks: dict[str, bool] = {}
+    messages: list[str] = []
+
+    checks["owner_configured"] = bool(config.owner)
+    if not config.owner:
+        messages.append("owner is not configured; set NATS_OWNER or pass --owner")
+
+    parsed = urlparse(config.deerflow_url)
+    checks["deerflow_url_shape"] = parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+    if not checks["deerflow_url_shape"]:
+        messages.append("deerflow_url must be an http(s) URL")
+
+    checks["nats_target_configured"] = bool(config.nats_context or config.nats_url)
+    if not checks["nats_target_configured"]:
+        messages.append("set NATS_CONTEXT or NATS_URL before starting the channel")
+
+    checks["agent_token_shape"] = (
+        config.agent.replace("-", "").isalnum() and config.agent.lower() == config.agent
+    )
+    if not checks["agent_token_shape"]:
+        messages.append("agent token must be lowercase alphanumeric plus hyphen")
+
+    ok = all(checks.values())
+    return DoctorReport(ok=ok, checks=checks, config=config.redacted_dict(), messages=messages)

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -13,9 +13,11 @@ from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
 from synadia_ai.agents import Envelope, load_context_options
 
 from .config import ChannelConfig
-from .runner import deerflow_gateway_runner
+from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent
 
 PromptRunner = Callable[[str], AsyncIterator[str]]
+QUERY_TIMEOUT_S = 300.0
+MAX_CLARIFICATION_ROUNDS = 8
 
 
 def _nats_connect_options(config: ChannelConfig) -> dict[str, object]:
@@ -43,12 +45,38 @@ def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
         description="DeerFlow channel wrapper for the Synadia Agent Protocol",
         attachments_ok=False,
     )
-    async def runner(prompt: str) -> AsyncIterator[str]:
-        async for chunk in deerflow_gateway_runner(prompt, config):
-            yield chunk
-
-    service.on_prompt(make_prompt_handler(runner))
+    service.on_prompt(make_deerflow_prompt_handler(config))
     return service
+
+
+def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
+    """Build a prompt handler that bridges DeerFlow SSE to protocol chunks.
+
+    DeerFlow surfaces human-in-the-loop clarification as an `ask_clarification`
+    tool message in the thread stream. The Synadia Agent Protocol equivalent is
+    a mid-stream query chunk, so the wrapper asks the caller and then posts the
+    answer back to the same DeerFlow thread as the next user message.
+    """
+
+    async def _handler(envelope: Envelope, stream: PromptStream) -> None:
+        client = DeerFlowGatewayClient(config)
+        prompt = envelope.prompt
+        for _ in range(MAX_CLARIFICATION_ROUNDS):
+            needs_followup = False
+            async for event in client.stream_events(prompt):
+                if isinstance(event, TextEvent):
+                    await stream.send(event.text)
+                    continue
+                if isinstance(event, ClarificationEvent):
+                    reply = await stream.ask(event.prompt, timeout=QUERY_TIMEOUT_S)
+                    prompt = reply.prompt
+                    needs_followup = True
+                    break
+            if not needs_followup:
+                return
+        raise RuntimeError("too many DeerFlow clarification rounds")
+
+    return _handler
 
 
 def make_prompt_handler(runner: PromptRunner) -> PromptHandler:

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -1,0 +1,73 @@
+"""Protocol host wiring for the DeerFlow NATS channel."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
+from typing import Any, cast
+
+import nats
+from nats.aio.client import Client as NATSClient
+from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
+from synadia_ai.agents import Envelope, load_context_options
+
+from .config import ChannelConfig
+from .runner import fake_deerflow_runner
+
+PromptRunner = Callable[[str], AsyncIterator[str]]
+
+
+def _nats_connect_options(config: ChannelConfig) -> dict[str, object]:
+    if config.nats_context:
+        return dict(load_context_options(config.nats_context))
+    if config.nats_url:
+        return {"servers": config.nats_url}
+    return dict(load_context_options("current"))
+
+
+async def connect_nats(config: ChannelConfig) -> NATSClient:
+    """Open a NATS connection for the channel wrapper."""
+    return await nats.connect(**cast(dict[str, Any], _nats_connect_options(config)))
+
+
+def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
+    """Build the Synadia Agent Protocol service for DeerFlow."""
+    if not config.owner:
+        raise ValueError("owner is required to host the protocol service")
+    service = AgentService(
+        agent=config.agent,
+        owner=config.owner,
+        session_name=config.session,
+        nc=nc,
+        description="DeerFlow channel wrapper for the Synadia Agent Protocol",
+        attachments_ok=False,
+    )
+    service.on_prompt(make_prompt_handler(fake_deerflow_runner))
+    return service
+
+
+def make_prompt_handler(runner: PromptRunner) -> PromptHandler:
+    """Adapt a prompt runner to the AgentService prompt-handler API."""
+
+    async def _handler(envelope: Envelope, stream: PromptStream) -> None:
+        async for chunk in runner(envelope.prompt):
+            await stream.send(chunk)
+
+    return _handler
+
+
+async def run_channel(config: ChannelConfig, *, stop_event: asyncio.Event | None = None) -> None:
+    """Run the long-lived protocol host until cancelled or stop_event is set."""
+    nc = await connect_nats(config)
+    service = build_agent_service(config, nc)
+    await service.start()
+    try:
+        if stop_event is None:
+            await asyncio.Event().wait()
+        else:
+            await stop_event.wait()
+    finally:
+        await service.stop()
+        with suppress(Exception):
+            await nc.close()

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -13,7 +13,7 @@ from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
 from synadia_ai.agents import Envelope, load_context_options
 
 from .config import ChannelConfig
-from .runner import fake_deerflow_runner
+from .runner import deerflow_gateway_runner
 
 PromptRunner = Callable[[str], AsyncIterator[str]]
 
@@ -43,7 +43,11 @@ def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
         description="DeerFlow channel wrapper for the Synadia Agent Protocol",
         attachments_ok=False,
     )
-    service.on_prompt(make_prompt_handler(fake_deerflow_runner))
+    async def runner(prompt: str) -> AsyncIterator[str]:
+        async for chunk in deerflow_gateway_runner(prompt, config):
+            yield chunk
+
+    service.on_prompt(make_prompt_handler(runner))
     return service
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -10,10 +10,16 @@ from typing import Any, cast
 import nats
 from nats.aio.client import Client as NATSClient
 from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
-from synadia_ai.agents import Envelope, ProtocolError, QueryTimeout, load_context_options
+from synadia_ai.agents import (
+    Envelope,
+    ProtocolError,
+    QueryTimeout,
+    StatusChunk,
+    load_context_options,
+)
 
 from .config import ChannelConfig
-from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent
+from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent, ToolEvent
 
 PromptRunner = Callable[[str], AsyncIterator[str]]
 MAX_CLARIFICATION_ROUNDS = 8
@@ -68,6 +74,9 @@ def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
             async for event in client.stream_events(prompt):
                 if isinstance(event, TextEvent):
                     await stream.send(event.text)
+                    continue
+                if isinstance(event, ToolEvent):
+                    await stream.send(StatusChunk(status=event.status))
                     continue
                 if isinstance(event, ClarificationEvent):
                     try:

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -10,13 +10,12 @@ from typing import Any, cast
 import nats
 from nats.aio.client import Client as NATSClient
 from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
-from synadia_ai.agents import Envelope, load_context_options
+from synadia_ai.agents import Envelope, ProtocolError, QueryTimeout, load_context_options
 
 from .config import ChannelConfig
 from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent
 
 PromptRunner = Callable[[str], AsyncIterator[str]]
-QUERY_TIMEOUT_S = 300.0
 MAX_CLARIFICATION_ROUNDS = 8
 
 
@@ -44,6 +43,7 @@ def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
         nc=nc,
         description="DeerFlow channel wrapper for the Synadia Agent Protocol",
         attachments_ok=False,
+        max_payload=config.max_payload,
     )
     service.on_prompt(make_deerflow_prompt_handler(config))
     return service
@@ -59,7 +59,9 @@ def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
     """
 
     async def _handler(envelope: Envelope, stream: PromptStream) -> None:
-        client = DeerFlowGatewayClient(config)
+        if envelope.attachments:
+            raise ProtocolError("attachments are not supported by the DeerFlow wrapper")
+        client = DeerFlowGatewayClient(config, timeout=config.deerflow_timeout_s)
         prompt = envelope.prompt
         for _ in range(MAX_CLARIFICATION_ROUNDS):
             needs_followup = False
@@ -68,7 +70,15 @@ def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
                     await stream.send(event.text)
                     continue
                 if isinstance(event, ClarificationEvent):
-                    reply = await stream.ask(event.prompt, timeout=QUERY_TIMEOUT_S)
+                    try:
+                        reply = await stream.ask(event.prompt, timeout=config.query_timeout_s)
+                    except QueryTimeout as exc:
+                        raise TimeoutError(
+                            f"caller did not answer DeerFlow clarification within "
+                            f"{config.query_timeout_s:g}s"
+                        ) from exc
+                    if reply.attachments:
+                        raise ProtocolError("attachments are not supported in query replies")
                     prompt = reply.prompt
                     needs_followup = True
                     break

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -68,32 +68,35 @@ def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
         if envelope.attachments:
             raise ProtocolError("attachments are not supported by the DeerFlow wrapper")
         client = DeerFlowGatewayClient(config, timeout=config.deerflow_timeout_s)
-        prompt = envelope.prompt
-        for _ in range(MAX_CLARIFICATION_ROUNDS):
-            needs_followup = False
-            async for event in client.stream_events(prompt):
-                if isinstance(event, TextEvent):
-                    await stream.send(event.text)
-                    continue
-                if isinstance(event, ToolEvent):
-                    await stream.send(StatusChunk(status=event.status))
-                    continue
-                if isinstance(event, ClarificationEvent):
-                    try:
-                        reply = await stream.ask(event.prompt, timeout=config.query_timeout_s)
-                    except QueryTimeout as exc:
-                        raise TimeoutError(
-                            f"caller did not answer DeerFlow clarification within "
-                            f"{config.query_timeout_s:g}s"
-                        ) from exc
-                    if reply.attachments:
-                        raise ProtocolError("attachments are not supported in query replies")
-                    prompt = reply.prompt
-                    needs_followup = True
-                    break
-            if not needs_followup:
-                return
-        raise RuntimeError("too many DeerFlow clarification rounds")
+        try:
+            prompt = envelope.prompt
+            for _ in range(MAX_CLARIFICATION_ROUNDS):
+                needs_followup = False
+                async for event in client.stream_events(prompt):
+                    if isinstance(event, TextEvent):
+                        await stream.send(event.text)
+                        continue
+                    if isinstance(event, ToolEvent):
+                        await stream.send(StatusChunk(status=event.status))
+                        continue
+                    if isinstance(event, ClarificationEvent):
+                        try:
+                            reply = await stream.ask(event.prompt, timeout=config.query_timeout_s)
+                        except QueryTimeout as exc:
+                            raise TimeoutError(
+                                f"caller did not answer DeerFlow clarification within "
+                                f"{config.query_timeout_s:g}s"
+                            ) from exc
+                        if reply.attachments:
+                            raise ProtocolError("attachments are not supported in query replies")
+                        prompt = reply.prompt
+                        needs_followup = True
+                        break
+                if not needs_followup:
+                    return
+            raise RuntimeError("too many DeerFlow clarification rounds")
+        finally:
+            await client.aclose()
 
     return _handler
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -69,6 +69,7 @@ class DeerFlowGatewayClient:
     ) -> None:
         self._config = config
         self._http_client = http_client
+        self._owned_http_client: httpx.AsyncClient | None = None
         self._timeout = timeout
         self._logged_in = False
 
@@ -105,17 +106,8 @@ class DeerFlowGatewayClient:
                 async for event, data in _iter_sse(response):
                     if event == "end":
                         break
-                    clarification = _extract_clarification_from_sse_event(event, data)
-                    if clarification:
-                        yield ClarificationEvent(prompt=clarification)
-                        continue
-                    tool_status = _extract_tool_status_from_sse_event(event, data)
-                    if tool_status:
-                        yield ToolEvent(status=tool_status)
-                        continue
-                    text = _extract_text_from_sse_event(event, data)
-                    if text:
-                        yield TextEvent(text=text)
+                    for semantic_event in _extract_events_from_sse_event(event, data):
+                        yield semantic_event
 
     async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
         """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
@@ -126,7 +118,16 @@ class DeerFlowGatewayClient:
     def _client(self) -> _ClientContext:
         if self._http_client is not None:
             return _ClientContext(self._http_client, close=False)
-        return _ClientContext(httpx.AsyncClient(timeout=self._timeout), close=True)
+        if self._owned_http_client is None:
+            self._owned_http_client = httpx.AsyncClient(timeout=self._timeout)
+        return _ClientContext(self._owned_http_client, close=False)
+
+    async def aclose(self) -> None:
+        """Close the owned HTTP client, if this wrapper created one."""
+        if self._owned_http_client is not None:
+            await self._owned_http_client.aclose()
+            self._owned_http_client = None
+            self._logged_in = False
 
     def _url(self, path: str) -> str:
         return urljoin(self._config.deerflow_url.rstrip("/") + "/", path.lstrip("/"))
@@ -165,6 +166,8 @@ class DeerFlowGatewayClient:
             },
             headers=self._request_headers(client),
         )
+        if response.status_code == httpx.codes.CONFLICT:
+            return
         if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
             detail = _safe_error_detail(response.text)
             suffix = f": {detail}" if detail else ""
@@ -210,8 +213,11 @@ async def deerflow_gateway_runner(
 ) -> AsyncIterator[str]:
     """Run one prompt through the configured DeerFlow Gateway."""
     client = DeerFlowGatewayClient(config, http_client=http_client)
-    async for chunk in client.stream_prompt(prompt):
-        yield chunk
+    try:
+        async for chunk in client.stream_prompt(prompt):
+            yield chunk
+    finally:
+        await client.aclose()
 
 
 def _prompt_request_body(prompt: str) -> dict[str, Any]:
@@ -274,6 +280,25 @@ ASSISTANT_TYPES = {"ai", "assistant", "AIMessage", "AIMessageChunk"}
 ASSISTANT_ROLES = {"assistant", "ai"}
 MAX_TOOL_NAME_CHARS = 80
 LANGGRAPH_TUPLE_ITEMS = 2
+MAX_STATE_TRAVERSAL_DEPTH = 32
+
+
+def _extract_events_from_sse_event(event: str, data: Any) -> list[DeerFlowEvent]:
+    """Extract all user-visible semantic events from one DeerFlow SSE frame."""
+    semantic_events: list[DeerFlowEvent] = []
+    for message in _iter_message_payloads(event, data):
+        clarification = _extract_clarification(message)
+        if clarification:
+            semantic_events.append(ClarificationEvent(prompt=clarification))
+            continue
+        status = _extract_tool_status(message)
+        if status:
+            semantic_events.append(ToolEvent(status=status))
+            continue
+        text = _extract_text(message)
+        if text:
+            semantic_events.append(TextEvent(text=text))
+    return semantic_events
 
 
 def _extract_clarification_from_sse_event(event: str, data: Any) -> str | None:
@@ -318,7 +343,12 @@ def _iter_message_payloads(event: str, data: Any) -> list[Any]:
 def _message_event_payloads(data: Any) -> list[Any]:
     """Return only the message half of LangGraph `[message, metadata]` tuples."""
     if isinstance(data, list):
-        if len(data) == LANGGRAPH_TUPLE_ITEMS and isinstance(data[1], dict):
+        if (
+            len(data) == LANGGRAPH_TUPLE_ITEMS
+            and isinstance(data[1], dict)
+            and bool(_coerce_message_list(data[0]))
+            and not _looks_like_message(data[1])
+        ):
             return _coerce_message_list(data[0])
         return [item for item in data if _looks_like_message(item)]
     if _looks_like_message(data):
@@ -328,23 +358,26 @@ def _message_event_payloads(data: Any) -> list[Any]:
     return []
 
 
-def _state_message_payloads(value: Any) -> list[Any]:
+def _state_message_payloads(value: Any, *, depth: int = 0) -> list[Any]:
+    if depth > MAX_STATE_TRAVERSAL_DEPTH:
+        return []
+
     messages: list[Any] = []
     if isinstance(value, dict):
         for key in ("messages", "message"):
             if key in value:
                 messages.extend(_coerce_message_list(value[key]))
         for key, nested in value.items():
-            if key in INTERNAL_KEYS or key in {"content", "text"}:
+            if key in INTERNAL_KEYS or key in {"content", "text", "messages", "message"}:
                 continue
             if isinstance(nested, dict | list):
-                messages.extend(_state_message_payloads(nested))
+                messages.extend(_state_message_payloads(nested, depth=depth + 1))
     elif isinstance(value, list):
         for item in value:
             if _looks_like_message(item):
                 messages.append(item)
             elif isinstance(item, dict | list):
-                messages.extend(_state_message_payloads(item))
+                messages.extend(_state_message_payloads(item, depth=depth + 1))
     return messages
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -42,7 +42,14 @@ class ClarificationEvent:
     prompt: str
 
 
-DeerFlowEvent = TextEvent | ClarificationEvent
+@dataclass(frozen=True)
+class ToolEvent:
+    """Meaningful DeerFlow tool activity surfaced as protocol status."""
+
+    status: str
+
+
+DeerFlowEvent = TextEvent | ClarificationEvent | ToolEvent
 
 
 class DeerFlowGatewayClient:
@@ -101,6 +108,10 @@ class DeerFlowGatewayClient:
                     clarification = _extract_clarification_from_sse_event(event, data)
                     if clarification:
                         yield ClarificationEvent(prompt=clarification)
+                        continue
+                    tool_status = _extract_tool_status_from_sse_event(event, data)
+                    if tool_status:
+                        yield ToolEvent(status=tool_status)
                         continue
                     text = _extract_text_from_sse_event(event, data)
                     if text:
@@ -253,6 +264,59 @@ def _extract_clarification_from_sse_event(event: str, data: Any) -> str | None:
     if event not in {"messages", "messages-tuple", "updates", "values"}:
         return None
     return _extract_clarification(data)
+
+
+def _extract_tool_status_from_sse_event(event: str, data: Any) -> str | None:
+    """Extract meaningful DeerFlow tool activity without leaking metadata noise."""
+    if event not in {"messages", "messages-tuple", "updates", "values"}:
+        return None
+    return _extract_tool_status(data)
+
+
+def _extract_tool_status(value: Any) -> str | None:  # noqa: PLR0911,PLR0912
+    if isinstance(value, dict):
+        tool_calls = value.get("tool_calls") or value.get("tool_call_chunks")
+        status = _extract_tool_call_status(tool_calls)
+        if status:
+            return status
+
+        name = value.get("name")
+        message_type = value.get("type")
+        if isinstance(name, str) and name and message_type == "tool":
+            return f"DeerFlow tool result: {name}"
+        if isinstance(name, str) and name and value.get("id", "").startswith("call_"):
+            return f"DeerFlow tool call: {name}"
+
+        for key in ("messages", "message"):
+            status = _extract_tool_status(value.get(key))
+            if status:
+                return status
+        for key, nested in value.items():
+            if key in {"metadata", "response_metadata", "usage_metadata", "config"}:
+                continue
+            if isinstance(nested, dict | list):
+                status = _extract_tool_status(nested)
+                if status:
+                    return status
+    if isinstance(value, list):
+        for item in value:
+            status = _extract_tool_status(item)
+            if status:
+                return status
+    return None
+
+
+def _extract_tool_call_status(tool_calls: Any) -> str | None:
+    if isinstance(tool_calls, dict):
+        name = tool_calls.get("name")
+        if isinstance(name, str) and name:
+            return f"DeerFlow tool call: {name}"
+    if isinstance(tool_calls, list):
+        for item in tool_calls:
+            status = _extract_tool_call_status(item)
+            if status:
+                return status
+    return None
 
 
 def _extract_clarification(value: Any) -> str | None:

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -2,15 +2,181 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+from .config import ChannelConfig
+
+HTTP_OK_MIN = 200
+HTTP_OK_MAX = 300
+
+
+class DeerFlowGatewayClient:
+    """Narrow async client for DeerFlow Gateway prompt streaming.
+
+    This intentionally uses only the LangGraph-compatible DeerFlow Gateway
+    surface the wrapper needs: health reachability and thread run SSE streams.
+    Status and heartbeat subjects remain owned by the Synadia wrapper.
+    """
+
+    def __init__(
+        self,
+        config: ChannelConfig,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self._config = config
+        self._http_client = http_client
+        self._timeout = timeout
+
+    async def check_reachable(self) -> bool:
+        """Return whether DeerFlow Gateway's public health endpoint responds 2xx."""
+        async with self._client() as client:
+            try:
+                response = await client.get(self._url("/health"))
+            except httpx.HTTPError:
+                return False
+        return HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX
+
+    async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
+        """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
+        body = _prompt_request_body(prompt)
+        path = f"/api/threads/{self._config.session}/runs/stream"
+        async with (
+            self._client() as client,
+            client.stream("POST", self._url(path), json=body) as response,
+        ):
+            if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
+                body_bytes = await response.aread()
+                detail = body_bytes.decode(errors="replace").strip()
+                suffix = f": {detail}" if detail else ""
+                raise RuntimeError(
+                    f"DeerFlow Gateway stream failed: {response.status_code}{suffix}"
+                )
+
+            async for event, data in _iter_sse(response):
+                if event == "end":
+                    break
+                text = _extract_text_from_sse_event(event, data)
+                if text:
+                    yield text
+
+    def _client(self) -> _ClientContext:
+        if self._http_client is not None:
+            return _ClientContext(self._http_client, close=False)
+        return _ClientContext(httpx.AsyncClient(timeout=self._timeout), close=True)
+
+    def _url(self, path: str) -> str:
+        return urljoin(self._config.deerflow_url.rstrip("/") + "/", path.lstrip("/"))
+
+
+class _ClientContext:
+    def __init__(self, client: httpx.AsyncClient, *, close: bool) -> None:
+        self._client = client
+        self._close = close
+
+    async def __aenter__(self) -> httpx.AsyncClient:
+        return self._client
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        if self._close:
+            await self._client.aclose()
 
 
 async def fake_deerflow_runner(prompt: str) -> AsyncIterator[str]:
-    """Yield deterministic chunks for Phase 2 protocol-host tests.
-
-    The real DeerFlow Gateway bridge replaces this in Phase 3. Keeping this
-    separate lets us prove protocol hosting without depending on a running
-    DeerFlow instance.
-    """
+    """Yield deterministic chunks for protocol-host tests."""
     yield "DeerFlow fake runner received: "
     yield prompt
+
+
+async def deerflow_gateway_runner(
+    prompt: str,
+    config: ChannelConfig,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> AsyncIterator[str]:
+    """Run one prompt through the configured DeerFlow Gateway."""
+    client = DeerFlowGatewayClient(config, http_client=http_client)
+    async for chunk in client.stream_prompt(prompt):
+        yield chunk
+
+
+def _prompt_request_body(prompt: str) -> dict[str, Any]:
+    return {
+        "assistant_id": "lead_agent",
+        "input": {"messages": [{"role": "user", "content": prompt}]},
+        "config": {"recursion_limit": 50},
+        "context": {
+            "mode": "flash",
+            "thinking_enabled": False,
+            "is_plan_mode": False,
+            "subagent_enabled": False,
+        },
+        "stream_mode": ["messages"],
+    }
+
+
+async def _iter_sse(response: httpx.Response) -> AsyncIterator[tuple[str, Any]]:
+    event = "message"
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        if line == "":
+            if data_lines:
+                yield event, _parse_sse_data("\n".join(data_lines))
+            event = "message"
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            event = line.removeprefix("event:").strip()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line.removeprefix("data:").lstrip())
+    if data_lines:
+        yield event, _parse_sse_data("\n".join(data_lines))
+
+
+def _parse_sse_data(raw: str) -> Any:
+    if raw == "":
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
+    """Extract assistant-visible text from LangGraph/DeerFlow SSE event data."""
+    if event not in {"messages", "messages-tuple", "updates", "values"}:
+        return None
+    return _extract_text(data)
+
+
+def _extract_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, dict):
+        content = value.get("content")
+        if isinstance(content, str) and content:
+            return content
+        for key in ("messages", "message"):
+            nested = value.get(key)
+            text = _extract_text(nested)
+            if text:
+                return text
+        for nested in value.values():
+            text = _extract_text(nested)
+            if text:
+                return text
+    if isinstance(value, list):
+        for item in value:
+            text = _extract_text(item)
+            if text:
+                return text
+    return None

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin
 
@@ -13,6 +14,23 @@ from .config import ChannelConfig
 
 HTTP_OK_MIN = 200
 HTTP_OK_MAX = 300
+
+
+@dataclass(frozen=True)
+class TextEvent:
+    """Assistant-visible text emitted by DeerFlow."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ClarificationEvent:
+    """DeerFlow ask_clarification tool message surfaced as a protocol query."""
+
+    prompt: str
+
+
+DeerFlowEvent = TextEvent | ClarificationEvent
 
 
 class DeerFlowGatewayClient:
@@ -43,8 +61,8 @@ class DeerFlowGatewayClient:
                 return False
         return HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX
 
-    async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
-        """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
+    async def stream_events(self, prompt: str) -> AsyncIterator[DeerFlowEvent]:
+        """POST a user prompt to DeerFlow Gateway and yield semantic stream events."""
         body = _prompt_request_body(prompt)
         path = f"/api/threads/{self._config.session}/runs/stream"
         async with (
@@ -62,9 +80,19 @@ class DeerFlowGatewayClient:
             async for event, data in _iter_sse(response):
                 if event == "end":
                     break
+                clarification = _extract_clarification_from_sse_event(event, data)
+                if clarification:
+                    yield ClarificationEvent(prompt=clarification)
+                    continue
                 text = _extract_text_from_sse_event(event, data)
                 if text:
-                    yield text
+                    yield TextEvent(text=text)
+
+    async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
+        """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
+        async for event in self.stream_events(prompt):
+            if isinstance(event, TextEvent):
+                yield event.text
 
     def _client(self) -> _ClientContext:
         if self._http_client is not None:
@@ -151,6 +179,36 @@ def _parse_sse_data(raw: str) -> Any:
         return raw
 
 
+def _extract_clarification_from_sse_event(event: str, data: Any) -> str | None:
+    """Extract DeerFlow ask_clarification tool text from SSE event data."""
+    if event not in {"messages", "messages-tuple", "updates", "values"}:
+        return None
+    return _extract_clarification(data)
+
+
+def _extract_clarification(value: Any) -> str | None:
+    if isinstance(value, dict):
+        if value.get("name") == "ask_clarification":
+            content = value.get("content")
+            if isinstance(content, str) and content:
+                return content
+        for key in ("messages", "message"):
+            nested = value.get(key)
+            clarification = _extract_clarification(nested)
+            if clarification:
+                return clarification
+        for nested in value.values():
+            clarification = _extract_clarification(nested)
+            if clarification:
+                return clarification
+    if isinstance(value, list):
+        for item in value:
+            clarification = _extract_clarification(item)
+            if clarification:
+                return clarification
+    return None
+
+
 def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
     """Extract assistant-visible text from LangGraph/DeerFlow SSE event data."""
     if event not in {"messages", "messages-tuple", "updates", "values"}:
@@ -158,10 +216,12 @@ def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
     return _extract_text(data)
 
 
-def _extract_text(value: Any) -> str | None:
+def _extract_text(value: Any) -> str | None:  # noqa: PLR0911
     if isinstance(value, str):
         return value or None
     if isinstance(value, dict):
+        if value.get("name") == "ask_clarification":
+            return None
         content = value.get("content")
         if isinstance(content, str) and content:
             return content

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -285,27 +285,45 @@ def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
     return _extract_text(data)
 
 
-def _extract_text(value: Any) -> str | None:  # noqa: PLR0911
+def _extract_text(value: Any) -> str | None:  # noqa: PLR0911,PLR0912
     if isinstance(value, str):
         return value or None
     if isinstance(value, dict):
         if value.get("name") == "ask_clarification":
             return None
         content = value.get("content")
-        if isinstance(content, str) and content:
+        if isinstance(content, str) and content and _is_assistant_message(value):
             return content
         for key in ("messages", "message"):
             nested = value.get(key)
             text = _extract_text(nested)
             if text:
                 return text
-        for nested in value.values():
-            text = _extract_text(nested)
-            if text:
-                return text
+        for key, nested in value.items():
+            if key in {"metadata", "response_metadata", "usage_metadata", "config"}:
+                continue
+            if isinstance(nested, dict | list):
+                text = _extract_text(nested)
+                if text:
+                    return text
     if isinstance(value, list):
         for item in value:
             text = _extract_text(item)
             if text:
                 return text
     return None
+
+
+def _is_assistant_message(value: dict[str, Any]) -> bool:
+    role = value.get("role")
+    if isinstance(role, str):
+        return role in {"assistant", "ai"}
+
+    message_type = value.get("type")
+    if isinstance(message_type, str):
+        return message_type in {"ai", "assistant", "AIMessage", "AIMessageChunk"}
+
+    # Some LangChain/LangGraph message chunks arrive as plain dicts with a
+    # content field after serialization. Treat absent role/type as assistant
+    # output, but reject known non-assistant payloads explicitly above.
+    return True

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -346,12 +346,12 @@ def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
     """Extract assistant-visible text from LangGraph/DeerFlow SSE event data."""
     if event not in {"messages", "messages-tuple", "updates", "values"}:
         return None
+    if isinstance(data, str):
+        return data or None
     return _extract_text(data)
 
 
-def _extract_text(value: Any) -> str | None:  # noqa: PLR0911,PLR0912
-    if isinstance(value, str):
-        return value or None
+def _extract_text(value: Any) -> str | None:
     if isinstance(value, dict):
         if value.get("name") == "ask_clarification":
             return None

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -63,6 +63,7 @@ class DeerFlowGatewayClient:
         self._config = config
         self._http_client = http_client
         self._timeout = timeout
+        self._logged_in = False
 
     async def check_reachable(self) -> bool:
         """Return whether DeerFlow Gateway's public health endpoint responds 2xx."""
@@ -77,28 +78,32 @@ class DeerFlowGatewayClient:
         """POST a user prompt to DeerFlow Gateway and yield semantic stream events."""
         body = _prompt_request_body(prompt)
         path = f"/api/threads/{self._config.session}/runs/stream"
-        async with (
-            self._client() as client,
-            client.stream("POST", self._url(path), json=body) as response,
-        ):
-            if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
-                body_bytes = await response.aread()
-                detail = _safe_error_detail(body_bytes.decode(errors="replace"))
-                suffix = f": {detail}" if detail else ""
-                raise DeerFlowGatewayError(
-                    f"DeerFlow Gateway stream failed: {response.status_code}{suffix}"
-                )
+        async with self._client() as client:
+            await self._ensure_authenticated(client)
+            async with client.stream(
+                "POST",
+                self._url(path),
+                json=body,
+                headers=self._request_headers(client),
+            ) as response:
+                if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
+                    body_bytes = await response.aread()
+                    detail = _safe_error_detail(body_bytes.decode(errors="replace"))
+                    suffix = f": {detail}" if detail else ""
+                    raise DeerFlowGatewayError(
+                        f"DeerFlow Gateway stream failed: {response.status_code}{suffix}"
+                    )
 
-            async for event, data in _iter_sse(response):
-                if event == "end":
-                    break
-                clarification = _extract_clarification_from_sse_event(event, data)
-                if clarification:
-                    yield ClarificationEvent(prompt=clarification)
-                    continue
-                text = _extract_text_from_sse_event(event, data)
-                if text:
-                    yield TextEvent(text=text)
+                async for event, data in _iter_sse(response):
+                    if event == "end":
+                        break
+                    clarification = _extract_clarification_from_sse_event(event, data)
+                    if clarification:
+                        yield ClarificationEvent(prompt=clarification)
+                        continue
+                    text = _extract_text_from_sse_event(event, data)
+                    if text:
+                        yield TextEvent(text=text)
 
     async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
         """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
@@ -113,6 +118,39 @@ class DeerFlowGatewayClient:
 
     def _url(self, path: str) -> str:
         return urljoin(self._config.deerflow_url.rstrip("/") + "/", path.lstrip("/"))
+
+    async def _ensure_authenticated(self, client: httpx.AsyncClient) -> None:
+        if self._logged_in or not self._config.deerflow_username:
+            return
+        if not self._config.deerflow_password:
+            raise DeerFlowGatewayError(
+                "DeerFlow username was configured but DeerFlow password is missing"
+            )
+        response = await client.post(
+            self._url("/api/v1/auth/login/local"),
+            data={
+                "username": self._config.deerflow_username,
+                "password": self._config.deerflow_password,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
+            detail = _safe_error_detail(response.text)
+            suffix = f": {detail}" if detail else ""
+            raise DeerFlowGatewayError(
+                f"DeerFlow Gateway login failed: {response.status_code}{suffix}"
+            )
+        self._logged_in = True
+
+    def _request_headers(self, client: httpx.AsyncClient) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        cookie = self._config.deerflow_cookie
+        csrf_token = self._config.deerflow_csrf_token or client.cookies.get("csrf_token")
+        if csrf_token:
+            headers["X-CSRF-Token"] = csrf_token
+        if cookie:
+            headers["Cookie"] = cookie
+        return headers
 
 
 class _ClientContext:

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -1,0 +1,16 @@
+"""Prompt runners for the DeerFlow channel."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+
+async def fake_deerflow_runner(prompt: str) -> AsyncIterator[str]:
+    """Yield deterministic chunks for Phase 2 protocol-host tests.
+
+    The real DeerFlow Gateway bridge replaces this in Phase 3. Keeping this
+    separate lets us prove protocol hosting without depending on a running
+    DeerFlow instance.
+    """
+    yield "DeerFlow fake runner received: "
+    yield prompt

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -14,6 +14,18 @@ from .config import ChannelConfig
 
 HTTP_OK_MIN = 200
 HTTP_OK_MAX = 300
+MAX_ERROR_DETAIL_CHARS = 500
+
+
+class DeerFlowGatewayError(RuntimeError):
+    """Raised for operator-safe DeerFlow Gateway failures."""
+
+
+def _safe_error_detail(detail: str) -> str:
+    flat = " | ".join(line.strip() for line in detail.splitlines() if line.strip())
+    if len(flat) > MAX_ERROR_DETAIL_CHARS:
+        flat = flat[: MAX_ERROR_DETAIL_CHARS - 3] + "..."
+    return flat
 
 
 @dataclass(frozen=True)
@@ -71,9 +83,9 @@ class DeerFlowGatewayClient:
         ):
             if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
                 body_bytes = await response.aread()
-                detail = body_bytes.decode(errors="replace").strip()
+                detail = _safe_error_detail(body_bytes.decode(errors="replace"))
                 suffix = f": {detail}" if detail else ""
-                raise RuntimeError(
+                raise DeerFlowGatewayError(
                     f"DeerFlow Gateway stream failed: {response.status_code}{suffix}"
                 )
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -199,12 +199,6 @@ class _ClientContext:
             await self._client.aclose()
 
 
-async def fake_deerflow_runner(prompt: str) -> AsyncIterator[str]:
-    """Yield deterministic chunks for protocol-host tests."""
-    yield "DeerFlow fake runner received: "
-    yield prompt
-
-
 async def deerflow_gateway_runner(
     prompt: str,
     config: ChannelConfig,

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -259,58 +259,165 @@ def _parse_sse_data(raw: str) -> Any:
         return raw
 
 
+MESSAGE_EVENTS = {"messages", "messages-tuple", "updates", "values"}
+INTERNAL_KEYS = {
+    "additional_kwargs",
+    "artifact",
+    "config",
+    "kwargs",
+    "lc_kwargs",
+    "metadata",
+    "response_metadata",
+    "usage_metadata",
+}
+ASSISTANT_TYPES = {"ai", "assistant", "AIMessage", "AIMessageChunk"}
+ASSISTANT_ROLES = {"assistant", "ai"}
+MAX_TOOL_NAME_CHARS = 80
+LANGGRAPH_TUPLE_ITEMS = 2
+
+
 def _extract_clarification_from_sse_event(event: str, data: Any) -> str | None:
     """Extract DeerFlow ask_clarification tool text from SSE event data."""
-    if event not in {"messages", "messages-tuple", "updates", "values"}:
-        return None
-    return _extract_clarification(data)
+    for message in _iter_message_payloads(event, data):
+        clarification = _extract_clarification(message)
+        if clarification:
+            return clarification
+    return None
 
 
 def _extract_tool_status_from_sse_event(event: str, data: Any) -> str | None:
     """Extract meaningful DeerFlow tool activity without leaking metadata noise."""
-    if event not in {"messages", "messages-tuple", "updates", "values"}:
-        return None
-    return _extract_tool_status(data)
+    for message in _iter_message_payloads(event, data):
+        status = _extract_tool_status(message)
+        if status:
+            return status
+    return None
 
 
-def _extract_tool_status(value: Any) -> str | None:  # noqa: PLR0911,PLR0912
+def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
+    """Extract assistant-visible text from LangGraph/DeerFlow SSE event data."""
+    for message in _iter_message_payloads(event, data):
+        text = _extract_text(message)
+        if text:
+            return text
+    return None
+
+
+def _walk_message_payloads(event: str, data: Any) -> list[Any]:
+    if event not in MESSAGE_EVENTS:
+        return []
+    if event in {"messages", "messages-tuple"}:
+        return list(_message_event_payloads(data))
+    return list(_state_message_payloads(data))
+
+
+def _iter_message_payloads(event: str, data: Any) -> list[Any]:
+    return _walk_message_payloads(event, data)
+
+
+def _message_event_payloads(data: Any) -> list[Any]:
+    """Return only the message half of LangGraph `[message, metadata]` tuples."""
+    if isinstance(data, list):
+        if len(data) == LANGGRAPH_TUPLE_ITEMS and isinstance(data[1], dict):
+            return _coerce_message_list(data[0])
+        return [item for item in data if _looks_like_message(item)]
+    if _looks_like_message(data):
+        return [data]
+    if isinstance(data, dict):
+        return _state_message_payloads(data)
+    return []
+
+
+def _state_message_payloads(value: Any) -> list[Any]:
+    messages: list[Any] = []
     if isinstance(value, dict):
-        tool_calls = value.get("tool_calls") or value.get("tool_call_chunks")
+        for key in ("messages", "message"):
+            if key in value:
+                messages.extend(_coerce_message_list(value[key]))
+        for key, nested in value.items():
+            if key in INTERNAL_KEYS or key in {"content", "text"}:
+                continue
+            if isinstance(nested, dict | list):
+                messages.extend(_state_message_payloads(nested))
+    elif isinstance(value, list):
+        for item in value:
+            if _looks_like_message(item):
+                messages.append(item)
+            elif isinstance(item, dict | list):
+                messages.extend(_state_message_payloads(item))
+    return messages
+
+
+def _coerce_message_list(value: Any) -> list[Any]:
+    if _looks_like_message(value):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if _looks_like_message(item)]
+    return []
+
+
+def _looks_like_message(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("name") == "ask_clarification":
+        return True
+    role = value.get("role")
+    if isinstance(role, str) and role in ASSISTANT_ROLES | {"user", "human", "tool"}:
+        return True
+    message_type = value.get("type")
+    if isinstance(message_type, str) and message_type in ASSISTANT_TYPES | {
+        "human",
+        "user",
+        "tool",
+    }:
+        return True
+    if "tool_calls" in value or "tool_call_chunks" in value or "tool_call_id" in value:
+        return True
+    return (
+        isinstance(value.get("additional_kwargs"), dict)
+        and "tool_calls" in value["additional_kwargs"]
+    )
+
+
+def _extract_tool_status(value: Any) -> str | None:  # noqa: PLR0911
+    if not isinstance(value, dict):
+        return None
+    if value.get("name") == "ask_clarification":
+        return None
+
+    for tool_calls in (
+        value.get("tool_calls"),
+        value.get("tool_call_chunks"),
+        _additional_tool_calls(value),
+    ):
         status = _extract_tool_call_status(tool_calls)
         if status:
             return status
 
-        name = value.get("name")
-        message_type = value.get("type")
-        if isinstance(name, str) and name and message_type == "tool":
-            return f"DeerFlow tool result: {name}"
-        if isinstance(name, str) and name and value.get("id", "").startswith("call_"):
-            return f"DeerFlow tool call: {name}"
+    name = value.get("name")
+    message_type = value.get("type")
+    if message_type == "tool":
+        if isinstance(name, str) and name:
+            return f"DeerFlow tool result: {_safe_tool_name(name)}"
+        if isinstance(value.get("tool_call_id"), str):
+            return "DeerFlow tool result"
+    if isinstance(name, str) and name and str(value.get("id", "")).startswith("call_"):
+        return f"DeerFlow tool call: {_safe_tool_name(name)}"
+    return None
 
-        for key in ("messages", "message"):
-            status = _extract_tool_status(value.get(key))
-            if status:
-                return status
-        for key, nested in value.items():
-            if key in {"metadata", "response_metadata", "usage_metadata", "config"}:
-                continue
-            if isinstance(nested, dict | list):
-                status = _extract_tool_status(nested)
-                if status:
-                    return status
-    if isinstance(value, list):
-        for item in value:
-            status = _extract_tool_status(item)
-            if status:
-                return status
+
+def _additional_tool_calls(value: dict[str, Any]) -> Any:
+    additional_kwargs = value.get("additional_kwargs")
+    if isinstance(additional_kwargs, dict):
+        return additional_kwargs.get("tool_calls")
     return None
 
 
 def _extract_tool_call_status(tool_calls: Any) -> str | None:
     if isinstance(tool_calls, dict):
-        name = tool_calls.get("name")
-        if isinstance(name, str) and name:
-            return f"DeerFlow tool call: {name}"
+        name = _tool_call_name(tool_calls)
+        if name:
+            return f"DeerFlow tool call: {_safe_tool_name(name)}"
     if isinstance(tool_calls, list):
         for item in tool_calls:
             status = _extract_tool_call_status(item)
@@ -319,75 +426,70 @@ def _extract_tool_call_status(tool_calls: Any) -> str | None:
     return None
 
 
-def _extract_clarification(value: Any) -> str | None:
-    if isinstance(value, dict):
-        if value.get("name") == "ask_clarification":
-            content = value.get("content")
-            if isinstance(content, str) and content:
-                return content
-        for key in ("messages", "message"):
-            nested = value.get(key)
-            clarification = _extract_clarification(nested)
-            if clarification:
-                return clarification
-        for nested in value.values():
-            clarification = _extract_clarification(nested)
-            if clarification:
-                return clarification
-    if isinstance(value, list):
-        for item in value:
-            clarification = _extract_clarification(item)
-            if clarification:
-                return clarification
+def _tool_call_name(tool_call: dict[str, Any]) -> str | None:
+    name = tool_call.get("name")
+    if isinstance(name, str) and name:
+        return name
+    function = tool_call.get("function")
+    if isinstance(function, dict):
+        function_name = function.get("name")
+        if isinstance(function_name, str) and function_name:
+            return function_name
     return None
 
 
-def _extract_text_from_sse_event(event: str, data: Any) -> str | None:
-    """Extract assistant-visible text from LangGraph/DeerFlow SSE event data."""
-    if event not in {"messages", "messages-tuple", "updates", "values"}:
+def _safe_tool_name(name: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"_", "-", "."} else "_" for ch in name).strip("_")
+    if not safe:
+        return "unknown"
+    if len(safe) > MAX_TOOL_NAME_CHARS:
+        safe = safe[: MAX_TOOL_NAME_CHARS - 1] + "…"
+    return safe
+
+
+def _extract_clarification(value: Any) -> str | None:
+    if not isinstance(value, dict) or value.get("name") != "ask_clarification":
         return None
-    if isinstance(data, str):
-        return data or None
-    return _extract_text(data)
+    content = value.get("content")
+    if isinstance(content, str) and content:
+        return content
+    return None
 
 
 def _extract_text(value: Any) -> str | None:
-    if isinstance(value, dict):
-        if value.get("name") == "ask_clarification":
-            return None
-        content = value.get("content")
-        if isinstance(content, str) and content and _is_assistant_message(value):
-            return content
-        for key in ("messages", "message"):
-            nested = value.get(key)
-            text = _extract_text(nested)
-            if text:
-                return text
-        for key, nested in value.items():
-            if key in {"metadata", "response_metadata", "usage_metadata", "config"}:
-                continue
-            if isinstance(nested, dict | list):
-                text = _extract_text(nested)
-                if text:
-                    return text
-    if isinstance(value, list):
-        for item in value:
-            text = _extract_text(item)
-            if text:
-                return text
+    if not isinstance(value, dict):
+        return None
+    if value.get("name") == "ask_clarification" or not _is_assistant_message(value):
+        return None
+    return _extract_text_content(value.get("content"))
+
+
+def _extract_text_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content or None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") not in {None, "text"}:
+                    continue
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif isinstance(item, str) and item:
+                parts.append(item)
+        if parts:
+            return "".join(parts)
     return None
 
 
 def _is_assistant_message(value: dict[str, Any]) -> bool:
     role = value.get("role")
     if isinstance(role, str):
-        return role in {"assistant", "ai"}
+        return role in ASSISTANT_ROLES
 
     message_type = value.get("type")
     if isinstance(message_type, str):
-        return message_type in {"ai", "assistant", "AIMessage", "AIMessageChunk"}
+        return message_type in ASSISTANT_TYPES
 
-    # Some LangChain/LangGraph message chunks arrive as plain dicts with a
-    # content field after serialization. Treat absent role/type as assistant
-    # output, but reject known non-assistant payloads explicitly above.
-    return True
+    return False

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -80,6 +80,7 @@ class DeerFlowGatewayClient:
         path = f"/api/threads/{self._config.session}/runs/stream"
         async with self._client() as client:
             await self._ensure_authenticated(client)
+            await self._ensure_thread_exists(client)
             async with client.stream(
                 "POST",
                 self._url(path),
@@ -120,7 +121,9 @@ class DeerFlowGatewayClient:
         return urljoin(self._config.deerflow_url.rstrip("/") + "/", path.lstrip("/"))
 
     async def _ensure_authenticated(self, client: httpx.AsyncClient) -> None:
-        if self._logged_in or not self._config.deerflow_username:
+        if not self._config.deerflow_username:
+            return
+        if self._logged_in and client.cookies.get("csrf_token"):
             return
         if not self._config.deerflow_password:
             raise DeerFlowGatewayError(
@@ -141,6 +144,22 @@ class DeerFlowGatewayClient:
                 f"DeerFlow Gateway login failed: {response.status_code}{suffix}"
             )
         self._logged_in = True
+
+    async def _ensure_thread_exists(self, client: httpx.AsyncClient) -> None:
+        response = await client.post(
+            self._url("/api/threads"),
+            json={
+                "thread_id": self._config.session,
+                "metadata": {"source": "synadia-nats-channel"},
+            },
+            headers=self._request_headers(client),
+        )
+        if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
+            detail = _safe_error_detail(response.text)
+            suffix = f": {detail}" if detail else ""
+            raise DeerFlowGatewayError(
+                f"DeerFlow Gateway thread ensure failed: {response.status_code}{suffix}"
+            )
 
     def _request_headers(self, client: httpx.AsyncClient) -> dict[str, str]:
         headers: dict[str, str] = {}

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/testing.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/testing.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+
+async def fake_deerflow_runner(prompt: str) -> AsyncIterator[str]:
+    """Yield deterministic chunks for protocol-host tests."""
+    yield "DeerFlow fake runner received: "
+    yield prompt

--- a/agents/deerflow/tests/test_cli.py
+++ b/agents/deerflow/tests/test_cli.py
@@ -32,6 +32,7 @@ def test_doctor_fails_without_owner_or_nats_target(
     monkeypatch.delenv("NATS_OWNER", raising=False)
     monkeypatch.delenv("NATS_URL", raising=False)
     monkeypatch.delenv("NATS_CONTEXT", raising=False)
+    monkeypatch.setenv("NATS_CONFIG_HOME", str(tmp_path / "nats"))
 
     code = main(["doctor", "--config-file", str(tmp_path / "missing.toml")])
 
@@ -39,7 +40,7 @@ def test_doctor_fails_without_owner_or_nats_target(
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
     assert payload["checks"]["owner_configured"] is False
-    assert payload["checks"]["nats_target_configured"] is False
+    assert payload["checks"]["nats_target_valid"] is False
 
 
 def test_configure_prints_config_path(capsys: Any, tmp_path: Path) -> None:

--- a/agents/deerflow/tests/test_cli.py
+++ b/agents/deerflow/tests/test_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from synadia_ai.nats_deerflow_channel.cli import main
+
+
+def test_doctor_success_with_cli_args(capsys: Any) -> None:
+    code = main(
+        [
+            "doctor",
+            "--owner",
+            "rene",
+            "--session",
+            "deerflow",
+            "--nats-url",
+            "nats://127.0.0.1:4222",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["config"]["prompt_subject"] == "agents.prompt.df.rene.deerflow"
+
+
+def test_doctor_fails_without_owner_or_nats_target(
+    capsys: Any, tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.delenv("NATS_OWNER", raising=False)
+    monkeypatch.delenv("NATS_URL", raising=False)
+    monkeypatch.delenv("NATS_CONTEXT", raising=False)
+
+    code = main(["doctor", "--config-file", str(tmp_path / "missing.toml")])
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["checks"]["owner_configured"] is False
+    assert payload["checks"]["nats_target_configured"] is False
+
+
+def test_configure_prints_config_path(capsys: Any, tmp_path: Path) -> None:
+    code = main(["configure", "--config-file", str(tmp_path / "config.toml")])
+
+    assert code == 0
+    assert capsys.readouterr().out.strip() == str(tmp_path / "config.toml")

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -25,16 +25,20 @@ def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
 def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: Any) -> None:
     config_file = tmp_path / "config.toml"
     config_file.write_text(
-        '\n'.join(
+        "\n".join(
             [
                 'agent = "from-file"',
                 'owner = "file-owner"',
                 'session = "file-session"',
                 'deerflow_url = "http://file.example"',
                 'nats_context = "file-context"',
-                'deerflow_timeout_s = 12.5',
-                'query_timeout_s = 45',
+                "deerflow_timeout_s = 12.5",
+                "query_timeout_s = 45",
                 'max_payload = "256KB"',
+                'deerflow_cookie = "access_token=file; csrf_token=file-csrf"',
+                'deerflow_csrf_token = "file-csrf"',
+                'deerflow_username = "file@example.com"',
+                'deerflow_password = "file-password"',
             ]
         ),
         encoding="utf-8",
@@ -44,12 +48,20 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
     monkeypatch.setenv("DEERFLOW_URL", "http://env.example")
     monkeypatch.setenv("DEERFLOW_TIMEOUT_S", "20")
     monkeypatch.setenv("DEERFLOW_QUERY_TIMEOUT_S", "90")
+    monkeypatch.setenv("DEERFLOW_COOKIE", "access_token=env; csrf_token=env-csrf")
+    monkeypatch.setenv("DEERFLOW_CSRF_TOKEN", "env-csrf")
+    monkeypatch.setenv("DEERFLOW_USERNAME", "env@example.com")
+    monkeypatch.setenv("DEERFLOW_PASSWORD", "env-password")
 
     config = resolve_config(
         config_file=config_file,
         owner="cli-owner",
         deerflow_url="http://cli.example",
         max_payload="512KB",
+        deerflow_cookie="access_token=cli; csrf_token=cli-csrf",
+        deerflow_csrf_token="cli-csrf",
+        deerflow_username="cli@example.com",
+        deerflow_password="cli-password",
     )
 
     assert config.agent == "from-file"
@@ -60,6 +72,14 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
     assert config.deerflow_timeout_s == 20
     assert config.query_timeout_s == 90
     assert config.max_payload == "512KB"
+    assert config.deerflow_cookie == "access_token=cli; csrf_token=cli-csrf"
+    assert config.deerflow_csrf_token == "cli-csrf"
+    assert config.redacted_dict()["deerflow_cookie"] == "[REDACTED]"
+    assert config.redacted_dict()["deerflow_csrf_token"] == "[REDACTED]"
+    assert config.deerflow_username == "cli@example.com"
+    assert config.deerflow_password == "cli-password"
+    assert config.redacted_dict()["deerflow_username"] == "cli@example.com"
+    assert config.redacted_dict()["deerflow_password"] == "[REDACTED]"
 
 
 def test_nats_url_env_is_used(tmp_path: Path, monkeypatch: Any) -> None:

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from synadia_ai.nats_deerflow_channel.config import resolve_config
+
+
+def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.delenv("NATS_OWNER", raising=False)
+    monkeypatch.delenv("NATS_AGENT_NAME", raising=False)
+    monkeypatch.delenv("DEERFLOW_URL", raising=False)
+
+    config = resolve_config(config_file=tmp_path / "missing.toml")
+
+    assert config.agent == "df"
+    assert config.session == "default"
+    assert config.deerflow_url == "http://localhost:2026"
+    assert config.redacted_dict()["prompt_subject"] == "agents.prompt.df.<owner>.default"
+
+
+def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: Any) -> None:
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '\n'.join(
+            [
+                'agent = "from-file"',
+                'owner = "file-owner"',
+                'session = "file-session"',
+                'deerflow_url = "http://file.example"',
+                'nats_context = "file-context"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NATS_OWNER", "env-owner")
+    monkeypatch.setenv("NATS_AGENT_NAME", "env-session")
+    monkeypatch.setenv("DEERFLOW_URL", "http://env.example")
+
+    config = resolve_config(
+        config_file=config_file,
+        owner="cli-owner",
+        deerflow_url="http://cli.example",
+    )
+
+    assert config.agent == "from-file"
+    assert config.owner == "cli-owner"
+    assert config.session == "env-session"
+    assert config.deerflow_url == "http://cli.example"
+    assert config.nats_context == "file-context"
+
+
+def test_nats_url_env_is_used(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setenv("NATS_URL", "nats://127.0.0.1:4222")
+
+    config = resolve_config(config_file=tmp_path / "missing.toml")
+
+    assert config.nats_url == "nats://127.0.0.1:4222"

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -16,6 +16,9 @@ def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
     assert config.agent == "df"
     assert config.session == "default"
     assert config.deerflow_url == "http://localhost:2026"
+    assert config.deerflow_timeout_s == 60.0
+    assert config.query_timeout_s == 300.0
+    assert config.max_payload == "1MB"
     assert config.redacted_dict()["prompt_subject"] == "agents.prompt.df.<owner>.default"
 
 
@@ -29,6 +32,9 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
                 'session = "file-session"',
                 'deerflow_url = "http://file.example"',
                 'nats_context = "file-context"',
+                'deerflow_timeout_s = 12.5',
+                'query_timeout_s = 45',
+                'max_payload = "256KB"',
             ]
         ),
         encoding="utf-8",
@@ -36,11 +42,14 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
     monkeypatch.setenv("NATS_OWNER", "env-owner")
     monkeypatch.setenv("NATS_AGENT_NAME", "env-session")
     monkeypatch.setenv("DEERFLOW_URL", "http://env.example")
+    monkeypatch.setenv("DEERFLOW_TIMEOUT_S", "20")
+    monkeypatch.setenv("DEERFLOW_QUERY_TIMEOUT_S", "90")
 
     config = resolve_config(
         config_file=config_file,
         owner="cli-owner",
         deerflow_url="http://cli.example",
+        max_payload="512KB",
     )
 
     assert config.agent == "from-file"
@@ -48,6 +57,9 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
     assert config.session == "env-session"
     assert config.deerflow_url == "http://cli.example"
     assert config.nats_context == "file-context"
+    assert config.deerflow_timeout_s == 20
+    assert config.query_timeout_s == 90
+    assert config.max_payload == "512KB"
 
 
 def test_nats_url_env_is_used(tmp_path: Path, monkeypatch: Any) -> None:

--- a/agents/deerflow/tests/test_doctor.py
+++ b/agents/deerflow/tests/test_doctor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig
@@ -20,6 +22,46 @@ def test_doctor_reports_deerflow_reachable_when_health_is_2xx() -> None:
 
     assert report.ok is True
     assert report.checks["deerflow_reachable"] is True
+
+
+def test_doctor_accepts_valid_current_nats_context(tmp_path: Any, monkeypatch: Any) -> None:
+    nats_home = tmp_path / "nats"
+    context_dir = nats_home / "context"
+    context_dir.mkdir(parents=True)
+    (nats_home / "context.txt").write_text("prod", encoding="utf-8")
+    (context_dir / "prod.json").write_text(
+        '{"url":"nats://127.0.0.1:4222"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NATS_CONFIG_HOME", str(nats_home))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json={"status": "healthy"})
+
+    report = run_doctor(
+        ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert report.ok is True
+    assert report.checks["nats_target_configured"] is False
+    assert report.checks["nats_target_valid"] is True
+
+
+def test_doctor_rejects_invalid_nats_url() -> None:
+    report = run_doctor(
+        ChannelConfig(
+            owner="rene",
+            nats_url="not a nats url",
+            deerflow_url="http://deerflow.test",
+        ),
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+
+    assert report.ok is False
+    assert report.checks["nats_target_valid"] is False
+    assert any(message.startswith("NATS_URL is invalid:") for message in report.messages)
 
 
 def test_doctor_reports_deerflow_unreachable_without_blocking_config_checks() -> None:

--- a/agents/deerflow/tests/test_doctor.py
+++ b/agents/deerflow/tests/test_doctor.py
@@ -12,7 +12,9 @@ def test_doctor_reports_deerflow_reachable_when_health_is_2xx() -> None:
         return httpx.Response(200, json={"status": "healthy"})
 
     report = run_doctor(
-        ChannelConfig(owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"),
+        ChannelConfig(
+            owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"
+        ),
         transport=httpx.MockTransport(handler),
     )
 
@@ -25,7 +27,9 @@ def test_doctor_reports_deerflow_unreachable_without_blocking_config_checks() ->
         return httpx.Response(503, text="starting")
 
     report = run_doctor(
-        ChannelConfig(owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"),
+        ChannelConfig(
+            owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"
+        ),
         transport=httpx.MockTransport(handler),
     )
 

--- a/agents/deerflow/tests/test_doctor.py
+++ b/agents/deerflow/tests/test_doctor.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import httpx
+
+from synadia_ai.nats_deerflow_channel.config import ChannelConfig
+from synadia_ai.nats_deerflow_channel.doctor import run_doctor
+
+
+def test_doctor_reports_deerflow_reachable_when_health_is_2xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json={"status": "healthy"})
+
+    report = run_doctor(
+        ChannelConfig(owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert report.ok is True
+    assert report.checks["deerflow_reachable"] is True
+
+
+def test_doctor_reports_deerflow_unreachable_without_blocking_config_checks() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="starting")
+
+    report = run_doctor(
+        ChannelConfig(owner="rene", nats_url="nats://127.0.0.1:4222", deerflow_url="http://deerflow.test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert report.ok is True
+    assert report.checks["deerflow_reachable"] is False
+    assert "DeerFlow Gateway is not reachable at http://deerflow.test/health" in report.messages

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from synadia_ai.nats_deerflow_channel.config import resolve_config
+from synadia_ai.nats_deerflow_channel.host import (
+    _nats_connect_options,
+    build_agent_service,
+    make_prompt_handler,
+)
+from synadia_ai.nats_deerflow_channel.runner import fake_deerflow_runner
+
+
+@pytest.mark.asyncio
+async def test_fake_runner_yields_deterministic_chunks() -> None:
+    chunks = [chunk async for chunk in fake_deerflow_runner("hello")]
+
+    assert chunks == ["DeerFlow fake runner received: ", "hello"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_handler_sends_runner_chunks() -> None:
+    sent: list[str] = []
+
+    async def runner(prompt: str) -> AsyncIterator[str]:
+        yield f"one:{prompt}"
+        yield "two"
+
+    class Stream:
+        async def send(self, chunk: str) -> None:
+            sent.append(chunk)
+
+    class Envelope:
+        prompt = "hello"
+
+    handler = make_prompt_handler(runner)
+    await handler(cast(Any, Envelope()), cast(Any, Stream()))
+
+    assert sent == ["one:hello", "two"]
+
+
+def test_connect_options_use_direct_url(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.delenv("NATS_CONTEXT", raising=False)
+    monkeypatch.setenv("NATS_URL", "nats://127.0.0.1:4222")
+    config = resolve_config(config_file=tmp_path / "missing.toml")
+
+    options = _nats_connect_options(config)
+
+    assert options == {"servers": "nats://127.0.0.1:4222"}
+
+
+def test_build_agent_service_requires_owner(tmp_path: Path) -> None:
+    config = resolve_config(config_file=tmp_path / "missing.toml")
+
+    with pytest.raises(ValueError, match="owner is required"):
+        build_agent_service(config, nc=object())  # type: ignore[arg-type]

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -14,7 +14,7 @@ from synadia_ai.nats_deerflow_channel.host import (
     make_deerflow_prompt_handler,
     make_prompt_handler,
 )
-from synadia_ai.nats_deerflow_channel.runner import fake_deerflow_runner
+from synadia_ai.nats_deerflow_channel.testing import fake_deerflow_runner
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from synadia_ai.agents import Attachment, Envelope, ProtocolError
 
-from synadia_ai.nats_deerflow_channel.config import resolve_config
+from synadia_ai.nats_deerflow_channel.config import ChannelConfig, resolve_config
 from synadia_ai.nats_deerflow_channel.host import (
     _nats_connect_options,
     build_agent_service,
+    make_deerflow_prompt_handler,
     make_prompt_handler,
 )
 from synadia_ai.nats_deerflow_channel.runner import fake_deerflow_runner
@@ -58,3 +60,28 @@ def test_build_agent_service_requires_owner(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="owner is required"):
         build_agent_service(config, nc=object())  # type: ignore[arg-type]
+
+
+def test_build_agent_service_passes_hardening_metadata() -> None:
+    config = ChannelConfig(owner="rene", max_payload="256KB")
+
+    service = build_agent_service(config, nc=object())  # type: ignore[arg-type]
+
+    assert service._attachments_ok is False
+    assert service._max_payload == "256KB"
+
+
+@pytest.mark.asyncio
+async def test_deerflow_handler_rejects_attachments_before_gateway() -> None:
+    class Stream:
+        async def send(self, chunk: str) -> None:
+            raise AssertionError("handler must reject before streaming")
+
+    handler = make_deerflow_prompt_handler(ChannelConfig(owner="rene"))
+    envelope = Envelope(
+        prompt="hi",
+        attachments=[Attachment(filename="x.txt", content="aGk=")],
+    )
+
+    with pytest.raises(ProtocolError, match="attachments are not supported"):
+        await handler(envelope, cast(Any, Stream()))

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -11,6 +11,7 @@ from synadia_ai.nats_deerflow_channel.runner import (
     DeerFlowGatewayClient,
     DeerFlowGatewayError,
     TextEvent,
+    ToolEvent,
     _extract_clarification_from_sse_event,
     _extract_text_from_sse_event,
     deerflow_gateway_runner,
@@ -308,6 +309,43 @@ async def test_gateway_stream_events_preserves_text_event_type() -> None:
         events = [event async for event in client.stream_events("hi")]
 
     assert events == [TextEvent(text="ok")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_stream_events_surfaces_tool_activity_as_status() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                "event: messages\n"
+                'data: [[{"type":"AIMessageChunk","content":"",'
+                '"tool_calls":[{"name":"web_search"}],'
+                '"response_metadata":{"model_name":"openai"}}],{}]\n\n'
+                "event: messages\n"
+                'data: [[{"type":"tool","name":"web_search",'
+                '"content":"{\\"query\\": \\"deerflow\\"}"}],{}]\n\n'
+                "event: messages\n"
+                'data: [[{"type":"AIMessageChunk","content":"answer"}],{}]\n\n'
+                "event: end\n"
+                "data: null\n\n"
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        events = [event async for event in client.stream_events("hi")]
+
+    assert events == [
+        ToolEvent(status="DeerFlow tool call: web_search"),
+        ToolEvent(status="DeerFlow tool result: web_search"),
+        TextEvent(text="answer"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -204,11 +204,45 @@ async def test_gateway_reachability_uses_health_endpoint() -> None:
 
 
 def test_extract_text_from_langgraph_sse_shapes() -> None:
-    assert _extract_text_from_sse_event("messages", [[{"content": "hello"}], {}]) == "hello"
+    assert (
+        _extract_text_from_sse_event("messages", [[{"type": "ai", "content": "hello"}], {}])
+        == "hello"
+    )
     assert _extract_text_from_sse_event("messages", [{"content": "hi"}, {}]) == "hi"
     updates_event = {"agent": {"messages": [{"content": "done"}]}}
     assert _extract_text_from_sse_event("updates", updates_event) == "done"
     assert _extract_text_from_sse_event("metadata", {"run_id": "r"}) is None
+
+
+def test_extract_text_ignores_non_assistant_langgraph_noise() -> None:
+    assert (
+        _extract_text_from_sse_event(
+            "messages",
+            [
+                {
+                    "type": "human",
+                    "content": "Give me a two sentence summary of what DeerFlow is.",
+                },
+                {"langgraph_node": "agent"},
+            ],
+        )
+        is None
+    )
+    assert (
+        _extract_text_from_sse_event(
+            "messages",
+            [
+                {
+                    "type": "AIMessageChunk",
+                    "content": "",
+                    "response_metadata": {"model_name": "openai", "finish_reason": "stop"},
+                    "usage_metadata": {"output_token_details": "tool_calls"},
+                },
+                {"message_class": "AIMessageChunk", "langgraph_node": "agent"},
+            ],
+        )
+        is None
+    )
 
 
 def test_extract_clarification_tool_message_from_deerflow_sse() -> None:

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -22,6 +22,9 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
     seen: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            seen["thread_body"] = request.read().decode()
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
         seen["method"] = request.method
         seen["path"] = request.url.path
         seen["json"] = request.read().decode()
@@ -46,6 +49,7 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
         chunks = [chunk async for chunk in client.stream_prompt("hi")]
 
     assert chunks == ["hello", " world"]
+    assert '"thread_id":"deerflow"' in seen["thread_body"].replace(" ", "")
     assert seen["method"] == "POST"
     assert seen["path"] == "/api/threads/deerflow/runs/stream"
     assert '"content":"hi"' in seen["json"].replace(" ", "")
@@ -59,6 +63,8 @@ async def test_gateway_runner_sends_deerflow_auth_headers() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         seen["csrf"] = request.headers.get("X-CSRF-Token")
         seen["cookie"] = request.headers.get("Cookie")
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
@@ -104,6 +110,9 @@ async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
             )
         seen["csrf"] = request.headers.get("X-CSRF-Token")
         seen["cookie"] = request.headers.get("Cookie")
+        if request.url.path == "/api/threads":
+            seen["thread_body"] = request.read().decode()
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
@@ -128,8 +137,10 @@ async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
     assert chunks == ["ok"]
     assert seen["paths"] == [
         "/api/v1/auth/login/local",
+        "/api/threads",
         "/api/threads/default/runs/stream",
     ]
+    assert '"thread_id":"default"' in seen["thread_body"].replace(" ", "")
     assert "username=rene%40example.com" in seen["login_body"]
     assert "password=secret" in seen["login_body"]
     assert seen["csrf"] == "csrf-from-login"
@@ -140,6 +151,8 @@ async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
 @pytest.mark.asyncio
 async def test_gateway_runner_raises_clear_error_for_non_2xx_stream() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
         return httpx.Response(503, text="not ready")
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
@@ -154,6 +167,8 @@ async def test_gateway_runner_raises_clear_error_for_non_2xx_stream() -> None:
 @pytest.mark.asyncio
 async def test_gateway_runner_sanitizes_non_2xx_detail() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
         return httpx.Response(500, text="first line\nsecond line" + ("x" * 600))
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
@@ -216,6 +231,8 @@ def test_extract_clarification_tool_message_from_deerflow_sse() -> None:
 @pytest.mark.asyncio
 async def test_gateway_stream_events_surfaces_clarification() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
@@ -241,6 +258,8 @@ async def test_gateway_stream_events_surfaces_clarification() -> None:
 @pytest.mark.asyncio
 async def test_gateway_stream_events_preserves_text_event_type() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
@@ -260,6 +279,8 @@ async def test_gateway_stream_events_preserves_text_event_type() -> None:
 @pytest.mark.asyncio
 async def test_deerflow_gateway_runner_builds_client_from_config() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -13,6 +13,7 @@ from synadia_ai.nats_deerflow_channel.runner import (
     TextEvent,
     ToolEvent,
     _extract_clarification_from_sse_event,
+    _extract_events_from_sse_event,
     _extract_text_from_sse_event,
     _extract_tool_status_from_sse_event,
     deerflow_gateway_runner,
@@ -151,6 +152,42 @@ async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
 
 
 @pytest.mark.asyncio
+async def test_gateway_client_reuses_owned_http_client_for_cookie_persistence() -> None:
+    client = DeerFlowGatewayClient(ChannelConfig(deerflow_url="http://deerflow.test"))
+    async with client._client() as first:
+        first.cookies.set("csrf_token", "csrf-one", domain="deerflow.test")
+    async with client._client() as second:
+        assert second is first
+        assert second.cookies.get("csrf_token") == "csrf-one"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_treats_existing_thread_conflict_as_success() -> None:
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/api/threads":
+            return httpx.Response(409, text="thread already exists")
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        chunks = [chunk async for chunk in client.stream_prompt("hi")]
+
+    assert chunks == ["ok"]
+    assert seen_paths == ["/api/threads", "/api/threads/deerflow/runs/stream"]
+
+
+@pytest.mark.asyncio
 async def test_gateway_runner_raises_clear_error_for_non_2xx_stream() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/threads":
@@ -268,6 +305,24 @@ def test_extract_text_ignores_non_assistant_langgraph_noise() -> None:
         )
         is None
     )
+
+
+def test_extract_events_keeps_two_real_messages_from_one_sse_event() -> None:
+    assert _extract_events_from_sse_event(
+        "messages",
+        [
+            {"type": "ai", "content": "first"},
+            {"type": "AIMessageChunk", "content": "second"},
+        ],
+    ) == [TextEvent(text="first"), TextEvent(text="second")]
+
+
+def test_state_message_payloads_has_depth_guard() -> None:
+    nested: dict[str, Any] = {"messages": [{"type": "ai", "content": "deep"}]}
+    for _ in range(80):
+        nested = {"nested": nested}
+
+    assert _extract_text_from_sse_event("updates", nested) is None
 
 
 def test_extract_clarification_tool_message_from_deerflow_sse() -> None:

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -9,6 +9,7 @@ from synadia_ai.nats_deerflow_channel.config import ChannelConfig
 from synadia_ai.nats_deerflow_channel.runner import (
     ClarificationEvent,
     DeerFlowGatewayClient,
+    DeerFlowGatewayError,
     TextEvent,
     _extract_clarification_from_sse_event,
     _extract_text_from_sse_event,
@@ -61,8 +62,27 @@ async def test_gateway_runner_raises_clear_error_for_non_2xx_stream() -> None:
             ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
             http_client=http,
         )
-        with pytest.raises(RuntimeError, match="DeerFlow Gateway stream failed: 503"):
+        with pytest.raises(DeerFlowGatewayError, match="DeerFlow Gateway stream failed: 503"):
             _ = [chunk async for chunk in client.stream_prompt("hi")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_sanitizes_non_2xx_detail() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="first line\nsecond line" + ("x" * 600))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        with pytest.raises(DeerFlowGatewayError) as err:
+            _ = [chunk async for chunk in client.stream_prompt("hi")]
+
+    message = str(err.value)
+    assert "first line | second line" in message
+    assert "\n" not in message
+    assert len(message) < 560
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -14,6 +14,7 @@ from synadia_ai.nats_deerflow_channel.runner import (
     ToolEvent,
     _extract_clarification_from_sse_event,
     _extract_text_from_sse_event,
+    _extract_tool_status_from_sse_event,
     deerflow_gateway_runner,
 )
 
@@ -209,8 +210,8 @@ def test_extract_text_from_langgraph_sse_shapes() -> None:
         _extract_text_from_sse_event("messages", [[{"type": "ai", "content": "hello"}], {}])
         == "hello"
     )
-    assert _extract_text_from_sse_event("messages", [{"content": "hi"}, {}]) == "hi"
-    updates_event = {"agent": {"messages": [{"content": "done"}]}}
+    assert _extract_text_from_sse_event("messages", [{"type": "ai", "content": "hi"}, {}]) == "hi"
+    updates_event = {"agent": {"messages": [{"type": "AIMessage", "content": "done"}]}}
     assert _extract_text_from_sse_event("updates", updates_event) == "done"
     assert _extract_text_from_sse_event("metadata", {"run_id": "r"}) is None
 
@@ -243,6 +244,27 @@ def test_extract_text_ignores_non_assistant_langgraph_noise() -> None:
                 },
                 {"message_class": "AIMessageChunk", "langgraph_node": "agent"},
             ],
+        )
+        is None
+    )
+    assert (
+        _extract_text_from_sse_event("messages", [{"debug": {"content": "internal"}}, {}]) is None
+    )
+    assert (
+        _extract_text_from_sse_event(
+            "values",
+            {
+                "messages": [{"type": "ai", "content": "visible"}],
+                "debug": {"type": "ai", "content": "internal"},
+                "response_metadata": {"model_name": "openai"},
+            },
+        )
+        == "visible"
+    )
+    assert (
+        _extract_clarification_from_sse_event(
+            "values",
+            {"metadata": {"name": "ask_clarification", "content": "hidden"}},
         )
         is None
     )
@@ -300,7 +322,10 @@ async def test_gateway_stream_events_preserves_text_event_type() -> None:
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
-            content='event: messages\ndata: [[{"content":"ok"}],{}]\n\nevent: end\ndata: null\n\n',
+            content=(
+                'event: messages\ndata: [[{"type":"AIMessageChunk","content":"ok"}],{}]\n\n'
+                "event: end\ndata: null\n\n"
+            ),
         )
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
@@ -311,6 +336,44 @@ async def test_gateway_stream_events_preserves_text_event_type() -> None:
         events = [event async for event in client.stream_events("hi")]
 
     assert events == [TextEvent(text="ok")]
+
+
+def test_extract_tool_status_handles_common_tool_call_shapes() -> None:
+    assert (
+        _extract_tool_status_from_sse_event(
+            "messages",
+            [
+                {
+                    "type": "AIMessageChunk",
+                    "content": "",
+                    "additional_kwargs": {"tool_calls": [{"function": {"name": "web_search"}}]},
+                },
+                {},
+            ],
+        )
+        == "DeerFlow tool call: web_search"
+    )
+    assert (
+        _extract_tool_status_from_sse_event(
+            "messages",
+            [
+                {
+                    "type": "AIMessageChunk",
+                    "content": "",
+                    "tool_calls": [{"function": {"name": "web search!?"}}],
+                },
+                {},
+            ],
+        )
+        == "DeerFlow tool call: web_search"
+    )
+    assert (
+        _extract_tool_status_from_sse_event(
+            "messages",
+            [{"type": "tool", "tool_call_id": "call_123", "content": "{}"}, {}],
+        )
+        == "DeerFlow tool result"
+    )
 
 
 @pytest.mark.asyncio
@@ -358,7 +421,10 @@ async def test_deerflow_gateway_runner_builds_client_from_config() -> None:
         return httpx.Response(
             200,
             headers={"content-type": "text/event-stream"},
-            content='event: messages\ndata: [[{"content":"ok"}],{}]\n\nevent: end\ndata: null\n\n',
+            content=(
+                'event: messages\ndata: [[{"type":"AIMessageChunk","content":"ok"}],{}]\n\n'
+                "event: end\ndata: null\n\n"
+            ),
         )
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -216,6 +216,8 @@ def test_extract_text_from_langgraph_sse_shapes() -> None:
 
 
 def test_extract_text_ignores_non_assistant_langgraph_noise() -> None:
+    assert _extract_text_from_sse_event("messages", ["branch:to:model", {}]) is None
+    assert _extract_text_from_sse_event("updates", {"agent": ["branch:to:model"]}) is None
     assert (
         _extract_text_from_sse_event(
             "messages",

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -29,12 +29,12 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
             200,
             headers={"content-type": "text/event-stream"},
             content=(
-                'event: messages\n'
+                "event: messages\n"
                 'data: [[{"type":"ai","content":"hello"}],{}]\n\n'
-                'event: messages\n'
+                "event: messages\n"
                 'data: [[{"type":"ai","content":" world"}],{}]\n\n'
-                'event: end\n'
-                'data: null\n\n'
+                "event: end\n"
+                "data: null\n\n"
             ),
         )
 
@@ -50,6 +50,91 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
     assert seen["path"] == "/api/threads/deerflow/runs/stream"
     assert '"content":"hi"' in seen["json"].replace(" ", "")
     assert '"stream_mode":["messages"]' in seen["json"].replace(" ", "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_sends_deerflow_auth_headers() -> None:
+    seen: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["csrf"] = request.headers.get("X-CSRF-Token")
+        seen["cookie"] = request.headers.get("Cookie")
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+        )
+
+    config = ChannelConfig(
+        deerflow_url="http://deerflow.local",
+        deerflow_cookie="access_token=session; csrf_token=csrf-123",
+        deerflow_csrf_token="csrf-123",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        chunks = [
+            chunk
+            async for chunk in deerflow_gateway_runner(
+                "question?",
+                config,
+                http_client=http,
+            )
+        ]
+        result = "".join(chunks)
+
+    assert result == "ok"
+    assert seen["csrf"] == "csrf-123"
+    assert seen["cookie"] == "access_token=session; csrf_token=csrf-123"
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
+    seen: dict[str, Any] = {"paths": []}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["paths"].append(request.url.path)
+        if request.url.path == "/api/v1/auth/login/local":
+            seen["login_body"] = request.read().decode()
+            return httpx.Response(
+                200,
+                headers=[
+                    ("set-cookie", "access_token=session-token; Path=/"),
+                    ("set-cookie", "csrf_token=csrf-from-login; Path=/"),
+                ],
+                json={"expires_in": 3600, "needs_setup": False},
+            )
+        seen["csrf"] = request.headers.get("X-CSRF-Token")
+        seen["cookie"] = request.headers.get("Cookie")
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+        )
+
+    config = ChannelConfig(
+        deerflow_url="http://deerflow.local",
+        deerflow_username="rene@example.com",
+        deerflow_password="secret",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        chunks = [
+            chunk
+            async for chunk in deerflow_gateway_runner(
+                "question?",
+                config,
+                http_client=http,
+            )
+        ]
+
+    assert chunks == ["ok"]
+    assert seen["paths"] == [
+        "/api/v1/auth/login/local",
+        "/api/threads/default/runs/stream",
+    ]
+    assert "username=rene%40example.com" in seen["login_body"]
+    assert "password=secret" in seen["login_body"]
+    assert seen["csrf"] == "csrf-from-login"
+    assert "access_token=session-token" in seen["cookie"]
+    assert "csrf_token=csrf-from-login" in seen["cookie"]
 
 
 @pytest.mark.asyncio
@@ -123,8 +208,7 @@ def test_extract_clarification_tool_message_from_deerflow_sse() -> None:
     }
 
     assert (
-        _extract_clarification_from_sse_event("updates", event)
-        == "❓ Which dataset should I use?"
+        _extract_clarification_from_sse_event("updates", event) == "❓ Which dataset should I use?"
     )
     assert _extract_text_from_sse_event("updates", event) is None
 
@@ -136,11 +220,11 @@ async def test_gateway_stream_events_surfaces_clarification() -> None:
             200,
             headers={"content-type": "text/event-stream"},
             content=(
-                'event: updates\n'
+                "event: updates\n"
                 'data: {"messages":[{"type":"tool",'
                 '"name":"ask_clarification","content":"Need input?"}]}\n\n'
-                'event: end\n'
-                'data: null\n\n'
+                "event: end\n"
+                "data: null\n\n"
             ),
         )
 

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -7,7 +7,10 @@ import pytest
 
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig
 from synadia_ai.nats_deerflow_channel.runner import (
+    ClarificationEvent,
     DeerFlowGatewayClient,
+    TextEvent,
+    _extract_clarification_from_sse_event,
     _extract_text_from_sse_event,
     deerflow_gateway_runner,
 )
@@ -86,6 +89,68 @@ def test_extract_text_from_langgraph_sse_shapes() -> None:
     updates_event = {"agent": {"messages": [{"content": "done"}]}}
     assert _extract_text_from_sse_event("updates", updates_event) == "done"
     assert _extract_text_from_sse_event("metadata", {"run_id": "r"}) is None
+
+
+def test_extract_clarification_tool_message_from_deerflow_sse() -> None:
+    event = {
+        "messages": [
+            {
+                "type": "tool",
+                "name": "ask_clarification",
+                "content": "❓ Which dataset should I use?",
+            }
+        ]
+    }
+
+    assert (
+        _extract_clarification_from_sse_event("updates", event)
+        == "❓ Which dataset should I use?"
+    )
+    assert _extract_text_from_sse_event("updates", event) is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_stream_events_surfaces_clarification() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                'event: updates\n'
+                'data: {"messages":[{"type":"tool",'
+                '"name":"ask_clarification","content":"Need input?"}]}\n\n'
+                'event: end\n'
+                'data: null\n\n'
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        events = [event async for event in client.stream_events("hi")]
+
+    assert events == [ClarificationEvent(prompt="Need input?")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_stream_events_preserves_text_event_type() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"content":"ok"}],{}]\n\nevent: end\ndata: null\n\n',
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        events = [event async for event in client.stream_events("hi")]
+
+    assert events == [TextEvent(text="ok")]
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from synadia_ai.nats_deerflow_channel.config import ChannelConfig
+from synadia_ai.nats_deerflow_channel.runner import (
+    DeerFlowGatewayClient,
+    _extract_text_from_sse_event,
+    deerflow_gateway_runner,
+)
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["json"] = request.read().decode()
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                'event: messages\n'
+                'data: [[{"type":"ai","content":"hello"}],{}]\n\n'
+                'event: messages\n'
+                'data: [[{"type":"ai","content":" world"}],{}]\n\n'
+                'event: end\n'
+                'data: null\n\n'
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        chunks = [chunk async for chunk in client.stream_prompt("hi")]
+
+    assert chunks == ["hello", " world"]
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/api/threads/deerflow/runs/stream"
+    assert '"content":"hi"' in seen["json"].replace(" ", "")
+    assert '"stream_mode":["messages"]' in seen["json"].replace(" ", "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_raises_clear_error_for_non_2xx_stream() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="not ready")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        with pytest.raises(RuntimeError, match="DeerFlow Gateway stream failed: 503"):
+            _ = [chunk async for chunk in client.stream_prompt("hi")]
+
+
+@pytest.mark.asyncio
+async def test_gateway_reachability_uses_health_endpoint() -> None:
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        return httpx.Response(200, json={"status": "healthy"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        assert await client.check_reachable() is True
+
+    assert seen_paths == ["/health"]
+
+
+def test_extract_text_from_langgraph_sse_shapes() -> None:
+    assert _extract_text_from_sse_event("messages", [[{"content": "hello"}], {}]) == "hello"
+    assert _extract_text_from_sse_event("messages", [{"content": "hi"}, {}]) == "hi"
+    updates_event = {"agent": {"messages": [{"content": "done"}]}}
+    assert _extract_text_from_sse_event("updates", updates_event) == "done"
+    assert _extract_text_from_sse_event("metadata", {"run_id": "r"}) is None
+
+
+@pytest.mark.asyncio
+async def test_deerflow_gateway_runner_builds_client_from_config() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"content":"ok"}],{}]\n\nevent: end\ndata: null\n\n',
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        chunks = [
+            chunk
+            async for chunk in deerflow_gateway_runner(
+                "hi",
+                ChannelConfig(owner="rene", deerflow_url="http://deerflow.test"),
+                http_client=http,
+            )
+        ]
+
+    assert chunks == ["ok"]

--- a/agents/deerflow/uv.lock
+++ b/agents/deerflow/uv.lock
@@ -1,0 +1,600 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
+    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "synadia-ai-agent-service"
+version = "0.4.1"
+source = { editable = "../../agent-sdk/python" }
+dependencies = [
+    { name = "nats-py" },
+    { name = "pydantic" },
+    { name = "synadia-ai-agents" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "nats-py", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.5" },
+    { name = "synadia-ai-agents", editable = "../../client-sdk/python" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = ">=0.5" },
+]
+
+[[package]]
+name = "synadia-ai-agents"
+version = "0.7.1"
+source = { editable = "../../client-sdk/python" }
+dependencies = [
+    { name = "nats-py" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "nats-py", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.5" },
+    { name = "rich", marker = "extra == 'examples'", specifier = ">=13" },
+]
+provides-extras = ["examples"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "rich", specifier = ">=13" },
+    { name = "ruff", specifier = ">=0.5" },
+]
+
+[[package]]
+name = "synadia-ai-nats-deerflow-channel"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "nats-py" },
+    { name = "pydantic" },
+    { name = "synadia-ai-agent-service" },
+    { name = "synadia-ai-agents" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "nats-py", specifier = ">=2.7" },
+    { name = "pydantic", specifier = ">=2.5" },
+    { name = "synadia-ai-agent-service", editable = "../../agent-sdk/python" },
+    { name = "synadia-ai-agents", editable = "../../client-sdk/python" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = ">=0.5" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Summary

Adds an external DeerFlow channel for the Synadia Agent Protocol, packaged as `synadia-ai-nats-deerflow-channel` with the `deerflow-nats-channel` CLI.

- Registers a NATS agent service on `agents.{verb}.{token}.{owner}.{session}` and bridges prompt streams to DeerFlow Gateway.
- Adds config loading from CLI flags, environment variables, and TOML config files, plus a `doctor` command for operator diagnostics.
- Supports DeerFlow Gateway authentication/CSRF with automatic local login via username/password, while keeping manual cookie/CSRF config as a debug fallback.
- Creates DeerFlow Gateway threads before streaming so `/runs/stream` does not fail on missing sessions.
- Maps DeerFlow `ask_clarification` tool messages into protocol `query` chunks.
- Parses DeerFlow/LangGraph SSE streams path-aware so assistant text, tool activity, and internal metadata do not get mixed together.
- Adds user-facing install/configuration docs and a tag-triggered PyPI release workflow for the package.

## Stream mapping notes

The adapter intentionally does not recursively mine arbitrary strings from DeerFlow/LangGraph SSE payloads. It now:

- emits `response` only from explicit assistant/AI message content;
- emits DeerFlow tool calls/results as `status` chunks;
- emits `ask_clarification` as protocol `query` chunks;
- ignores provider/routing/metadata artifacts such as `openai`, `tool_calls`, `AIMessageChunk`, `stop`, and `branch:to:model`.

## Local verification

Run from `agents/deerflow`:

```bash
uv run pytest -q
uv run ruff check .
uv run ruff format --check .
uv run mypy src tests
uv build
```

Result:

```text
28 passed
ruff clean
format clean
mypy clean
sdist/wheel built successfully
```

Also smoke-tested against a local NATS server + DeerFlow Gateway on the M3 Max using:

```bash
nats req agents.prompt.df.rene.deerflow \
  "Give me a two sentence summary of what DeerFlow is." \
  --wait-for-empty \
  --reply-timeout 30s \
  --timeout 240s
```

Observed protocol behavior:

- leading `status` ack;
- streamed `response` chunks with DeerFlow answer text;
- zero-byte terminator at stream end;
- no LangGraph/provider metadata leaked as response text.

## Notes for reviewers

This PR treats DeerFlow as an HTTP Gateway dependency and does not modify/fork DeerFlow itself. The NATS bridge lives entirely under `agents/deerflow/`, with one small Python agent-service completion-error fix used by the new host tests.
