### PR TITLE
docs(agent-sdk): add tool-call example backed by a NATS microservice

### DIFF
--- a/agent-sdk/typescript/examples/03-tools.ts
+++ b/agent-sdk/typescript/examples/03-tools.ts
@@ -89,10 +89,13 @@ const TOOLS = [
 async function runTool(
   nc: NatsConnection,
   name: string,
-  args: Record<string, unknown>,
+  args: Record<string, unknown> | string,
 ): Promise<string> {
   if (name !== "read_sensor") return `error: unknown tool '${name}'`;
-  const location = typeof args["location"] === "string" ? args["location"] : "";
+  // Most models hand back parsed arguments; some return a JSON string instead.
+  const parsed: Record<string, unknown> =
+    typeof args === "string" ? (JSON.parse(args) as Record<string, unknown>) : args;
+  const location = typeof parsed["location"] === "string" ? parsed["location"] : "";
   const reply = await nc.request(SENSOR_SUBJECT, location, { timeout: 5000 });
   const value = reply.string();
   return value === "unknown" ? `no sensor at '${location}'` : `${location} is ${value}°C`;
@@ -104,7 +107,7 @@ async function runTool(
 interface ChatMessage {
   role: string;
   content: string;
-  tool_calls?: { function: { name: string; arguments: Record<string, unknown> } }[];
+  tool_calls?: { function: { name: string; arguments: Record<string, unknown> | string } }[];
 }
 
 // One non-streamed turn — used for the tool-decision round, where we want a
@@ -139,8 +142,15 @@ async function* chatStream(messages: ChatMessage[]): AsyncGenerator<string> {
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (line.trim() === "") continue;
-      const token = (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
-      if (token) yield token;
+      // One JSON object per line; tolerate a rare non-JSON line (e.g. an error
+      // emitted mid-stream) instead of crashing the whole reply.
+      try {
+        const token =
+          (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
+        if (token) yield token;
+      } catch {
+        /* skip malformed line */
+      }
     }
   }
 }

--- a/agent-sdk/typescript/examples/03-tools.ts
+++ b/agent-sdk/typescript/examples/03-tools.ts
@@ -1,0 +1,213 @@
+// 03-tools.ts — an LLM agent whose tool calls a NATS microservice.
+//
+// Step 3 of the ladder. Example 2 gave the agent a model; this gives it a
+// *tool*, and wires that tool to a NATS microservice. The point of the demo:
+//
+//   any microservice already on your NATS network can become an agent
+//   capability — the agent need not embed the database, device, or
+//   credential that sits behind it.
+//
+// The agent process here holds only an LLM and a NATS connection — it can't
+// read a sensor itself. So when the model needs live data it calls a tool,
+// the tool makes a NATS request, and a microservice answers. That service
+// could run anywhere: another host, a leaf node, a Raspberry Pi wired to a
+// real thermometer. For a self-contained demo we start it in this same file;
+// in production it lives elsewhere and the agent never knows where.
+//
+// Two round-trips with Ollama (`/api/chat` with `tools`):
+//   1. Send the prompt + tool schema; the model replies asking to call
+//      `read_sensor(location)`.
+//   2. We run the tool (a NATS request), feed the result back, and the model
+//      streams its final answer.
+//
+// Prereqs: a local Ollama with a tool-capable model:
+//   ollama pull llama3.1:8b
+//
+// Connection resolution (same as 01/02):
+//   $NATS_CONTEXT > $NATS_URL > nats://127.0.0.1:4222
+
+import { connect as natsConnect, type NatsConnection } from "@nats-io/transport-node";
+import { Svcm, type ServiceMsg } from "@nats-io/services";
+import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
+import { AgentService } from "@synadia-ai/agent-service";
+
+const MODEL = process.env["OLLAMA_MODEL"] ?? "llama3.1:8b";
+const OLLAMA_URL = process.env["OLLAMA_URL"] ?? "http://localhost:11434";
+
+// Subject the sensor microservice listens on. The agent's tool sends requests
+// here; nothing else couples the agent to the service.
+const SENSOR_SUBJECT = "sensors.read";
+
+// ---------------------------------------------------------------------------
+// The microservice — a stand-in for "some service already on your network".
+// Given a location, reply with its current temperature in °C. Backed by a
+// lookup table so the demo is deterministic; swap in a real sensor at will.
+// ---------------------------------------------------------------------------
+const READINGS: Record<string, number> = {
+  "cold-storage-1": 3.4,
+  "cold-storage-2": 2.8,
+  "cold-storage-3": 6.2, // too warm on purpose — gives the agent something to flag
+};
+
+async function startSensorService(nc: NatsConnection): Promise<void> {
+  const service = await new Svcm(nc).add({
+    name: "sensors",
+    version: "0.1.0",
+    description: "Returns the current temperature (°C) for a location",
+  });
+  service.addEndpoint("read", {
+    subject: SENSOR_SUBJECT,
+    handler: (err, msg: ServiceMsg) => {
+      if (err) return;
+      const reading = READINGS[msg.string()]; // request body is the bare location
+      msg.respond(reading === undefined ? "unknown" : String(reading));
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The tool — what we advertise to the model, and what runs when it's called.
+// The handler body is the whole point: one NATS request to the microservice.
+// ---------------------------------------------------------------------------
+const TOOLS = [
+  {
+    type: "function",
+    function: {
+      name: "read_sensor",
+      description: "Read the current temperature in Celsius at a location.",
+      parameters: {
+        type: "object",
+        properties: {
+          location: { type: "string", description: "sensor location, e.g. 'cold-storage-3'" },
+        },
+        required: ["location"],
+      },
+    },
+  },
+];
+
+async function runTool(
+  nc: NatsConnection,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  if (name !== "read_sensor") return `error: unknown tool '${name}'`;
+  const location = typeof args["location"] === "string" ? args["location"] : "";
+  const reply = await nc.request(SENSOR_SUBJECT, location, { timeout: 5000 });
+  const value = reply.string();
+  return value === "unknown" ? `no sensor at '${location}'` : `${location} is ${value}°C`;
+}
+
+// ---------------------------------------------------------------------------
+// Ollama `/api/chat` helpers.
+// ---------------------------------------------------------------------------
+interface ChatMessage {
+  role: string;
+  content: string;
+  tool_calls?: { function: { name: string; arguments: Record<string, unknown> } }[];
+}
+
+// One non-streamed turn — used for the tool-decision round, where we want a
+// clean `tool_calls` array back rather than a token stream.
+async function chat(messages: ChatMessage[]): Promise<ChatMessage> {
+  const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: MODEL, messages, tools: TOOLS, stream: false }),
+  });
+  if (!res.ok) throw new Error(`Ollama chat failed: ${res.status} ${res.statusText}`);
+  return ((await res.json()) as { message: ChatMessage }).message;
+}
+
+// Final turn — stream the model's answer token by token (same NDJSON parsing
+// as 02-ollama, but `/api/chat` carries each token at `message.content`). No
+// tools here: the model has its data and just needs to answer.
+async function* chatStream(messages: ChatMessage[]): AsyncGenerator<string> {
+  const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: MODEL, messages, stream: true }),
+  });
+  if (!res.ok || res.body === null) {
+    throw new Error(`Ollama chat failed: ${res.status} ${res.statusText}`);
+  }
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const bytes of res.body) {
+    buffer += decoder.decode(bytes as Uint8Array, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      const token = (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
+      if (token) yield token;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const opts = process.env["NATS_CONTEXT"]
+    ? await loadContextOptions(process.env["NATS_CONTEXT"])
+    : process.env["NATS_URL"]
+      ? parseNatsUrl(process.env["NATS_URL"])
+      : { servers: "nats://127.0.0.1:4222" };
+  const nc = await natsConnect(opts);
+
+  // Start the microservice the agent's tool will call. In production this is a
+  // separate process somewhere on the network — here it just shares `nc`.
+  await startSensorService(nc);
+
+  const service = new AgentService({
+    nc,
+    agent: "tools",
+    owner: process.env["USER"] ?? "anon",
+    name: "main",
+    description: "LLM agent with a read_sensor tool backed by a NATS microservice",
+  });
+
+  service.onPrompt(async (envelope, response) => {
+    const messages: ChatMessage[] = [{ role: "user", content: envelope.prompt }];
+
+    // Round 1 — does the model want a tool? (non-streamed, for clean tool_calls)
+    const decision = await chat(messages);
+    messages.push(decision);
+
+    // Run whatever tools the model asked for, appending each result to the
+    // conversation. (One round is plenty for this demo; a fuller agent would
+    // loop until the model stops requesting tools.)
+    for (const call of decision.tool_calls ?? []) {
+      const result = await runTool(nc, call.function.name, call.function.arguments);
+      messages.push({ role: "tool", content: result });
+    }
+
+    // No tool needed → round 1 was already the answer.
+    if (!decision.tool_calls?.length) {
+      await response.send(decision.content);
+      return;
+    }
+
+    // Round 2 — the model now has the sensor reading; stream its final answer.
+    for await (const token of chatStream(messages)) {
+      await response.send(token);
+    }
+  });
+
+  await service.start();
+  console.log(`tools agent listening on ${service.subject.prompt}`);
+  console.log(`sensor service on '${SENSOR_SUBJECT}', model '${MODEL}' at ${OLLAMA_URL}`);
+  console.log("press Ctrl+C to stop");
+
+  const shutdown = async (): Promise<void> => {
+    console.log("\nshutting down…");
+    await service.stop();
+    await nc.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}
+
+void main().catch((err: unknown) => {
+  console.error("tools agent failed:", err);
+  process.exit(1);
+});

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -83,21 +83,34 @@ Output (one `response` chunk per token, then the terminator):
 
 ### `03-tools.ts` — give the agent a tool backed by a microservice
 
-The agent gains a `read_sensor` tool, and that tool is wired to a NATS
-microservice. The agent holds only an LLM and a NATS connection — when the
-model needs live data it calls the tool, the tool makes a NATS request, and a
-microservice answers. For a self-contained demo the service (a faked
-temperature sensor) is started in the same file; in production it runs anywhere
-on your network.
+The agent gains a `read_sensor` **tool**, and that tool is wired to a NATS
+microservice. This is the whole point in one file:
 
-Needs a tool-capable model:
+> any microservice already on your NATS network can become an agent
+> capability — the agent need not embed the database, device, or credential
+> that sits behind it.
+
+The agent here holds only an LLM and a NATS connection; it can't read a sensor
+itself. When the model needs live data it calls the tool, the tool makes a
+single `nc.request(...)`, and a microservice answers. That service could run
+anywhere — another host, a leaf node, a Raspberry Pi wired to a real
+thermometer. For a self-contained demo it's faked in the same file; in
+production it runs elsewhere and the agent never knows where.
+
+It uses Ollama's `/api/chat` tool-calling in two round-trips: first the model
+asks to call `read_sensor(location)`, then — once we feed the reading back — it
+streams its final answer.
+
+Needs a tool-capable model. `llama3.1:8b` is the default; `gemma`-family models
+don't do native tool-calls, and `qwen3` works but clutters the output with
+`<think>` blocks:
 
 ```sh
 ollama pull llama3.1:8b
 bun examples/03-tools.ts
 ```
 
-Ask it something that needs the sensor:
+Then ask it something that needs the sensor:
 
 ```sh
 nats req agents.prompt.tools.<you>.main \
@@ -116,6 +129,16 @@ the temperature, and the agent streams its verdict:
 (empty terminator)
 ```
 
-Run `nats micro ls` while it's up to see both services on the bus — the
-`agents` service (the agent) and the `sensors` service (the microservice it
-calls).
+The faked service answers from a small lookup table. Room 3 is deliberately too
+warm, so the agent has something to flag — swap in room 1 or 2 to see it answer
+"yes":
+
+| Location         | Temperature | Within range (below 4°C)? |
+| ---------------- | ----------- | ------------------------- |
+| `cold-storage-1` | 3.4°C       | yes                       |
+| `cold-storage-2` | 2.8°C       | yes                       |
+| `cold-storage-3` | 6.2°C       | no — too warm             |
+
+While the agent runs, `nats micro ls` shows both services registered on the bus
+side by side — the `agents` service (the agent itself) and the `sensors`
+service (the microservice its tool calls).

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -5,10 +5,11 @@ speaking the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/syn
 Counterpart to the caller-side numbered demos in
 [`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/).
 
-| Example                        | What it shows                                                                              |
-| ------------------------------ | ------------------------------------------------------------------------------------------ |
-| [`01-echo.ts`](01-echo.ts)     | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`.                    |
-| [`02-ollama.ts`](02-ollama.ts) | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply. |
+| Example                        | What it shows                                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| [`01-echo.ts`](01-echo.ts)     | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`.                         |
+| [`02-ollama.ts`](02-ollama.ts) | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply.      |
+| [`03-tools.ts`](03-tools.ts)   | Gives the LLM a `read_sensor` tool wired to a NATS microservice, then reasons over the reading. |
 
 ## Run
 
@@ -79,3 +80,42 @@ Output (one `response` chunk per token, then the terminator):
 ...
 (empty terminator)
 ```
+
+### `03-tools.ts` — give the agent a tool backed by a microservice
+
+The agent gains a `read_sensor` tool, and that tool is wired to a NATS
+microservice. The agent holds only an LLM and a NATS connection — when the
+model needs live data it calls the tool, the tool makes a NATS request, and a
+microservice answers. For a self-contained demo the service (a faked
+temperature sensor) is started in the same file; in production it runs anywhere
+on your network.
+
+Needs a tool-capable model:
+
+```sh
+ollama pull llama3.1:8b
+bun examples/03-tools.ts
+```
+
+Ask it something that needs the sensor:
+
+```sh
+nats req agents.prompt.tools.<you>.main \
+  "Is cold-storage room 3 within the safe range (below 4°C)?" \
+  --replies=0 --reply-timeout=45s --timeout=90s
+```
+
+The model calls `read_sensor("cold-storage-3")`, the microservice replies with
+the temperature, and the agent streams its verdict:
+
+```
+{"type":"status","data":"ack"}
+{"type":"response","data":"No"}
+{"type":"response","data":", the"}
+... cold-storage room 3 is not within the safe range ...
+(empty terminator)
+```
+
+Run `nats micro ls` while it's up to see both services on the bus — the
+`agents` service (the agent) and the `sensors` service (the microservice it
+calls).


### PR DESCRIPTION
## What

Adds `agent-sdk/typescript/examples/03-tools.ts` — **step 3** of the agent-sdk example ladder (`01-echo` → `02-ollama` → `03-tools`).

The agent gains a `read_sensor` **tool**, and that tool is wired to a **NATS microservice**. The point of the example:

> any microservice already on your NATS network can become an agent capability — without the agent embedding the device, database, or credential behind it.

The agent process holds only an LLM + a NATS connection. When the model needs live data it calls the tool; the tool's entire handler is one `nc.request(...)` to the microservice. For a self-contained single-file demo, the microservice (a faked temperature sensor) is registered in the same file — in production it runs anywhere on the network and the agent never knows where.

```ts
// the tool handler — this one line is the whole lesson:
const reply = await nc.request(SENSOR_SUBJECT, location, { timeout: 5000 });
```

## How it works

Ollama `/api/chat` tool-calling in the canonical two round-trips:
1. **Round 1** (non-streamed) — send the prompt + tool schema; the model asks to call `read_sensor(location)`.
2. Run the tool (the NATS request), feed the result back.
3. **Round 2** (streamed) — the model streams its final answer, reusing the exact token-streaming shape from `02-ollama.ts`.

Default model `llama3.1:8b` (tool-capable), overridable via `OLLAMA_MODEL`; host via `OLLAMA_URL`.

## Verification

Full end-to-end run against a local `nats-server` + Ollama:
- `nats micro ls` shows **both** services on the bus — `agents` (the agent) and `sensors` (the microservice it calls).
- A real prompt drove the complete path: `ack` → tool decision → NATS request to the sensor → streamed verdict (*"No, the cold storage room 3 is not within the safe range…"*).
- `typecheck`, `lint`, `format:check` all clean; both SDKs build.

README updated with the new row and a run section (including a `nats micro ls` tip).

## Context

Conference-talk material (reThinkConn) demonstrating the Synadia Agent Protocol in three small steps. This is the final step — giving an agent access to existing NATS microservices as tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)