### PR TITLE
feat(pi-channel): make SAP owner subject token overridable

### DIFF
--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -60,8 +60,9 @@ Config file lives at `~/.pi/agent/nats-channel.json`:
 |-------|----------|---------|-------------|
 | `context` | no | — | Name of a NATS CLI context (file under `~/.config/nats/context/<name>.json`). When unset, falls back to `$NATS_URL` or, if that's also unset, the built-in `demo.nats.io`. |
 | `sessionName` | no | sanitized basename of CWD | The 5th subject token. Override to give your session a stable, addressable name. |
+| `owner` | no | `$USER` | The 4th subject token. Override to scope the session to a service account, deployment, or tenant instead of the OS user — sanitized to a legal subject token. |
 
-The `owner` token (4th) is always derived from `$USER` — there's no override for it. For multi-tenant isolation, see [Multi-tenancy](#multi-tenancy) below.
+The `owner` token (4th) defaults to `$USER` but is overridable via the `owner` config field or the `NATS_PI_OWNER` env var (see below) — useful for service-account or deployment-scoped sessions. For multi-tenant isolation, see [Multi-tenancy](#multi-tenancy) below.
 
 ### Environment variables
 
@@ -72,6 +73,7 @@ Env vars override the config file:
 | `NATS_CONTEXT` | `context` | Highest precedence — see below. |
 | `NATS_URL` | raw URL (no auth context) | Used only when `NATS_CONTEXT` and `config.context` are both unset. |
 | `NATS_SESSION_NAME` | `sessionName` | |
+| `NATS_PI_OWNER` | `owner` | Overrides `$USER`; loses to the `owner` config field. |
 
 ### Resolution order
 
@@ -81,6 +83,8 @@ Env vars override the config file:
 4. **`$NATS_CONTEXT`** — wins over everything
 
 For `sessionName`: `$NATS_SESSION_NAME` overrides `config.sessionName`, which overrides the CWD-basename default.
+
+For `owner`: `config.owner` overrides `$NATS_PI_OWNER`, which overrides `$USER`, which falls back to `unknown`.
 
 ### In-PI commands
 
@@ -203,7 +207,7 @@ Multiple PI sessions on the same host register as distinct service instances; `n
 
 ## Multi-tenancy
 
-The agent subject layout has no per-tenant slot. For real isolation between tenants or environments, use **NATS accounts** and subject permissions — that's a server-side configuration, not an extension one. Within a single account, sessions with distinct `owner` values (i.e. different `$USER`s) coexist cleanly.
+The agent subject layout has no per-tenant slot. For real isolation between tenants or environments, use **NATS accounts** and subject permissions — that's a server-side configuration, not an extension one. Within a single account, sessions with distinct `owner` values (different `$USER`s, or owners set via the `owner` config field / `NATS_PI_OWNER`) coexist cleanly.
 
 ## Limitations
 

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -66,6 +66,8 @@ import {
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
+import { resolveOwner, sanitizeSubjectToken } from "./subject.ts";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // PI-specific protocol constants
 // ─────────────────────────────────────────────────────────────────────────────
@@ -114,6 +116,7 @@ const DEFAULT_CONTEXT: NatsContext = {
 type PiNatsConfig = {
 	context?: string;
 	sessionName?: string;
+	owner?: string;
 };
 
 // Matches NATS CLI context files at ~/.config/nats/context/<name>.json.
@@ -154,17 +157,6 @@ type PendingRequest = {
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure helpers
 // ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Sanitize a subject token per spec §2.2 SHOULD rules: [a-z0-9_-], lowercase,
- * no leading/trailing dashes. Replaces disallowed characters with `-`.
- */
-function sanitizeSubjectToken(s: string): string {
-	return s
-		.replace(/[^a-zA-Z0-9_-]/g, "-")
-		.toLowerCase()
-		.replace(/^-+|-+$/g, "");
-}
 
 function loadNatsContext(name: string): NatsContext {
 	// Reject names that would escape the context directory. `$NATS_CONTEXT`
@@ -834,8 +826,13 @@ export default function (pi: ExtensionAPI) {
 		contextLabel = ctxName ?? (envUrl ? "$NATS_URL" : "default");
 		serverUrl = natsCtx.url ?? "demo.nats.io";
 
-		// 2. Resolve owner + session base name
-		owner = sanitizeSubjectToken(process.env.USER ?? "unknown") || "unknown";
+		// 2. Resolve owner + session base name. Owner precedence (highest
+		//    first): config-file `owner` → `$NATS_PI_OWNER` → `$USER` →
+		//    "unknown". This makes a service-account / deployment / SOE-scoped
+		//    owner expressible instead of forcing `$USER`, matching how the
+		//    core SDK, Python SDK and open-agent all treat `owner` as
+		//    caller-supplied. See `subject.ts#resolveOwner`.
+		owner = resolveOwner(config.owner, process.env.NATS_PI_OWNER, process.env.USER);
 		const rawSession =
 			(process.env.NATS_SESSION_NAME ??
 				config.sessionName ??

--- a/agents/pi/extensions/subject.ts
+++ b/agents/pi/extensions/subject.ts
@@ -1,0 +1,44 @@
+// Pure subject-token helpers, kept free of any NATS/SDK imports so they can
+// be unit-tested in isolation (see `test/owner.test.ts`). The channel
+// extension (`nats-channel.ts`) imports from here rather than defining these
+// inline, mirroring the pure-module pattern used by `agents/openclaw`.
+
+/**
+ * Sanitize a subject token per spec §2.2 SHOULD rules: [a-z0-9_-], lowercase,
+ * no leading/trailing dashes. Replaces disallowed characters with `-`.
+ */
+export function sanitizeSubjectToken(s: string): string {
+	return s
+		.replace(/[^a-zA-Z0-9_-]/g, "-")
+		.toLowerCase()
+		.replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Resolve the SAP `owner` subject token (4th token in
+ * `agents.prompt.pi.<owner>.<name>`) from its precedence chain, then sanitize
+ * the winner into a legal subject token.
+ *
+ * Precedence — highest first — mirrors Synadia's own open-agent reference
+ * (`agents/open-agent/src/cli.ts`), so a service-account / deployment /
+ * SOE-scoped owner is expressible instead of being forced to `$USER`:
+ *
+ *   1. `config.owner`     — explicit field in `~/.pi/agent/nats-channel.json`
+ *   2. `NATS_PI_OWNER`    — dedicated env override (cf. open-agent's
+ *                           `OPEN_AGENT_OWNER`); do not overload `$USER`
+ *   3. `$USER`            — existing default; unchanged for everyone else
+ *   4. `"unknown"`        — last-resort fallback
+ *
+ * A winner that sanitizes to the empty string (e.g. all-punctuation) also
+ * falls back to `"unknown"` so the subject token is always non-empty.
+ */
+export function resolveOwner(
+	configOwner: string | undefined,
+	envOwner: string | undefined,
+	envUser: string | undefined,
+): string {
+	return (
+		sanitizeSubjectToken(configOwner ?? envOwner ?? envUser ?? "unknown") ||
+		"unknown"
+	);
+}

--- a/agents/pi/extensions/subject.ts
+++ b/agents/pi/extensions/subject.ts
@@ -29,8 +29,14 @@ export function sanitizeSubjectToken(s: string): string {
  *   3. `$USER`            — existing default; unchanged for everyone else
  *   4. `"unknown"`        — last-resort fallback
  *
- * A winner that sanitizes to the empty string (e.g. all-punctuation) also
- * falls back to `"unknown"` so the subject token is always non-empty.
+ * A winner that sanitizes to the empty string (e.g. all-punctuation) falls
+ * back to `"unknown"` so the subject token is always non-empty. Note this is
+ * `??`-then-sanitize, not a per-source cascade: the first *present* source
+ * wins even if it sanitizes to empty — it does NOT fall through to the next
+ * source. This deliberately matches open-agent's `??` precedence
+ * (`agents/open-agent/src/cli.ts`) and pi's own coerce-via-sanitize
+ * convention, and keeps a misconfigured explicit owner visible as `unknown`
+ * rather than silently re-resolving the session under a different identity.
  */
 export function resolveOwner(
 	configOwner: string | undefined,

--- a/agents/pi/test/owner.test.ts
+++ b/agents/pi/test/owner.test.ts
@@ -1,0 +1,39 @@
+// Unit tests for owner-token precedence (resolveOwner).
+//
+// The SAP `owner` subject token (4th token in `agents.prompt.pi.<owner>.<name>`)
+// must be caller-overridable so service-account / deployment / SOE-scoped
+// owners are expressible, with `$USER` kept only as a last-resort default.
+// Precedence mirrors Synadia's own open-agent reference
+// (`agents/open-agent/src/cli.ts`): config.owner → NATS_PI_OWNER → $USER →
+// "unknown", with the result sanitized into a legal subject token.
+//
+// Run with: bun test test/owner.test.ts
+
+import { test, expect } from "bun:test";
+import { resolveOwner } from "../extensions/subject.ts";
+
+test("config.owner wins over the NATS_PI_OWNER env and $USER", () => {
+	expect(resolveOwner("from-config", "from-env", "from-user")).toBe("from-config");
+});
+
+test("NATS_PI_OWNER env wins over $USER when config.owner is unset", () => {
+	expect(resolveOwner(undefined, "from-env", "from-user")).toBe("from-env");
+});
+
+test("falls back to $USER when neither config.owner nor NATS_PI_OWNER is set", () => {
+	expect(resolveOwner(undefined, undefined, "from-user")).toBe("from-user");
+});
+
+test("falls back to 'unknown' when nothing is set", () => {
+	expect(resolveOwner(undefined, undefined, undefined)).toBe("unknown");
+});
+
+test("sanitizes an override into a legal lowercase subject token", () => {
+	expect(resolveOwner("Service Account/Prod", undefined, undefined)).toBe(
+		"service-account-prod",
+	);
+});
+
+test("an override that sanitizes to empty falls back to 'unknown'", () => {
+	expect(resolveOwner("///", undefined, undefined)).toBe("unknown");
+});

--- a/agents/pi/test/owner.test.ts
+++ b/agents/pi/test/owner.test.ts
@@ -37,3 +37,12 @@ test("sanitizes an override into a legal lowercase subject token", () => {
 test("an override that sanitizes to empty falls back to 'unknown'", () => {
 	expect(resolveOwner("///", undefined, undefined)).toBe("unknown");
 });
+
+test("a present-but-empty-sanitizing config.owner does NOT cascade to lower sources", () => {
+	// `??`-then-sanitize semantics (matching open-agent's `??` precedence):
+	// the first *present* source wins. A defined-but-all-punctuation
+	// config.owner resolves to "unknown" rather than falling through to
+	// NATS_PI_OWNER / $USER — a misconfigured explicit owner stays visible
+	// instead of silently re-resolving under a different identity.
+	expect(resolveOwner("///", "svc-account", "alice")).toBe("unknown");
+});


### PR DESCRIPTION
## Problem

`agents/pi` (`@synadia-ai/nats-pi-channel`) hard-pins the SAP `owner` subject token to `$USER` with no override:

```js
owner = sanitizeSubjectToken(process.env.USER ?? "unknown") || "unknown";
```

This makes a service-account / deployment / SOE-scoped owner impossible, which is at odds with `core-protocol.md` §3.2's own "operator/**account**" wording — and makes the pi channel the lone outlier among first-party Synadia implementations:

| Implementation | How `owner` is set |
|---|---|
| Core TS SDK `@synadia-ai/agents` | required param to `AgentSubject.new(agent, owner, name)` |
| Python SDK `synadia_ai.agent_service` | required ctor param `owner: str` |
| **open-agent** (reference agent) | `out["owner"] ?? process.env["OPEN_AGENT_OWNER"] ?? process.env["USER"] ?? "anon"` (`agents/open-agent/src/cli.ts`) |
| **`@synadia-ai/nats-pi-channel`** | `process.env.USER` only — **the outlier** |

## Fix

Add an owner precedence chain mirroring `open-agent/src/cli.ts`:

1. `config.owner` — new optional field in `~/.pi/agent/nats-channel.json`
2. `NATS_PI_OWNER` — dedicated env override (cf. open-agent's `OPEN_AGENT_OWNER`; deliberately *not* overloading `$USER`)
3. `$USER` — existing default
4. `"unknown"` — last-resort fallback

The winner is still run through `sanitizeSubjectToken`, so an override is always a legal NATS subject token (this also neutralises subject-injection, the concern open-agent's `bridge.ts` validates separately).

**Backwards compatible:** when neither override is set, `owner` still resolves to sanitized `$USER` — unchanged for existing users. The existing smoke test's owner assertions pass without modification.

## Structure

The pure subject-token helpers (`sanitizeSubjectToken` + the new `resolveOwner`) are extracted into `extensions/subject.ts` so the precedence logic is unit-testable without importing the SDK-heavy channel module — mirroring the pure-module pattern already used by `agents/openclaw`.

## Tests

- New `test/owner.test.ts` (bun): config.owner wins; `NATS_PI_OWNER` wins over `$USER`; `$USER` fallback; `unknown` when nothing set; sanitisation of a bad override; empty-after-sanitise falls back to `unknown`. All 6 green.
- All changed files transpile clean.

## Docs

README config/env reference, resolution-order, and multi-tenancy sections updated; the now-false "there's no override for it" line is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)