### PR TITLE
docs: mark DeerFlow package ready for PyPI release

### DIFF
--- a/.github/workflows/release-python-deerflow.yml
+++ b/.github/workflows/release-python-deerflow.yml
@@ -6,7 +6,7 @@ name: Release — agents/deerflow
 # agent-service (`python-agent-service-v*`) releases. Verification runs
 # before publishing and the publish job uses PyPI trusted publishing.
 #
-# Before the first release, register a pending publisher on PyPI for:
+# PyPI trusted publishing is configured with a pending publisher for:
 #   project: synadia-ai-nats-deerflow-channel
 #   owner: synadia-ai
 #   repo: synadia-agents

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [OpenClaw](agents/openclaw/) | `oc` | `@synadia-ai/nats-channel` |
 | [PI Agent](agents/pi/) | `pi` | `@synadia-ai/nats-pi-channel` |
 | [Hermes](agents/hermes/) | `hermes` | upstream fork — see [`agents/hermes/`](agents/hermes/) (work in progress) |
-| [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway; package pending first release |
+| [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway |
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -10,10 +10,6 @@ This package is deliberately narrow: it is a **Synadia Agent Protocol channel wr
 
 ### Package index install
 
-The package is intended to publish as `synadia-ai-nats-deerflow-channel`. Until the first release is published, install it from this monorepo using the editable flow below.
-
-After publication, the package-index flow will be:
-
 ```bash
 pip install synadia-ai-nats-deerflow-channel
 ```


### PR DESCRIPTION
## Summary

Prepare the DeerFlow package docs for the first PyPI release now that the PyPI pending publisher is configured.

- remove root README wording that says the DeerFlow package is pending first release
- make `agents/deerflow/README.md` show package-index install as the normal install path
- update the release workflow comment to reflect that the PyPI pending publisher is configured

## Verified publisher settings

```text
PyPI project: synadia-ai-nats-deerflow-channel
Owner:        synadia-ai
Repository:   synadia-agents
Workflow:     release-python-deerflow.yml
Environment:  pypi
```

## Verification

```text
git grep stale pending-release wording in release-facing files -> no matches
python YAML parse of .github/workflows/release-python-deerflow.yml -> workflow-yaml-ok
cd agents/deerflow && uv build -> sdist + wheel built
```

## Release note

After this PR is merged, the release tag should be `python-deerflow-v<pyproject-version>` so `.github/workflows/release-python-deerflow.yml` publishes the package through PyPI trusted publishing.