### PR TITLE
docs(agent-sdk): add Ollama LLM streaming example

### DIFF
--- a/agent-sdk/typescript/examples/02-ollama.ts
+++ b/agent-sdk/typescript/examples/02-ollama.ts
@@ -1,0 +1,98 @@
+// LLM agent — forwards each prompt to a local Ollama and streams the reply.
+//
+// Step 2 of the example ladder: take the echo agent (`01-echo.ts`) and swap
+// the one-line `echo: <prompt>` reply for a real LLM round-trip. The shape is
+// identical — only the `onPrompt` body changes. Tokens are streamed back to
+// the caller as they arrive, so the front-end sees the answer render live.
+//
+// Prerequisites: a local Ollama (https://ollama.com) with the model pulled:
+//   ollama pull llama3.2
+//
+// Connection resolution (same as 01-echo.ts):
+//   1. $NATS_CONTEXT — name of a NATS CLI context under ~/.config/nats/context/
+//   2. $NATS_URL     — raw URL (credentials in userinfo are honored)
+//   3. nats://127.0.0.1:4222
+
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
+import { AgentService } from "@synadia-ai/agent-service";
+
+// Which model to prompt, and where Ollama lives. Override either from the
+// environment, or just edit the defaults below.
+const MODEL = process.env["OLLAMA_MODEL"] ?? "llama3.2";
+const OLLAMA_URL = process.env["OLLAMA_URL"] ?? "http://localhost:11434";
+
+/**
+ * Stream a completion from Ollama, yielding each token as it arrives.
+ *
+ * Ollama's `/api/generate` returns newline-delimited JSON — one object per
+ * line, each carrying the next `response` fragment until a final `done`. We
+ * read the HTTP body as a stream and re-assemble those lines as they trickle
+ * in, so tokens flow out the moment the model produces them.
+ */
+async function* ollamaTokens(prompt: string): AsyncGenerator<string> {
+  const res = await fetch(`${OLLAMA_URL}/api/generate`, {
+    method: "POST",
+    body: JSON.stringify({ model: MODEL, prompt, stream: true }),
+  });
+  if (!res.ok || res.body === null) {
+    throw new Error(`Ollama request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const bytes of res.body) {
+    buffer += decoder.decode(bytes as Uint8Array, { stream: true });
+    // A network read may split mid-line; keep the trailing partial in `buffer`.
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      yield (JSON.parse(line) as { response?: string }).response ?? "";
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const opts = process.env["NATS_CONTEXT"]
+    ? await loadContextOptions(process.env["NATS_CONTEXT"])
+    : process.env["NATS_URL"]
+      ? parseNatsUrl(process.env["NATS_URL"])
+      : { servers: "nats://127.0.0.1:4222" };
+  const nc = await natsConnect(opts);
+
+  const service = new AgentService({
+    nc,
+    agent: "ollama",
+    owner: process.env["USER"] ?? "anon",
+    name: "main",
+    description: `LLM agent — answers prompts with the local Ollama '${MODEL}' model`,
+  });
+
+  // Same handler shape as the echo agent: instead of one reply, we `send(...)`
+  // each token as Ollama emits it. The SDK closes the stream when we return.
+  service.onPrompt(async (envelope, response) => {
+    for await (const token of ollamaTokens(envelope.prompt)) {
+      await response.send(token);
+    }
+  });
+
+  await service.start();
+  console.log(`ollama agent listening on ${service.subject.prompt}`);
+  console.log(`prompting model '${MODEL}' at ${OLLAMA_URL}`);
+  console.log("press Ctrl+C to stop");
+
+  const shutdown = async (): Promise<void> => {
+    console.log("\nshutting down…");
+    await service.stop();
+    await nc.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}
+
+void main().catch((err: unknown) => {
+  console.error("ollama agent failed:", err);
+  process.exit(1);
+});

--- a/agent-sdk/typescript/examples/02-ollama.ts
+++ b/agent-sdk/typescript/examples/02-ollama.ts
@@ -33,6 +33,7 @@ const OLLAMA_URL = process.env["OLLAMA_URL"] ?? "http://localhost:11434";
 async function* ollamaTokens(prompt: string): AsyncGenerator<string> {
   const res = await fetch(`${OLLAMA_URL}/api/generate`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ model: MODEL, prompt, stream: true }),
   });
   if (!res.ok || res.body === null) {
@@ -48,7 +49,10 @@ async function* ollamaTokens(prompt: string): AsyncGenerator<string> {
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (line.trim() === "") continue;
-      yield (JSON.parse(line) as { response?: string }).response ?? "";
+      // The final `{"done":true,"response":""}` packet carries no text — skip
+      // empties so we never stream a vacuous chunk to the caller.
+      const token = (JSON.parse(line) as { response?: string }).response ?? "";
+      if (token) yield token;
     }
   }
 }

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -5,9 +5,10 @@ speaking the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/syn
 Counterpart to the caller-side numbered demos in
 [`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/).
 
-| Example                    | What it shows                                                           |
-| -------------------------- | ----------------------------------------------------------------------- |
-| [`01-echo.ts`](01-echo.ts) | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`. |
+| Example                        | What it shows                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| [`01-echo.ts`](01-echo.ts)     | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`.                    |
+| [`02-ollama.ts`](02-ollama.ts) | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply. |
 
 ## Run
 
@@ -32,6 +33,19 @@ You should see:
 echo agent listening on agents.prompt.echo.<you>.main
 press Ctrl+C to stop
 ```
+
+### `02-ollama.ts` — prompt a local LLM
+
+Needs a running [Ollama](https://ollama.com) with the model pulled:
+
+```sh
+ollama pull llama3.2
+bun examples/02-ollama.ts            # uses llama3.2 by default
+OLLAMA_MODEL=qwen2.5 bun examples/02-ollama.ts   # or pick another model
+```
+
+The agent registers as `ollama` and streams the model's answer back token by
+token — drive it with the same caller demos or `nats` CLI as above.
 
 Drive it from another terminal with the caller-side
 [`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/)

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -34,19 +34,6 @@ echo agent listening on agents.prompt.echo.<you>.main
 press Ctrl+C to stop
 ```
 
-### `02-ollama.ts` — prompt a local LLM
-
-Needs a running [Ollama](https://ollama.com) with the model pulled:
-
-```sh
-ollama pull llama3.2
-bun examples/02-ollama.ts            # uses llama3.2 by default
-OLLAMA_MODEL=qwen2.5 bun examples/02-ollama.ts   # or pick another model
-```
-
-The agent registers as `ollama` and streams the model's answer back token by
-token — drive it with the same caller demos or `nats` CLI as above.
-
 Drive it from another terminal with the caller-side
 [`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/)
 demos, or directly with the `nats` CLI:
@@ -61,5 +48,34 @@ Output:
 ```
 {"type":"status","data":"ack"}
 {"type":"response","data":"echo: hello!"}
+(empty terminator)
+```
+
+### `02-ollama.ts` — prompt a local LLM
+
+Needs a running [Ollama](https://ollama.com) with the model pulled:
+
+```sh
+ollama pull llama3.2
+bun examples/02-ollama.ts            # uses llama3.2 by default
+OLLAMA_MODEL=qwen2.5 bun examples/02-ollama.ts   # or pick another model
+```
+
+The agent registers as `ollama` and streams the model's answer back token by
+token. Drive it the same way, but point `nats req` at the `ollama` subject:
+
+```sh
+nats req agents.prompt.ollama.<you>.main "Say hello in five words." \
+  --replies=0 --reply-timeout=30s --timeout=60s
+```
+
+Output (one `response` chunk per token, then the terminator):
+
+```
+{"type":"status","data":"ack"}
+{"type":"response","data":"Hello"}
+{"type":"response","data":" there"}
+{"type":"response","data":","}
+...
 (empty terminator)
 ```


### PR DESCRIPTION
## What

Adds `agent-sdk/typescript/examples/02-ollama.ts` — **step 2** of the agent-sdk example ladder, after `01-echo.ts`.

It's deliberately the echo agent with **one thing changed**: the `AgentService` setup, connection resolution, and shutdown are identical; only the `onPrompt` body differs. Instead of a single `echo: <prompt>` reply, it forwards the prompt to a local [Ollama](https://ollama.com) and streams the model's answer back token by token.

```ts
// echo (01):  one reply
await response.send(`echo: ${envelope.prompt}`);

// ollama (02): a stream of replies
for await (const token of ollamaTokens(envelope.prompt)) {
  await response.send(token);
}
```

The single helper, `ollamaTokens()`, is an async generator that hits `/api/generate` with plain `fetch` (**no new dependencies**) and reassembles Ollama's newline-delimited JSON into tokens. The SDK owns stream termination, so the handler just returns when the loop ends.

## Config

- `MODEL` constant, default `llama3.2`, overridable via `OLLAMA_MODEL`
- Host via `OLLAMA_URL` (default `http://localhost:11434`)

## Context

Built as conference-talk material (reThinkConn) demonstrating the Synadia Agent Protocol in three small steps: echo → LLM prompt/response → tool calls. This is step 2; step 3 (tool calls) to follow.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean
- Smoke-tested the streaming/parse path against a real local Ollama — tokens stream and reassemble correctly
- Author confirmed it works end-to-end against the agent

README updated with the new row and a run note. No SDK surface, wire-format, or dependency changes — examples-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)