### PR TITLE
feat: add DeerFlow attachment uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [OpenClaw](agents/openclaw/) | `oc` | `@synadia-ai/nats-channel` |
 | [PI Agent](agents/pi/) | `pi` | `@synadia-ai/nats-pi-channel` |
 | [Hermes](agents/hermes/) | `hermes` | upstream fork — see [`agents/hermes/`](agents/hermes/) (work in progress) |
+| [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway |
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 
@@ -149,6 +150,7 @@ synadia-agents/
 │   ├── openclaw/
 │   ├── pi/
 │   ├── hermes/
+│   ├── deerflow/
 │   └── open-agent/              ← inbound bridge for vercel-labs/open-agents
 └── examples/              ← apps built with the SDKs (callers and agents)
     ├── agent-web-ui/             ← Vue 3 + Bun browser client

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [OpenClaw](agents/openclaw/) | `oc` | `@synadia-ai/nats-channel` |
 | [PI Agent](agents/pi/) | `pi` | `@synadia-ai/nats-pi-channel` |
 | [Hermes](agents/hermes/) | `hermes` | upstream fork — see [`agents/hermes/`](agents/hermes/) (work in progress) |
-| [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway |
+| [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway; package pending first release |
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,7 +15,7 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 | `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | server-negotiated | true |
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 | `open-agent/`       | `open-agent` | [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) | `agents.prompt.open-agent.<owner>.<session>` | server-negotiated | false |
-| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated | false |
+| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated | true |
 
 `max_payload` is read from the NATS connection's `INFO` block at startup and advertised verbatim, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and the agents track it.
 
@@ -32,9 +32,9 @@ Every agent registers a NATS micro service called `agents` with an endpoint name
 - **`claude-code/`** - ships as a Claude Code plugin (`/plugin install`). Two permission modes: `terminal` (prompt locally) or `query` (relay as a `query` chunk over NATS). Attachments stage at `~/.claude/channels/nats/attachments/<request_id>/`, cleaned on reply completion.
 - **`open-agent/`** - inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents). Vendors `packages/agent` verbatim and ships a `LocalSandbox` so the harness runs without a Vercel account; first agent in the repo built directly on `AgentService` from `@synadia-ai/agent-service`. The companion [`../examples/open-agent-vercel/`](../examples/open-agent-vercel/) swaps in `@vercel/sandbox` to prove the sandbox seam is interchangeable. v1 is single-process / single-session (one bridge handles one `(owner, session)` pair).
 - **`hermes/`** - full Hermes Agent (CLI + TUI + messaging gateway). Unlike the others, each gateway registers **one** identity and multiplexes conversations via the envelope's optional `session` field (§5.1); subject stays stable per instance. Images route through Hermes's `vision_analyze` tool so the model actually sees them. Currently installed from [`synadia-ai/hermes-agent`, branch `nats-gateway`](https://github.com/synadia-ai/hermes-agent/tree/nats-gateway) - upstream PR pending.
-- **`deerflow/`** - external Python wrapper around a running DeerFlow Gateway. Built on `synadia-ai-agent-service`, advertises `attachments_ok=false`, streams Gateway SSE responses as protocol chunks, and bridges DeerFlow clarification requests to protocol `query` chunks.
+- **`deerflow/`** - external Python wrapper around a running DeerFlow Gateway. Built on `synadia-ai-agent-service`, uploads protocol attachments to DeerFlow's thread uploads API, includes the returned upload metadata in `additional_kwargs.files` for the Gateway run, streams Gateway SSE responses as protocol chunks, and bridges DeerFlow clarification requests to protocol `query` chunks.
 
-When an agent accepts attachments, it decodes them to disk and prepends the absolute paths to the prompt text like so:
+Most agents that accept attachments decode them to disk and prepend the absolute paths to the prompt text like so. DeerFlow is the exception: it uploads attachments to the Gateway and sends the returned upload metadata as `additional_kwargs.files`.
 
 ```
 [Attachments available at the following absolute paths]
@@ -57,7 +57,7 @@ When an agent accepts attachments, it decodes them to disk and prepends the abso
 2. Expose an endpoint named `prompt` that advertises `max_payload` and `attachments_ok`. The subject is your choice; the agents in this repo serve it at `agents.prompt.<type-token>.<owner>.<session>` (v0.3 verb-first).
 3. Publish heartbeats on `agents.hb.<type-token>.<owner>.<session>` (verb `hb`, §8.1 v0.3).
 3b. Optionally expose a `status` endpoint on `agents.status.<type-token>.<owner>.<session>` that returns the same payload shape as a heartbeat — useful for callers that want one-shot liveness without subscribing.
-4. Accept plain-text OR JSON envelopes. Decode inline attachments to a per-session staging dir and prepend their absolute paths to the prompt.
+4. Accept plain-text OR JSON envelopes. For inline attachments, either decode to a per-session staging dir and prepend paths to the prompt, or map them to the target harness's native upload/file API when one exists.
 5. Stream typed chunks on the reply subject: `status` (ack / keep-alive), `response` (content deltas), `query` (mid-stream questions, when supported).
 6. Terminate with an empty body and no headers.
 7. Reject malformed envelopes, oversized payloads, invalid base64, and unsafe filenames with `Nats-Service-Error-Code: 400`. Internal failures return `500`.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-Plugins that wrap existing AI harnesses - PI, OpenClaw, Claude Code, Hermes - as NATS micro services speaking the **Synadia Agent Protocol for NATS**, so any SDK in `../client-sdk/` can drive them the same way.
+Plugins that wrap existing AI harnesses — PI, OpenClaw, Claude Code, Hermes, DeerFlow, and open-agent — as NATS micro services speaking the **Synadia Agent Protocol for NATS**, so any SDK in `../client-sdk/` can drive them the same way.
 
 The plugins are built on the SDK pair: caller-side primitives from [`../client-sdk/`](../client-sdk/) for subjects, envelope types, and the error hierarchy; server-side helpers from [`../agent-sdk/`](../agent-sdk/) (`encodeChunk`, `splitResponseText`, the heartbeat-payload encoders, and — when the harness fits — `AgentService`) for putting an agent on the wire. The OpenClaw, PI, and Claude Code harnesses currently call the encoders directly; the controller agents in [`../examples/pi-headless/`](../examples/pi-headless/) and [`../examples/claude-code-headless/`](../examples/claude-code-headless/) are obvious migration candidates for `AgentService` once their custom `spawn` / `stop` / `list` endpoints land on `extraEndpoints`.
 
@@ -15,9 +15,9 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 | `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | server-negotiated | true |
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 | `open-agent/`       | `open-agent` | [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) | `agents.prompt.open-agent.<owner>.<session>` | server-negotiated | false |
-| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated | true |
+| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | configured cap, clamped to server limit | true |
 
-`max_payload` is read from the NATS connection's `INFO` block at startup and advertised verbatim, formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and the agents track it.
+Most agents read `max_payload` from the NATS connection's `INFO` block at startup and advertise that server limit formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and server-negotiated agents track it. Agents with their own configured cap, such as DeerFlow, advertise the configured cap unless the NATS server is smaller, in which case they clamp down to the server limit.
 
 Every agent also publishes heartbeats on `agents.hb.<type-token>.<owner>.<session>` every 30 s and answers `agents.status.<type-token>.<owner>.<session>` requests with the same payload (§8.7 (v0.3)).
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,9 +15,9 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 | `claude-code/`      | `cc`       | [Claude Code](https://claude.com/claude-code) | `agents.prompt.cc.<owner>.<name>`                          | server-negotiated | true |
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 | `open-agent/`       | `open-agent` | [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) | `agents.prompt.open-agent.<owner>.<session>` | server-negotiated | false |
-| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | configured cap, clamped to server limit | true |
+| `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated by default; optional smaller configured cap | true |
 
-Most agents read `max_payload` from the NATS connection's `INFO` block at startup and advertise that server limit formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and server-negotiated agents track it. Agents with their own configured cap, such as DeerFlow, advertise the configured cap unless the NATS server is smaller, in which case they clamp down to the server limit.
+Most agents read `max_payload` from the NATS connection's `INFO` block at startup and advertise that server limit formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and server-negotiated agents track it. Agents with their own configured cap, such as Hermes or DeerFlow when `max_payload` is explicitly set, advertise that configured cap unless the NATS server is smaller, in which case they clamp down to the server limit.
 
 Every agent also publishes heartbeats on `agents.hb.<type-token>.<owner>.<session>` every 30 s and answers `agents.status.<type-token>.<owner>.<session>` requests with the same payload (§8.7 (v0.3)).
 

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -151,7 +151,7 @@ TOML
 | `nats_url` | no | — | Raw NATS server URL. Useful for local development. If unset, `nats_context` or the current NATS CLI context is used. |
 | `deerflow_timeout_s` | no | `60` | HTTP connect/read timeout for DeerFlow Gateway health and stream calls. |
 | `query_timeout_s` | no | `300` | Seconds to wait for a caller reply to a DeerFlow clarification query before failing the stream. |
-| `max_payload` | no | `1MB` | Prompt endpoint `max_payload` metadata. The host rejects larger payloads with a protocol error and clamps to the NATS server limit when needed. |
+| `max_payload` | no | NATS server limit | Optional smaller prompt endpoint `max_payload` cap. By default the host advertises the connected NATS server limit; if configured, the value is honored unless the server limit is smaller. |
 
 ### Environment variables
 
@@ -276,7 +276,7 @@ asyncio.run(main())
 
 - The wrapper uses `AgentService` from `synadia-ai-agent-service`.
 - `attachments_ok` is advertised as `true`. The wrapper accepts protocol inline attachments, validates basename-only filenames, uploads them to `POST /api/threads/{session}/uploads`, and includes the returned DeerFlow sandbox virtual paths in `additional_kwargs.files` on the Gateway run request.
-- `max_payload` defaults to `1MB`; the protocol host advertises it, clamps it to the connected NATS server limit when needed, and rejects oversized prompt envelopes before the DeerFlow handler runs.
+- `max_payload` follows the connected NATS server limit by default; operators may configure a smaller cap to reject expensive prompts earlier. The protocol host clamps configured values down if the NATS server is smaller and rejects oversized prompt envelopes before the DeerFlow handler runs.
 - DeerFlow HTTP calls use `deerflow_timeout_s` (default `60`). Clarification replies use `query_timeout_s` (default `300`) and fail the stream if the caller does not answer in time.
 - When `deerflow_username` and `deerflow_password` are configured, the wrapper logs into DeerFlow via `/api/v1/auth/login/local`, stores the returned `access_token`/`csrf_token` cookies, and sends `X-CSRF-Token` automatically on Gateway stream POSTs. Manual `deerflow_cookie`/`deerflow_csrf_token` exists only as a debug fallback.
 - Before each prompt, the wrapper idempotently ensures the configured DeerFlow thread exists via `POST /api/threads`, so operators do not need to pre-create the session in the Web UI.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -271,13 +271,13 @@ asyncio.run(main())
 ## Runtime behavior
 
 - The wrapper uses `AgentService` from `synadia-ai-agent-service`.
-- `attachments_ok` is advertised as `false`; DeerFlow Gateway prompts are text-only in this MVP. The host also rejects attachment-bearing prompt envelopes and clarification replies server-side, so non-validating callers get a protocol error instead of forwarding binary data into DeerFlow.
+- `attachments_ok` is advertised as `true`. The wrapper accepts protocol inline attachments, validates basename-only filenames, uploads them to `POST /api/threads/{session}/uploads`, and includes the returned DeerFlow sandbox virtual paths in `additional_kwargs.files` on the Gateway run request.
 - `max_payload` defaults to `1MB`; the protocol host advertises it, clamps it to the connected NATS server limit when needed, and rejects oversized prompt envelopes before the DeerFlow handler runs.
 - DeerFlow HTTP calls use `deerflow_timeout_s` (default `60`). Clarification replies use `query_timeout_s` (default `300`) and fail the stream if the caller does not answer in time.
 - When `deerflow_username` and `deerflow_password` are configured, the wrapper logs into DeerFlow via `/api/v1/auth/login/local`, stores the returned `access_token`/`csrf_token` cookies, and sends `X-CSRF-Token` automatically on Gateway stream POSTs. Manual `deerflow_cookie`/`deerflow_csrf_token` exists only as a debug fallback.
 - Before each prompt, the wrapper idempotently ensures the configured DeerFlow thread exists via `POST /api/threads`, so operators do not need to pre-create the session in the Web UI.
 - DeerFlow SSE `messages`/`updates` events are normalized into protocol response chunks.
-- DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer is sent back to the same DeerFlow thread as the next user message.
+- DeerFlow `ask_clarification` tool messages are bridged to Synadia Agent Protocol `query` chunks. The caller's answer, including any safe attachments, is sent back to the same DeerFlow thread as the next user message.
 - A single wrapper instance serves one `(agent, owner, session)` identity. Run multiple processes for multiple exposed DeerFlow sessions.
 
 ## Troubleshooting
@@ -288,6 +288,8 @@ asyncio.run(main())
 - **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.
 - **`403: CSRF token missing. Include X-CSRF-Token header.`** — configure `DEERFLOW_USERNAME` and `DEERFLOW_PASSWORD` so the wrapper can log into DeerFlow and send CSRF headers automatically. If you are debugging manually, provide both `DEERFLOW_COOKIE='access_token=...; csrf_token=...'` and `DEERFLOW_CSRF_TOKEN=...`.
 - **`404: Thread ... not found`** — upgrade/reinstall the wrapper. Current versions create the configured DeerFlow thread automatically before streaming; older editable installs required the thread to already exist.
+- **`unsafe attachment filename`** — attachment filenames must be plain basenames: no `/`, `\`, NUL bytes, empty names, `.`/`..`, or names longer than 255 UTF-8 bytes. The wrapper rejects unsafe names before calling DeerFlow.
+- **`DeerFlow Gateway upload failed`** — NATS routing and envelope decoding worked; inspect DeerFlow Gateway auth/CSRF, upload limits, and `/api/threads/{session}/uploads` logs next.
 - **NATS CLI receives only an ack or exits early** — include both `--wait-for-empty` and a generous `--reply-timeout`, e.g. `30s`.
 - **No discovery responses** — confirm the wrapper is still running, check `NATS_CONTEXT`/`NATS_URL`, then query `$SRV.INFO.agents` on the same NATS account the wrapper uses.
 - **Prompt hangs during a clarification** — DeerFlow asked for human input and the caller must support protocol `query` chunks. Use an SDK caller that handles `query`, or avoid DeerFlow flows that require clarification.
@@ -295,7 +297,7 @@ asyncio.run(main())
 
 ## Limitations
 
-- Text prompts only; inline attachments are not accepted by the DeerFlow wrapper yet.
+- Attachments are uploaded to DeerFlow's thread uploads area and referenced in prompt text. The Synadia wrapper does not invent a DeerFlow-native multimodal API; it uses DeerFlow's existing file-upload surface.
 - The wrapper fronts DeerFlow Gateway HTTP/SSE. It does not embed DeerFlow Harness directly.
 - `configure` is intentionally minimal in this phase: it prints the target config path instead of running an interactive wizard.
 - No generic NATS tools are exposed to DeerFlow. This is inbound protocol hosting, not a NATS toolbox.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -8,7 +8,11 @@ This package is deliberately narrow: it is a **Synadia Agent Protocol channel wr
 
 ## Install
 
-### From a package index
+### Package index install
+
+The package is intended to publish as `synadia-ai-nats-deerflow-channel`. Until the first release is published, install it from this monorepo using the editable flow below.
+
+After publication, the package-index flow will be:
 
 ```bash
 pip install synadia-ai-nats-deerflow-channel
@@ -50,7 +54,7 @@ deerflow-nats-channel doctor --owner acme --session research --nats-url nats://1
 ## Prerequisites
 
 - A reachable NATS server, or a NATS CLI context created with `nats context add`.
-- A running DeerFlow Gateway. The wrapper expects the Gateway HTTP API, including `/health` and `/api/threads/{session}/runs/stream`.
+- A running DeerFlow Gateway. The wrapper expects the Gateway HTTP API, including `/health`, `/api/threads/{session}/uploads`, and `/api/threads/{session}/runs/stream`.
 - Python 3.11+.
 
 ## Quickstart: env-first
@@ -297,7 +301,7 @@ asyncio.run(main())
 
 ## Limitations
 
-- Attachments are uploaded to DeerFlow's thread uploads area and referenced in prompt text. The Synadia wrapper does not invent a DeerFlow-native multimodal API; it uses DeerFlow's existing file-upload surface.
+- Attachments are uploaded to DeerFlow's thread uploads area and referenced in the Gateway run payload via `additional_kwargs.files`. The Synadia wrapper does not invent a DeerFlow-native multimodal API; it uses DeerFlow's existing file-upload surface.
 - The wrapper fronts DeerFlow Gateway HTTP/SSE. It does not embed DeerFlow Harness directly.
 - `configure` is intentionally minimal in this phase: it prints the target config path instead of running an interactive wizard.
 - No generic NATS tools are exposed to DeerFlow. This is inbound protocol hosting, not a NATS toolbox.

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/cli.py
@@ -42,7 +42,7 @@ def _add_config_flags(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--max-payload",
-        help="Advertised prompt max_payload metadata; default: 1MB, clamped by NATS server",
+        help="Advertised prompt max_payload metadata; default follows NATS server max_payload",
     )
     parser.add_argument(
         "--deerflow-cookie",

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
@@ -13,7 +13,7 @@ DEFAULT_SESSION = "default"
 DEFAULT_DEERFLOW_URL = "http://localhost:2026"
 DEFAULT_DEERFLOW_TIMEOUT_S = 60.0
 DEFAULT_QUERY_TIMEOUT_S = 300.0
-DEFAULT_MAX_PAYLOAD = "1MB"
+DEFAULT_MAX_PAYLOAD = None
 DEFAULT_CONFIG_PATH = Path("~/.config/synadia/deerflow-channel/config.toml")
 
 
@@ -33,7 +33,7 @@ class ChannelConfig:
     nats_url: str | None = None
     deerflow_timeout_s: float = DEFAULT_DEERFLOW_TIMEOUT_S
     query_timeout_s: float = DEFAULT_QUERY_TIMEOUT_S
-    max_payload: str = DEFAULT_MAX_PAYLOAD
+    max_payload: str | None = DEFAULT_MAX_PAYLOAD
     deerflow_cookie: str | None = None
     deerflow_csrf_token: str | None = None
     deerflow_username: str | None = None

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from typing import Any, cast
@@ -11,6 +12,7 @@ import nats
 from nats.aio.client import Client as NATSClient
 from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
 from synadia_ai.agents import (
+    Attachment,
     Envelope,
     ProtocolError,
     QueryTimeout,
@@ -23,6 +25,8 @@ from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent, ToolEv
 
 PromptRunner = Callable[[str], AsyncIterator[str]]
 MAX_CLARIFICATION_ROUNDS = 8
+MAX_ATTACHMENT_FILENAME_BYTES = 255
+_SAFE_ATTACHMENT_BASENAME = re.compile(r"^[^/\\\x00]+$")
 
 
 def _nats_connect_options(config: ChannelConfig) -> dict[str, object]:
@@ -48,7 +52,7 @@ def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
         session_name=config.session,
         nc=nc,
         description="DeerFlow channel wrapper for the Synadia Agent Protocol",
-        attachments_ok=False,
+        attachments_ok=True,
         max_payload=config.max_payload,
     )
     service.on_prompt(make_deerflow_prompt_handler(config))
@@ -65,40 +69,66 @@ def make_deerflow_prompt_handler(config: ChannelConfig) -> PromptHandler:
     """
 
     async def _handler(envelope: Envelope, stream: PromptStream) -> None:
-        if envelope.attachments:
-            raise ProtocolError("attachments are not supported by the DeerFlow wrapper")
+        _validate_attachment_filenames(envelope)
         client = DeerFlowGatewayClient(config, timeout=config.deerflow_timeout_s)
         try:
             prompt = envelope.prompt
+            attachments = envelope.attachments
             for _ in range(MAX_CLARIFICATION_ROUNDS):
-                needs_followup = False
-                async for event in client.stream_events(prompt):
-                    if isinstance(event, TextEvent):
-                        await stream.send(event.text)
-                        continue
-                    if isinstance(event, ToolEvent):
-                        await stream.send(StatusChunk(status=event.status))
-                        continue
-                    if isinstance(event, ClarificationEvent):
-                        try:
-                            reply = await stream.ask(event.prompt, timeout=config.query_timeout_s)
-                        except QueryTimeout as exc:
-                            raise TimeoutError(
-                                f"caller did not answer DeerFlow clarification within "
-                                f"{config.query_timeout_s:g}s"
-                            ) from exc
-                        if reply.attachments:
-                            raise ProtocolError("attachments are not supported in query replies")
-                        prompt = reply.prompt
-                        needs_followup = True
-                        break
-                if not needs_followup:
+                reply = await _run_one_deerflow_turn(
+                    client,
+                    stream,
+                    prompt,
+                    attachments=attachments,
+                    query_timeout_s=config.query_timeout_s,
+                )
+                if reply is None:
                     return
+                _validate_attachment_filenames(reply)
+                prompt = reply.prompt
+                attachments = reply.attachments
             raise RuntimeError("too many DeerFlow clarification rounds")
         finally:
             await client.aclose()
 
     return _handler
+
+
+async def _run_one_deerflow_turn(
+    client: DeerFlowGatewayClient,
+    stream: PromptStream,
+    prompt: str,
+    *,
+    attachments: list[Attachment] | None,
+    query_timeout_s: float,
+) -> Envelope | None:
+    async for event in client.stream_events(prompt, attachments=attachments):
+        if isinstance(event, TextEvent):
+            await stream.send(event.text)
+            continue
+        if isinstance(event, ToolEvent):
+            await stream.send(StatusChunk(status=event.status))
+            continue
+        if isinstance(event, ClarificationEvent):
+            try:
+                return await stream.ask(event.prompt, timeout=query_timeout_s)
+            except QueryTimeout as exc:
+                raise TimeoutError(
+                    f"caller did not answer DeerFlow clarification within {query_timeout_s:g}s"
+                ) from exc
+    return None
+
+
+def _validate_attachment_filenames(envelope: Envelope) -> None:
+    for attachment in envelope.attachments or []:
+        filename = attachment.filename
+        if (
+            not filename
+            or filename in {".", ".."}
+            or not _SAFE_ATTACHMENT_BASENAME.match(filename)
+            or len(filename.encode("utf-8")) > MAX_ATTACHMENT_FILENAME_BYTES
+        ):
+            raise ProtocolError(f"unsafe attachment filename: {filename!r}")
 
 
 def make_prompt_handler(runner: PromptRunner) -> PromptHandler:

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 import nats
 from nats.aio.client import Client as NATSClient
-from synadia_ai.agent_service import AgentService, PromptHandler, PromptStream
+from synadia_ai.agent_service import DEFAULT_MAX_PAYLOAD, AgentService, PromptHandler, PromptStream
 from synadia_ai.agents import (
     Attachment,
     Envelope,
@@ -27,6 +27,22 @@ PromptRunner = Callable[[str], AsyncIterator[str]]
 MAX_CLARIFICATION_ROUNDS = 8
 MAX_ATTACHMENT_FILENAME_BYTES = 255
 _SAFE_ATTACHMENT_BASENAME = re.compile(r"^[^/\\\x00]+$")
+
+
+def _format_human_bytes(byte_count: int) -> str:
+    for suffix, factor in (("GB", 1024**3), ("MB", 1024**2), ("KB", 1024)):
+        if byte_count >= factor and byte_count % factor == 0:
+            return f"{byte_count // factor}{suffix}"
+    return f"{byte_count}B"
+
+
+def _advertised_max_payload(config: ChannelConfig, nc: NATSClient) -> str:
+    if config.max_payload is not None:
+        return config.max_payload
+    server_bytes = getattr(nc, "max_payload", 0) or 0
+    if server_bytes > 0:
+        return _format_human_bytes(server_bytes)
+    return DEFAULT_MAX_PAYLOAD
 
 
 def _nats_connect_options(config: ChannelConfig) -> dict[str, object]:
@@ -53,7 +69,7 @@ def build_agent_service(config: ChannelConfig, nc: NATSClient) -> AgentService:
         nc=nc,
         description="DeerFlow channel wrapper for the Synadia Agent Protocol",
         attachments_ok=True,
-        max_payload=config.max_payload,
+        max_payload=_advertised_max_payload(config, nc),
     )
     service.on_prompt(make_deerflow_prompt_handler(config))
     return service

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/host.py
@@ -26,13 +26,16 @@ from .runner import ClarificationEvent, DeerFlowGatewayClient, TextEvent, ToolEv
 PromptRunner = Callable[[str], AsyncIterator[str]]
 MAX_CLARIFICATION_ROUNDS = 8
 MAX_ATTACHMENT_FILENAME_BYTES = 255
-_SAFE_ATTACHMENT_BASENAME = re.compile(r"^[^/\\\x00]+$")
+KIB = 1024
+_SAFE_ATTACHMENT_BASENAME = re.compile(r"^[^/\\\x00\r\n]+$")
 
 
 def _format_human_bytes(byte_count: int) -> str:
     for suffix, factor in (("GB", 1024**3), ("MB", 1024**2), ("KB", 1024)):
         if byte_count >= factor and byte_count % factor == 0:
             return f"{byte_count // factor}{suffix}"
+    if byte_count >= KIB:
+        return f"{byte_count // KIB}KB"
     return f"{byte_count}B"
 
 

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import binascii
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 import httpx
 from pydantic import BaseModel
-from synadia_ai.agents import Attachment
+from synadia_ai.agents import Attachment, ProtocolError
 
 from .config import ChannelConfig
 
@@ -101,7 +102,7 @@ class DeerFlowGatewayClient:
         attachments: list[Attachment] | None = None,
     ) -> AsyncIterator[DeerFlowEvent]:
         """POST a user prompt to DeerFlow Gateway and yield semantic stream events."""
-        path = f"/api/threads/{self._config.session}/runs/stream"
+        path = f"/api/threads/{self._thread_id_path_segment()}/runs/stream"
         async with self._client() as client:
             await self._ensure_authenticated(client)
             await self._ensure_thread_exists(client)
@@ -155,6 +156,9 @@ class DeerFlowGatewayClient:
     def _url(self, path: str) -> str:
         return urljoin(self._config.deerflow_url.rstrip("/") + "/", path.lstrip("/"))
 
+    def _thread_id_path_segment(self) -> str:
+        return quote(self._config.session, safe="")
+
     async def _ensure_authenticated(self, client: httpx.AsyncClient) -> None:
         if not self._config.deerflow_username:
             return
@@ -187,24 +191,31 @@ class DeerFlowGatewayClient:
     ) -> list[UploadedAttachment]:
         if not attachments:
             return []
-        files: list[tuple[str, tuple[str, bytes]]] = [
-            ("files", (attachment.filename, attachment.to_bytes())) for attachment in attachments
-        ]
+        files: list[tuple[str, tuple[str, bytes]]] = []
+        for attachment in attachments:
+            try:
+                content = attachment.to_bytes()
+            except binascii.Error as exc:
+                raise ProtocolError(
+                    f"invalid base64 content for attachment {attachment.filename!r}"
+                ) from exc
+            files.append(("files", (attachment.filename, content)))
         response = await client.post(
-            self._url(f"/api/threads/{self._config.session}/uploads"),
+            self._url(f"/api/threads/{self._thread_id_path_segment()}/uploads"),
             files=files,
             headers=self._request_headers(client),
         )
         if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
             detail = _safe_error_detail(response.text)
             suffix = f": {detail}" if detail else ""
-            raise DeerFlowGatewayError(
-                f"DeerFlow Gateway upload failed: {response.status_code}{suffix}"
-            )
+            message = f"DeerFlow Gateway upload failed: {response.status_code}{suffix}"
+            if response.status_code < httpx.codes.INTERNAL_SERVER_ERROR:
+                raise ProtocolError(message)
+            raise DeerFlowGatewayError(message)
         data = response.json()
-        uploaded = _parse_upload_response(data)
+        uploaded = _parse_upload_response(data, expected_count=len(attachments))
         if not uploaded:
-            raise DeerFlowGatewayError("DeerFlow Gateway accepted no attachments")
+            raise ProtocolError("DeerFlow Gateway accepted no attachments")
         return uploaded
 
     async def _ensure_thread_exists(self, client: httpx.AsyncClient) -> None:
@@ -265,9 +276,16 @@ async def deerflow_gateway_runner(
         await client.aclose()
 
 
-def _parse_upload_response(data: Any) -> list[UploadedAttachment]:
+def _parse_upload_response(
+    data: Any, *, expected_count: int | None = None
+) -> list[UploadedAttachment]:
     if not isinstance(data, dict):
         return []
+    if data.get("success") is False:
+        raise ProtocolError("DeerFlow Gateway rejected attachment upload")
+    skipped_files = data.get("skipped_files")
+    if isinstance(skipped_files, list) and skipped_files:
+        raise ProtocolError("DeerFlow Gateway skipped one or more attachments")
     files = data.get("files")
     if not isinstance(files, list):
         return []
@@ -290,6 +308,8 @@ def _parse_upload_response(data: Any) -> list[UploadedAttachment]:
                 ),
             )
         )
+    if expected_count is not None and len(uploaded) != expected_count:
+        raise ProtocolError("DeerFlow Gateway did not accept all attachments")
     return uploaded
 
 
@@ -319,7 +339,10 @@ def _prompt_request_body(
     *,
     uploaded_attachments: list[UploadedAttachment] | None = None,
 ) -> dict[str, Any]:
-    message: dict[str, Any] = {"role": "user", "content": prompt}
+    message: dict[str, Any] = {
+        "type": "human",
+        "content": [{"type": "text", "text": prompt}],
+    }
     if uploaded_attachments:
         message["additional_kwargs"] = {
             "files": [

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -9,6 +9,8 @@ from typing import Any
 from urllib.parse import urljoin
 
 import httpx
+from pydantic import BaseModel
+from synadia_ai.agents import Attachment
 
 from .config import ChannelConfig
 
@@ -26,6 +28,16 @@ def _safe_error_detail(detail: str) -> str:
     if len(flat) > MAX_ERROR_DETAIL_CHARS:
         flat = flat[: MAX_ERROR_DETAIL_CHARS - 3] + "..."
     return flat
+
+
+class UploadedAttachment(BaseModel):
+    """One file accepted by the DeerFlow Gateway upload API."""
+
+    filename: str
+    virtual_path: str
+    size: int | None = None
+    path: str | None = None
+    artifact_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,13 +94,19 @@ class DeerFlowGatewayClient:
                 return False
         return HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX
 
-    async def stream_events(self, prompt: str) -> AsyncIterator[DeerFlowEvent]:
+    async def stream_events(
+        self,
+        prompt: str,
+        *,
+        attachments: list[Attachment] | None = None,
+    ) -> AsyncIterator[DeerFlowEvent]:
         """POST a user prompt to DeerFlow Gateway and yield semantic stream events."""
-        body = _prompt_request_body(prompt)
         path = f"/api/threads/{self._config.session}/runs/stream"
         async with self._client() as client:
             await self._ensure_authenticated(client)
             await self._ensure_thread_exists(client)
+            uploaded = await self._upload_attachments(client, attachments or [])
+            body = _prompt_request_body(prompt, uploaded_attachments=uploaded)
             async with client.stream(
                 "POST",
                 self._url(path),
@@ -109,9 +127,14 @@ class DeerFlowGatewayClient:
                     for semantic_event in _extract_events_from_sse_event(event, data):
                         yield semantic_event
 
-    async def stream_prompt(self, prompt: str) -> AsyncIterator[str]:
+    async def stream_prompt(
+        self,
+        prompt: str,
+        *,
+        attachments: list[Attachment] | None = None,
+    ) -> AsyncIterator[str]:
         """POST a user prompt to DeerFlow Gateway and yield text chunks from SSE."""
-        async for event in self.stream_events(prompt):
+        async for event in self.stream_events(prompt, attachments=attachments):
             if isinstance(event, TextEvent):
                 yield event.text
 
@@ -156,6 +179,33 @@ class DeerFlowGatewayClient:
                 f"DeerFlow Gateway login failed: {response.status_code}{suffix}"
             )
         self._logged_in = True
+
+    async def _upload_attachments(
+        self,
+        client: httpx.AsyncClient,
+        attachments: list[Attachment],
+    ) -> list[UploadedAttachment]:
+        if not attachments:
+            return []
+        files: list[tuple[str, tuple[str, bytes]]] = [
+            ("files", (attachment.filename, attachment.to_bytes())) for attachment in attachments
+        ]
+        response = await client.post(
+            self._url(f"/api/threads/{self._config.session}/uploads"),
+            files=files,
+            headers=self._request_headers(client),
+        )
+        if not HTTP_OK_MIN <= response.status_code < HTTP_OK_MAX:
+            detail = _safe_error_detail(response.text)
+            suffix = f": {detail}" if detail else ""
+            raise DeerFlowGatewayError(
+                f"DeerFlow Gateway upload failed: {response.status_code}{suffix}"
+            )
+        data = response.json()
+        uploaded = _parse_upload_response(data)
+        if not uploaded:
+            raise DeerFlowGatewayError("DeerFlow Gateway accepted no attachments")
+        return uploaded
 
     async def _ensure_thread_exists(self, client: httpx.AsyncClient) -> None:
         response = await client.post(
@@ -204,20 +254,81 @@ async def deerflow_gateway_runner(
     config: ChannelConfig,
     *,
     http_client: httpx.AsyncClient | None = None,
+    attachments: list[Attachment] | None = None,
 ) -> AsyncIterator[str]:
     """Run one prompt through the configured DeerFlow Gateway."""
     client = DeerFlowGatewayClient(config, http_client=http_client)
     try:
-        async for chunk in client.stream_prompt(prompt):
+        async for chunk in client.stream_prompt(prompt, attachments=attachments):
             yield chunk
     finally:
         await client.aclose()
 
 
-def _prompt_request_body(prompt: str) -> dict[str, Any]:
+def _parse_upload_response(data: Any) -> list[UploadedAttachment]:
+    if not isinstance(data, dict):
+        return []
+    files = data.get("files")
+    if not isinstance(files, list):
+        return []
+    uploaded: list[UploadedAttachment] = []
+    for item in files:
+        if not isinstance(item, dict):
+            continue
+        filename = item.get("filename")
+        virtual_path = item.get("virtual_path")
+        if not isinstance(filename, str) or not isinstance(virtual_path, str):
+            continue
+        uploaded.append(
+            UploadedAttachment(
+                filename=filename,
+                virtual_path=virtual_path,
+                size=_parse_optional_int(item.get("size")),
+                path=item.get("path") if isinstance(item.get("path"), str) else None,
+                artifact_url=(
+                    item.get("artifact_url") if isinstance(item.get("artifact_url"), str) else None
+                ),
+            )
+        )
+    return uploaded
+
+
+def _parse_optional_int(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None
+
+
+def _uploaded_attachment_metadata(attachment: UploadedAttachment) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "filename": attachment.filename,
+        "path": attachment.virtual_path,
+        "status": "uploaded",
+    }
+    if attachment.size is not None:
+        data["size"] = attachment.size
+    if attachment.artifact_url is not None:
+        data["artifact_url"] = attachment.artifact_url
+    return data
+
+
+def _prompt_request_body(
+    prompt: str,
+    *,
+    uploaded_attachments: list[UploadedAttachment] | None = None,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "user", "content": prompt}
+    if uploaded_attachments:
+        message["additional_kwargs"] = {
+            "files": [
+                _uploaded_attachment_metadata(attachment) for attachment in uploaded_attachments
+            ]
+        }
     return {
         "assistant_id": "lead_agent",
-        "input": {"messages": [{"role": "user", "content": prompt}]},
+        "input": {"messages": [message]},
         "config": {"recursion_limit": 50},
         "context": {
             "mode": "flash",

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/runner.py
@@ -103,10 +103,11 @@ class DeerFlowGatewayClient:
     ) -> AsyncIterator[DeerFlowEvent]:
         """POST a user prompt to DeerFlow Gateway and yield semantic stream events."""
         path = f"/api/threads/{self._thread_id_path_segment()}/runs/stream"
+        attachment_files = _attachment_files(attachments or [])
         async with self._client() as client:
             await self._ensure_authenticated(client)
             await self._ensure_thread_exists(client)
-            uploaded = await self._upload_attachments(client, attachments or [])
+            uploaded = await self._upload_attachment_files(client, attachment_files)
             body = _prompt_request_body(prompt, uploaded_attachments=uploaded)
             async with client.stream(
                 "POST",
@@ -184,22 +185,13 @@ class DeerFlowGatewayClient:
             )
         self._logged_in = True
 
-    async def _upload_attachments(
+    async def _upload_attachment_files(
         self,
         client: httpx.AsyncClient,
-        attachments: list[Attachment],
+        files: list[tuple[str, tuple[str, bytes]]],
     ) -> list[UploadedAttachment]:
-        if not attachments:
+        if not files:
             return []
-        files: list[tuple[str, tuple[str, bytes]]] = []
-        for attachment in attachments:
-            try:
-                content = attachment.to_bytes()
-            except binascii.Error as exc:
-                raise ProtocolError(
-                    f"invalid base64 content for attachment {attachment.filename!r}"
-                ) from exc
-            files.append(("files", (attachment.filename, content)))
         response = await client.post(
             self._url(f"/api/threads/{self._thread_id_path_segment()}/uploads"),
             files=files,
@@ -213,7 +205,7 @@ class DeerFlowGatewayClient:
                 raise ProtocolError(message)
             raise DeerFlowGatewayError(message)
         data = response.json()
-        uploaded = _parse_upload_response(data, expected_count=len(attachments))
+        uploaded = _parse_upload_response(data, expected_count=len(files))
         if not uploaded:
             raise ProtocolError("DeerFlow Gateway accepted no attachments")
         return uploaded
@@ -274,6 +266,19 @@ async def deerflow_gateway_runner(
             yield chunk
     finally:
         await client.aclose()
+
+
+def _attachment_files(attachments: list[Attachment]) -> list[tuple[str, tuple[str, bytes]]]:
+    files: list[tuple[str, tuple[str, bytes]]] = []
+    for attachment in attachments:
+        try:
+            content = attachment.to_bytes()
+        except binascii.Error as exc:
+            raise ProtocolError(
+                f"invalid base64 content for attachment {attachment.filename!r}"
+            ) from exc
+        files.append(("files", (attachment.filename, content)))
+    return files
 
 
 def _parse_upload_response(

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -18,7 +18,7 @@ def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
     assert config.deerflow_url == "http://localhost:2026"
     assert config.deerflow_timeout_s == 60.0
     assert config.query_timeout_s == 300.0
-    assert config.max_payload == "1MB"
+    assert config.max_payload is None
     assert config.redacted_dict()["prompt_subject"] == "agents.prompt.df.<owner>.default"
 
 

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -11,6 +11,7 @@ from synadia_ai.nats_deerflow_channel import host as host_module
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig, resolve_config
 from synadia_ai.nats_deerflow_channel.host import (
     _advertised_max_payload,
+    _format_human_bytes,
     _nats_connect_options,
     build_agent_service,
     make_deerflow_prompt_handler,
@@ -95,8 +96,15 @@ def test_advertised_max_payload_falls_back_when_nats_info_missing() -> None:
     assert _advertised_max_payload(config, nc=object()) == "1MB"  # type: ignore[arg-type]
 
 
+def test_format_human_bytes_rounds_non_aligned_limits_down_to_kb() -> None:
+    assert _format_human_bytes((1536 * 1024) + 1) == "1536KB"
+
+
+@pytest.mark.parametrize("filename", ["../x.txt", "file.txt\r\nX-Injected: evil"])
 @pytest.mark.asyncio
-async def test_deerflow_handler_rejects_unsafe_attachment_filename_before_gateway() -> None:
+async def test_deerflow_handler_rejects_unsafe_attachment_filename_before_gateway(
+    filename: str,
+) -> None:
     class Stream:
         async def send(self, chunk: str) -> None:
             raise AssertionError("handler must reject before streaming")
@@ -104,7 +112,7 @@ async def test_deerflow_handler_rejects_unsafe_attachment_filename_before_gatewa
     handler = make_deerflow_prompt_handler(ChannelConfig(owner="rene"))
     envelope = Envelope(
         prompt="hi",
-        attachments=[Attachment(filename="../x.txt", content="aGk=")],
+        attachments=[Attachment(filename=filename, content="aGk=")],
     )
 
     with pytest.raises(ProtocolError, match="unsafe attachment filename"):

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -10,6 +10,7 @@ from synadia_ai.agents import Attachment, Envelope, ProtocolError
 from synadia_ai.nats_deerflow_channel import host as host_module
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig, resolve_config
 from synadia_ai.nats_deerflow_channel.host import (
+    _advertised_max_payload,
     _nats_connect_options,
     build_agent_service,
     make_deerflow_prompt_handler,
@@ -64,13 +65,34 @@ def test_build_agent_service_requires_owner(tmp_path: Path) -> None:
         build_agent_service(config, nc=object())  # type: ignore[arg-type]
 
 
-def test_build_agent_service_passes_hardening_metadata() -> None:
+def test_build_agent_service_uses_nats_server_max_payload_by_default() -> None:
+    class Nats:
+        max_payload = 8 * 1024 * 1024
+
+    config = ChannelConfig(owner="rene")
+
+    service = build_agent_service(config, nc=Nats())  # type: ignore[arg-type]
+
+    assert service._attachments_ok is True
+    assert service._max_payload == "8MB"
+
+
+def test_build_agent_service_honors_smaller_configured_max_payload() -> None:
+    class Nats:
+        max_payload = 8 * 1024 * 1024
+
     config = ChannelConfig(owner="rene", max_payload="256KB")
 
-    service = build_agent_service(config, nc=object())  # type: ignore[arg-type]
+    service = build_agent_service(config, nc=Nats())  # type: ignore[arg-type]
 
     assert service._attachments_ok is True
     assert service._max_payload == "256KB"
+
+
+def test_advertised_max_payload_falls_back_when_nats_info_missing() -> None:
+    config = ChannelConfig(owner="rene")
+
+    assert _advertised_max_payload(config, nc=object()) == "1MB"  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -67,12 +67,12 @@ def test_build_agent_service_passes_hardening_metadata() -> None:
 
     service = build_agent_service(config, nc=object())  # type: ignore[arg-type]
 
-    assert service._attachments_ok is False
+    assert service._attachments_ok is True
     assert service._max_payload == "256KB"
 
 
 @pytest.mark.asyncio
-async def test_deerflow_handler_rejects_attachments_before_gateway() -> None:
+async def test_deerflow_handler_rejects_unsafe_attachment_filename_before_gateway() -> None:
     class Stream:
         async def send(self, chunk: str) -> None:
             raise AssertionError("handler must reject before streaming")
@@ -80,8 +80,8 @@ async def test_deerflow_handler_rejects_attachments_before_gateway() -> None:
     handler = make_deerflow_prompt_handler(ChannelConfig(owner="rene"))
     envelope = Envelope(
         prompt="hi",
-        attachments=[Attachment(filename="x.txt", content="aGk=")],
+        attachments=[Attachment(filename="../x.txt", content="aGk=")],
     )
 
-    with pytest.raises(ProtocolError, match="attachments are not supported"):
+    with pytest.raises(ProtocolError, match="unsafe attachment filename"):
         await handler(envelope, cast(Any, Stream()))

--- a/agents/deerflow/tests/test_host.py
+++ b/agents/deerflow/tests/test_host.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import pytest
 from synadia_ai.agents import Attachment, Envelope, ProtocolError
 
+from synadia_ai.nats_deerflow_channel import host as host_module
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig, resolve_config
 from synadia_ai.nats_deerflow_channel.host import (
     _nats_connect_options,
@@ -14,6 +15,7 @@ from synadia_ai.nats_deerflow_channel.host import (
     make_deerflow_prompt_handler,
     make_prompt_handler,
 )
+from synadia_ai.nats_deerflow_channel.runner import ClarificationEvent, TextEvent
 from synadia_ai.nats_deerflow_channel.testing import fake_deerflow_runner
 
 
@@ -85,3 +87,86 @@ async def test_deerflow_handler_rejects_unsafe_attachment_filename_before_gatewa
 
     with pytest.raises(ProtocolError, match="unsafe attachment filename"):
         await handler(envelope, cast(Any, Stream()))
+
+
+@pytest.mark.asyncio
+async def test_deerflow_handler_forwards_query_reply_attachments(monkeypatch: Any) -> None:
+    calls: list[tuple[str, list[Attachment] | None]] = []
+
+    class FakeClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def stream_events(
+            self,
+            prompt: str,
+            *,
+            attachments: list[Attachment] | None = None,
+        ) -> AsyncIterator[ClarificationEvent | TextEvent]:
+            calls.append((prompt, attachments))
+            if len(calls) == 1:
+                yield ClarificationEvent("Which file?")
+            else:
+                yield TextEvent("done")
+
+        async def aclose(self) -> None:
+            pass
+
+    class Stream:
+        async def send(self, chunk: str) -> None:
+            assert chunk == "done"
+
+        async def ask(self, prompt: str, *, timeout: float) -> Envelope:
+            assert prompt == "Which file?"
+            assert timeout == 300
+            return Envelope(
+                prompt="use the follow-up file",
+                attachments=[Attachment.from_bytes("reply.txt", b"reply")],
+            )
+
+    monkeypatch.setattr(host_module, "DeerFlowGatewayClient", FakeClient)
+    handler = make_deerflow_prompt_handler(ChannelConfig(owner="rene"))
+
+    await handler(
+        Envelope(prompt="start", attachments=[Attachment.from_bytes("initial.txt", b"initial")]),
+        cast(Any, Stream()),
+    )
+
+    assert calls == [
+        ("start", [Attachment.from_bytes("initial.txt", b"initial")]),
+        ("use the follow-up file", [Attachment.from_bytes("reply.txt", b"reply")]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deerflow_handler_rejects_unsafe_query_reply_attachment(monkeypatch: Any) -> None:
+    class FakeClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def stream_events(
+            self,
+            prompt: str,
+            *,
+            attachments: list[Attachment] | None = None,
+        ) -> AsyncIterator[ClarificationEvent]:
+            yield ClarificationEvent("Need a file")
+
+        async def aclose(self) -> None:
+            pass
+
+    class Stream:
+        async def send(self, chunk: str) -> None:
+            raise AssertionError("handler should reject before second turn")
+
+        async def ask(self, prompt: str, *, timeout: float) -> Envelope:
+            return Envelope(
+                prompt="bad reply",
+                attachments=[Attachment.from_bytes("../secret.txt", b"reply")],
+            )
+
+    monkeypatch.setattr(host_module, "DeerFlowGatewayClient", FakeClient)
+    handler = make_deerflow_prompt_handler(ChannelConfig(owner="rene"))
+
+    with pytest.raises(ProtocolError, match="unsafe attachment filename"):
+        await handler(Envelope(prompt="start"), cast(Any, Stream()))

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
 import pytest
+from synadia_ai.agents import Attachment
 
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig
 from synadia_ai.nats_deerflow_channel.runner import (
@@ -57,6 +59,80 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
     assert seen["path"] == "/api/threads/deerflow/runs/stream"
     assert '"content":"hi"' in seen["json"].replace(" ", "")
     assert '"stream_mode":["messages"]' in seen["json"].replace(" ", "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_uploads_attachments_and_includes_virtual_paths_in_prompt() -> None:
+    seen: dict[str, Any] = {"paths": []}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["paths"].append(request.url.path)
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
+        if request.url.path == "/api/threads/deerflow/uploads":
+            body = request.read()
+            seen["upload_content_type"] = request.headers.get("content-type")
+            seen["upload_body"] = body
+            return httpx.Response(
+                200,
+                json={
+                    "success": True,
+                    "files": [
+                        {
+                            "filename": "brief.txt",
+                            "size": 15,
+                            "virtual_path": "/mnt/user-data/uploads/brief.txt",
+                            "path": "/sandbox/uploads/brief.txt",
+                            "artifact_url": (
+                                "/api/threads/deerflow/artifacts/mnt/user-data/uploads/brief.txt"
+                            ),
+                        }
+                    ],
+                    "message": "Successfully uploaded 1 file(s)",
+                    "skipped_files": [],
+                },
+            )
+        seen["stream_json"] = request.read().decode()
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        chunks = [
+            chunk
+            async for chunk in client.stream_prompt(
+                "read it",
+                attachments=[Attachment.from_bytes("brief.txt", b"attachment text")],
+            )
+        ]
+
+    assert chunks == ["ok"]
+    assert seen["paths"] == [
+        "/api/threads",
+        "/api/threads/deerflow/uploads",
+        "/api/threads/deerflow/runs/stream",
+    ]
+    assert str(seen["upload_content_type"]).startswith("multipart/form-data")
+    assert b'filename="brief.txt"' in seen["upload_body"]
+    assert b"attachment text" in seen["upload_body"]
+    stream_body = json.loads(seen["stream_json"])
+    message = stream_body["input"]["messages"][0]
+    assert message["content"] == "read it"
+    assert message["additional_kwargs"]["files"] == [
+        {
+            "filename": "brief.txt",
+            "path": "/mnt/user-data/uploads/brief.txt",
+            "status": "uploaded",
+            "size": 15,
+            "artifact_url": "/api/threads/deerflow/artifacts/mnt/user-data/uploads/brief.txt",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
-from synadia_ai.agents import Attachment
+from synadia_ai.agents import Attachment, ProtocolError
 
 from synadia_ai.nats_deerflow_channel.config import ChannelConfig
 from synadia_ai.nats_deerflow_channel.runner import (
@@ -57,7 +57,10 @@ async def test_gateway_runner_posts_prompt_to_deerflow_stream() -> None:
     assert '"thread_id":"deerflow"' in seen["thread_body"].replace(" ", "")
     assert seen["method"] == "POST"
     assert seen["path"] == "/api/threads/deerflow/runs/stream"
-    assert '"content":"hi"' in seen["json"].replace(" ", "")
+    stream_body = json.loads(seen["json"])
+    message = stream_body["input"]["messages"][0]
+    assert message["type"] == "human"
+    assert message["content"] == [{"type": "text", "text": "hi"}]
     assert '"stream_mode":["messages"]' in seen["json"].replace(" ", "")
 
 
@@ -123,7 +126,8 @@ async def test_gateway_runner_uploads_attachments_and_includes_virtual_paths_in_
     assert b"attachment text" in seen["upload_body"]
     stream_body = json.loads(seen["stream_json"])
     message = stream_body["input"]["messages"][0]
-    assert message["content"] == "read it"
+    assert message["type"] == "human"
+    assert message["content"] == [{"type": "text", "text": "read it"}]
     assert message["additional_kwargs"]["files"] == [
         {
             "filename": "brief.txt",
@@ -133,6 +137,117 @@ async def test_gateway_runner_uploads_attachments_and_includes_virtual_paths_in_
             "artifact_url": "/api/threads/deerflow/artifacts/mnt/user-data/uploads/brief.txt",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_url_escapes_thread_path_segments() -> None:
+    seen_raw_paths: list[bytes] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_raw_paths.append(request.url.raw_path)
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "space session/one", "status": "idle"})
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(
+                owner="rene",
+                session="space session/one",
+                deerflow_url="http://deerflow.test",
+            ),
+            http_client=http,
+        )
+        chunks = [chunk async for chunk in client.stream_prompt("hi")]
+
+    assert chunks == ["ok"]
+    assert seen_raw_paths == [b"/api/threads", b"/api/threads/space%20session%2Fone/runs/stream"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_rejects_skipped_uploads_before_stream() -> None:
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
+        if request.url.path == "/api/threads/deerflow/uploads":
+            return httpx.Response(
+                200,
+                json={
+                    "success": True,
+                    "files": [],
+                    "skipped_files": [{"filename": "too-big.pdf", "reason": "too large"}],
+                },
+            )
+        raise AssertionError("stream should not be called after skipped upload")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        with pytest.raises(ProtocolError, match="skipped"):
+            _ = [
+                chunk
+                async for chunk in client.stream_prompt(
+                    "read it",
+                    attachments=[Attachment.from_bytes("too-big.pdf", b"x")],
+                )
+            ]
+
+    assert seen_paths == ["/api/threads", "/api/threads/deerflow/uploads"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_maps_4xx_upload_failure_to_protocol_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
+        if request.url.path == "/api/threads/deerflow/uploads":
+            return httpx.Response(400, text="bad file")
+        raise AssertionError("stream should not be called after upload failure")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        with pytest.raises(ProtocolError, match="upload failed: 400"):
+            _ = [
+                chunk
+                async for chunk in client.stream_prompt(
+                    "read it",
+                    attachments=[Attachment.from_bytes("brief.txt", b"x")],
+                )
+            ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_maps_invalid_attachment_base64_to_protocol_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
+        raise AssertionError("upload should not be called with invalid base64")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        client = DeerFlowGatewayClient(
+            ChannelConfig(owner="rene", session="deerflow", deerflow_url="http://deerflow.test"),
+            http_client=http,
+        )
+        with pytest.raises(ProtocolError, match="invalid base64"):
+            _ = [
+                chunk
+                async for chunk in client.stream_prompt(
+                    "read it",
+                    attachments=[Attachment(filename="brief.txt", content="not valid base64")],
+                )
+            ]
 
 
 @pytest.mark.asyncio

--- a/agents/deerflow/tests/test_runner.py
+++ b/agents/deerflow/tests/test_runner.py
@@ -231,9 +231,7 @@ async def test_gateway_runner_maps_4xx_upload_failure_to_protocol_error() -> Non
 @pytest.mark.asyncio
 async def test_gateway_runner_maps_invalid_attachment_base64_to_protocol_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/api/threads":
-            return httpx.Response(200, json={"thread_id": "deerflow", "status": "idle"})
-        raise AssertionError("upload should not be called with invalid base64")
+        raise AssertionError(f"HTTP should not be called with invalid base64: {request.url.path}")
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
         client = DeerFlowGatewayClient(
@@ -340,6 +338,91 @@ async def test_gateway_runner_can_login_and_use_csrf_cookie() -> None:
     assert seen["csrf"] == "csrf-from-login"
     assert "access_token=session-token" in seen["cookie"]
     assert "csrf_token=csrf-from-login" in seen["cookie"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_uploads_attachments_with_login_csrf_headers() -> None:
+    seen: dict[str, Any] = {"paths": [], "csrf_by_path": {}, "cookie_by_path": {}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        seen["paths"].append(path)
+        if path == "/api/v1/auth/login/local":
+            return httpx.Response(
+                200,
+                headers=[
+                    ("set-cookie", "access_token=session-token; Path=/"),
+                    ("set-cookie", "csrf_token=csrf-from-login; Path=/"),
+                ],
+                json={"expires_in": 3600, "needs_setup": False},
+            )
+        seen["csrf_by_path"][path] = request.headers.get("X-CSRF-Token")
+        seen["cookie_by_path"][path] = request.headers.get("Cookie")
+        if path == "/api/threads":
+            return httpx.Response(200, json={"thread_id": "default", "status": "idle"})
+        if path == "/api/threads/default/uploads":
+            assert b'filename="brief.txt"' in request.read()
+            return httpx.Response(
+                200,
+                json={
+                    "success": True,
+                    "files": [
+                        {
+                            "filename": "brief.txt",
+                            "virtual_path": "/mnt/user-data/uploads/brief.txt",
+                        }
+                    ],
+                    "skipped_files": [],
+                },
+            )
+        if path == "/api/threads/default/runs/stream":
+            seen["stream_body"] = json.loads(request.read())
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content='event: messages\ndata: [[{"type":"ai","content":"ok"}],{}]\n\n',
+            )
+        raise AssertionError(f"unexpected request: {path}")
+
+    config = ChannelConfig(
+        deerflow_url="http://deerflow.local",
+        deerflow_username="rene@example.com",
+        deerflow_password="secret",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        chunks = [
+            chunk
+            async for chunk in deerflow_gateway_runner(
+                "question?",
+                config,
+                http_client=http,
+                attachments=[Attachment.from_bytes("brief.txt", b"attachment text")],
+            )
+        ]
+
+    assert chunks == ["ok"]
+    assert seen["paths"] == [
+        "/api/v1/auth/login/local",
+        "/api/threads",
+        "/api/threads/default/uploads",
+        "/api/threads/default/runs/stream",
+    ]
+    for path in [
+        "/api/threads",
+        "/api/threads/default/uploads",
+        "/api/threads/default/runs/stream",
+    ]:
+        assert seen["csrf_by_path"][path] == "csrf-from-login"
+        assert "access_token=session-token" in seen["cookie_by_path"][path]
+        assert "csrf_token=csrf-from-login" in seen["cookie_by_path"][path]
+    message = seen["stream_body"]["input"]["messages"][0]
+    assert message["additional_kwargs"]["files"] == [
+        {
+            "filename": "brief.txt",
+            "path": "/mnt/user-data/uploads/brief.txt",
+            "status": "uploaded",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds DeerFlow Gateway-native attachment support to the external NATS channel wrapper.

- accepts Synadia Agent Protocol inline attachments
- validates attachment filenames/base64 before DeerFlow side effects
- uploads files to DeerFlow Gateway `/api/threads/{session}/uploads`
- sends returned upload metadata via `input.messages[].additional_kwargs.files`
- maps upload failures/skipped/partial uploads to protocol errors
- advertises `attachments_ok=true`
- makes DeerFlow `max_payload` follow the connected NATS server by default, with optional smaller configured cap
- updates root/package docs without claiming PyPI availability before first release

## Verification

Local DeerFlow package gate, latest branch state:

```text
uv run pytest -q              -> 44 passed
uv run ruff check .           -> passed
uv run ruff format --check .  -> passed
uv run mypy src tests         -> passed
uv build                      -> passed
```

Fresh-eyes Codex review:

```text
VERDICT: TRUST WITH CONDITIONS
BLOCKERS: none
```

Codex's only remaining condition was that it could not run pytest inside its read-only sandbox. The same focused/full test suite was run successfully in the normal dev environment above.

Real M3 Max smoke against live NATS + DeerFlow Gateway:

```text
DISCOVERED 1
SUBJECT agents.prompt.df.rene.deerflow
ATTACHMENTS_OK True
MAX_PAYLOAD_BYTES 1048576
MSG StatusChunk ack
MSG StatusChunk DeerFlow tool call: read_file
MSG StatusChunk DeerFlow tool result: read_file
MSG ResponseChunk deerflow-attachment-smoke-ok
FINAL_TEXT deerflow-attachment-smoke-ok
SMOKE_OK
```

Smoke attachment:

```text
filename: smoke-note.txt
content: SECRET_WORD: deerflow-attachment-smoke-ok
```

The prompt asked DeerFlow to return only the value after `SECRET_WORD`; the response proves the upload path reached DeerFlow's runtime/read_file tool.

## Notes

This is intentionally an external wrapper change only. It does not fork or modify DeerFlow.