### PR TITLE
feat: add Flue NATS channel adapter

### DIFF
--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -1,8 +1,30 @@
 # Flue NATS channel
 
-TypeScript sidecar that exposes a running Flue attached agent as a Synadia Agent Protocol for NATS agent.
+TypeScript sidecar that exposes a running Flue agent as a Synadia Agent Protocol for NATS agent.
 
-This package is intentionally Bun-first for local commands. Flue's `--target node` flag is a Flue server compatibility target for the attached HTTP/WebSocket surface, not a preference for npm/Node tooling.
+The sidecar sits between Synadia/NATS callers and Flue:
+
+```text
+Synadia client / nats req
+  → NATS
+  → AgentService
+  → agents/flue sidecar
+  → @flue/sdk
+  → running Flue app / agent
+```
+
+This package is intentionally **Bun-first** for local commands. Flue's `--target node` flag is a Flue server compatibility target for the attached HTTP/WebSocket surface, not a preference for npm/Node tooling.
+
+## Status and defaults
+
+- Host-side protocol SDK: `AgentService` from `@synadia-ai/agent-service`.
+- No hand-rolled Synadia Agent Protocol subject plumbing.
+- Default Flue transport: `http-stream`.
+- `websocket` is available as an explicit diagnostic option only.
+- Attachments are rejected (`attachmentsOk: false`).
+- NATS auth supports either a NATS context or URL mode with optional creds file.
+
+`http-stream` is the default because the real Flue faux-echo smoke test verified it against a live Flue dev server. Flue 0.9.1's local Node WebSocket path returned server-side 500s during verification, so WebSocket is not the safe default.
 
 ## Install
 
@@ -11,31 +33,104 @@ cd agents/flue
 bun install
 ```
 
-## Configure
+## Configuration model
 
-Print a TOML template:
+The sidecar can be configured by CLI flags, environment variables, or a small TOML file.
+
+Precedence is:
+
+```text
+CLI flags > environment variables > config file > defaults
+```
+
+Default config path:
+
+```text
+~/.config/synadia/flue-nats-channel.toml
+```
+
+Print a template:
 
 ```bash
 bun src/cli.ts configure --print-template
 ```
 
-Core precedence is CLI flags, then environment variables, then config file, then defaults. NATS contexts are preferred when you already manage auth with the `nats` CLI; otherwise use `--nats-url`/`NATS_URL` plus `--nats-creds`/`NATS_CREDS` for a credentials file.
+Template:
 
-Environment variables:
+```toml
+[nats]
+url = "nats://127.0.0.1:4222"
+context = "local"
+creds = "/path/to/user.creds"
 
-- `NATS_URL`
-- `NATS_CONTEXT`
-- `NATS_CREDS` / `NATS_CREDENTIALS`
-- `SYNADIA_FLUE_OWNER`
-- `SYNADIA_FLUE_NAME`
-- `SYNADIA_FLUE_CONFIG`
-- `FLUE_BASE_URL`
-- `FLUE_AGENT`
-- `FLUE_INSTANCE`
-- `FLUE_SESSION`
-- `FLUE_TRANSPORT`
+[agent]
+owner = "rene"
+name = "support"
+subject_token = "flue"
+heartbeat_interval_s = 30
+keepalive_interval_s = 30
 
-## Run
+[flue]
+base_url = "http://127.0.0.1:3583"
+agent = "assistant"
+instance = "customer-123"
+session = "ticket-123"
+transport = "http-stream"
+```
+
+### NATS settings
+
+| Field | CLI | Environment | TOML | Notes |
+|---|---|---|---|---|
+| URL | `--nats-url` | `NATS_URL` | `[nats].url` | Defaults to `nats://127.0.0.1:4222`. |
+| Context | `--nats-context` | `NATS_CONTEXT` | `[nats].context` | Preferred when auth is managed by the `nats` CLI. |
+| Creds | `--nats-creds` | `NATS_CREDS` / `NATS_CREDENTIALS` | `[nats].creds` | Used in URL mode via `credsAuthenticator`. |
+
+If `context` is set, the NATS CLI context is used and carries its own auth. If URL mode is used and `creds` is set, the sidecar wires the creds file into the NATS connection authenticator.
+
+Never commit real creds files or seed-shaped dummy values. Tests deliberately use non-secret-shaped fixture text.
+
+### Agent settings
+
+| Field | CLI | Environment | TOML | Notes |
+|---|---|---|---|---|
+| Owner | `--owner` | `SYNADIA_FLUE_OWNER` | `[agent].owner` | Subject owner token; defaults to `$USER` or `unknown`. |
+| Name | `--name` | `SYNADIA_FLUE_NAME` | `[agent].name` | Agent service name; defaults to `main`. |
+| Subject token | `--subject-token` | — | `[agent].subject_token` | Protocol subject token; defaults to `flue`. |
+| Heartbeat | `--heartbeat-interval-s` | — | `[agent].heartbeat_interval_s` | Defaults to `30`. |
+| Keepalive | `--keepalive-interval-s` | — | `[agent].keepalive_interval_s` | Defaults to `30`. |
+
+Subject tokens are sanitized to the protocol-safe character set.
+
+### Flue settings
+
+| Field | CLI | Environment | TOML | Notes |
+|---|---|---|---|---|
+| Base URL | `--flue-base-url` | `FLUE_BASE_URL` | `[flue].base_url` | Defaults to `http://127.0.0.1:3583`. |
+| Agent | `--flue-agent` | `FLUE_AGENT` | `[flue].agent` | Flue agent name, e.g. `assistant` or `echo`. |
+| Instance | `--flue-instance` | `FLUE_INSTANCE` | `[flue].instance` | Flue instance identifier. |
+| Session | `--flue-session` | `FLUE_SESSION` | `[flue].session` | Flue session identifier. |
+| Transport | `--flue-transport` | `FLUE_TRANSPORT` | `[flue].transport` | `http-stream`, `http-sync`, or `websocket`. Defaults to `http-stream`. |
+
+## Run with a NATS context
+
+Use this when your local or deployment environment already manages NATS auth through the `nats` CLI.
+
+```bash
+bun src/cli.ts start \
+  --nats-context local \
+  --owner rene \
+  --name support \
+  --subject-token flue \
+  --flue-base-url http://127.0.0.1:3583 \
+  --flue-agent assistant \
+  --flue-instance customer-123 \
+  --flue-session ticket-123
+```
+
+## Run with URL + creds file
+
+Use this when you want the sidecar to connect directly to a NATS URL with a creds file.
 
 ```bash
 bun src/cli.ts start \
@@ -50,33 +145,169 @@ bun src/cli.ts start \
   --flue-session ticket-123
 ```
 
+Expected startup output:
+
+```text
+flue agent listening on agents.prompt.flue.<owner>.<name>
+press Ctrl+C to stop
+```
+
+For example, `--subject-token flue --owner rene --name support` listens on:
+
+```text
+agents.prompt.flue.rene.support
+```
+
 The sidecar registers a Synadia `AgentService` with:
 
 - `agent: "flue"`
-- `subjectToken: "flue"`
+- configured owner/name/subject token
 - `attachmentsOk: false`
 - metadata describing the configured Flue target
 
-The default transport is `http-stream`. It invokes Flue's real HTTP streaming path, maps Flue `text_delta` events into Synadia `response` chunks as they arrive, and lets `AgentService` handle ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination. `websocket` remains an explicit diagnostic option only; Flue 0.9.1's Node/local WebSocket upgrade path returned server-side 500s on both the Mac mini and M3 Max during verification. No hand-rolled protocol service plumbing lives here.
+`AgentService` handles ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination.
 
 ## Doctor
 
+Run a local diagnostic before starting or before filing a bug:
+
 ```bash
-bun src/cli.ts doctor --flue-base-url http://127.0.0.1:3583
+bun src/cli.ts doctor \
+  --flue-base-url http://127.0.0.1:3583 \
+  --flue-agent echo \
+  --flue-instance real-smoke-dev \
+  --owner rs \
+  --name main
 ```
 
+Expected reachable-Flue output can include HTTP `405`:
+
+```text
+ok	config	agent flue/rs/main
+ok	flue-http	http://127.0.0.1:3583/agents/echo/real-smoke-dev returned HTTP 405 (reachable; GET probe method unsupported)
+```
+
+That `405` means the Flue server is reachable but does not accept the doctor's GET probe method at that agent route. It is not a connectivity failure.
+
 ## Verification
+
+Run the full local ladder before PR handoff:
 
 ```bash
 bun run typecheck
 bun test
+bun run smoke:protocol
+FLUE_BASE_URL=http://127.0.0.1:3583 \
+FLUE_AGENT=echo \
+FLUE_INSTANCE=real-smoke-dev \
+FLUE_SESSION=real-smoke-dev \
+SMOKE_PROMPT=hello-real-flow \
+SMOKE_EXPECTS=echo:hello-real-flow \
+bun run smoke:real-flue
 ```
 
-If `nats-server` is available locally, run a protocol smoke test with a fake Flue client and real NATS broker:
+### Protocol smoke
+
+`smoke:protocol` uses a real local NATS broker and an injected fake Flue client. It verifies the Synadia side: subject shape, discovery, ack, status, response, and terminator behavior.
+
+Start NATS first if it is not already running:
 
 ```bash
 nats-server -p 4222
 bun run smoke:protocol
 ```
 
-The smoke test verifies the protocol stream includes the leading `ack`, a Flue bridge status chunk, a response chunk, and the final SDK `done` terminator status.
+Expected message shape:
+
+```json
+[
+  { "type": "status", "status": "ack" },
+  { "type": "status", "status": "connected to Flue assistant/fake-instance via http-stream" },
+  { "type": "response", "text": "fake Flue response to hello smoke for assistant/fake-instance/smoke-session" },
+  { "type": "status", "status": "done" }
+]
+```
+
+### Real Flue faux-echo smoke
+
+`smoke:real-flue` exercises the real Flue runtime boundary without using a paid or nondeterministic LLM. The project-level testing docs describe the local probe app in detail, but the short version is:
+
+1. Start NATS on `4222`.
+2. Start a Flue dev server on `3583` with an `echo` agent backed by the Flue faux provider.
+3. Run `bun run smoke:real-flue` with `SMOKE_EXPECTS=echo:hello-real-flow`.
+
+Expected response:
+
+```json
+{ "type": "response", "text": "echo:hello-real-flow" }
+```
+
+The real-Flue smoke is not optional theater. The first real-runtime probe caught the WebSocket compatibility failure that the mock-only smoke could not see.
+
+## Troubleshooting
+
+### `doctor` reports HTTP 405
+
+This is okay for the current Flue agent route GET probe. Treat it as reachable-method-unsupported unless the smoke test also fails.
+
+### WebSocket fails with `Flue WebSocket connection failed`
+
+Use `http-stream`. WebSocket remains diagnostic-only until the Flue local Node WebSocket upgrade failure is fixed upstream or proven deployment-specific.
+
+### NATS connection fails with creds
+
+Check whether you are using context mode or URL mode:
+
+- context mode: `--nats-context` / `NATS_CONTEXT`; auth comes from the NATS context.
+- URL mode: `--nats-url` plus optional `--nats-creds`; creds are wired through `credsAuthenticator`.
+
+If both context and URL are configured, context mode wins.
+
+### Environment overrides do not seem to work
+
+Remember the precedence rule:
+
+```text
+CLI > environment > config file > defaults
+```
+
+For owner specifically:
+
+```text
+--owner > SYNADIA_FLUE_OWNER > [agent].owner > USER/default
+```
+
+### Attachments fail
+
+Expected. The adapter currently rejects attachments explicitly because the Flue prompt bridge only maps text prompts.
+
+## Limitations
+
+- Text prompts only; attachments are not supported.
+- One configured Flue target per sidecar process.
+- WebSocket transport is diagnostic-only in the verified local Flue 0.9.1 setup.
+- Real-Flue smoke uses a local faux echo agent; it proves runtime/SDK compatibility, not LLM quality.
+- NATS contexts and URL+creds are supported; do not commit actual credentials or seed-shaped test material.
+
+## Current verified state
+
+Last verified before Phase 6 docs handoff:
+
+```text
+bun run typecheck
+PASS
+
+bun test
+19 pass
+0 fail
+42 expect() calls
+
+bun run smoke:protocol
+PASS
+
+bun run smoke:real-flue
+PASS — echo:hello-real-flow
+
+bun src/cli.ts doctor ...
+PASS — Flue HTTP 405 treated as reachable-method-unsupported
+```

--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -1,0 +1,80 @@
+# Flue NATS channel
+
+TypeScript sidecar that exposes a running Flue attached agent as a Synadia Agent Protocol for NATS agent.
+
+This package is intentionally Bun-first for local commands. Flue's `--target node` flag is a Flue server compatibility target for the attached HTTP/WebSocket surface, not a preference for npm/Node tooling.
+
+## Install
+
+```bash
+cd agents/flue
+bun install
+```
+
+## Configure
+
+Print a TOML template:
+
+```bash
+bun src/cli.ts configure --print-template
+```
+
+Core precedence is CLI flags, then environment variables, then config file, then defaults.
+
+Environment variables:
+
+- `NATS_URL`
+- `NATS_CONTEXT`
+- `SYNADIA_FLUE_OWNER`
+- `SYNADIA_FLUE_NAME`
+- `SYNADIA_FLUE_CONFIG`
+- `FLUE_BASE_URL`
+- `FLUE_AGENT`
+- `FLUE_INSTANCE`
+- `FLUE_SESSION`
+- `FLUE_TRANSPORT`
+
+## Run
+
+```bash
+bun src/cli.ts start \
+  --nats-url nats://127.0.0.1:4222 \
+  --owner rene \
+  --name support \
+  --subject-token flue \
+  --flue-base-url http://127.0.0.1:3583 \
+  --flue-agent assistant \
+  --flue-instance customer-123 \
+  --flue-session ticket-123
+```
+
+The sidecar registers a Synadia `AgentService` with:
+
+- `agent: "flue"`
+- `subjectToken: "flue"`
+- `attachmentsOk: false`
+- metadata describing the configured Flue target
+
+The v1 transport opens a Flue SDK attached-agent connection per prompt, emits lifecycle status chunks, sends one final response chunk, and lets `AgentService` handle ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination. No hand-rolled protocol service plumbing lives here.
+
+## Doctor
+
+```bash
+bun src/cli.ts doctor --flue-base-url http://127.0.0.1:3583
+```
+
+## Verification
+
+```bash
+bun run typecheck
+bun test
+```
+
+If `nats-server` is available locally, run a protocol smoke test with a fake Flue client and real NATS broker:
+
+```bash
+nats-server -p 4222
+bun run smoke:protocol
+```
+
+The smoke test verifies the protocol stream includes the leading `ack`, a Flue bridge status chunk, a response chunk, and the final SDK `done` terminator status.

--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -55,7 +55,7 @@ The sidecar registers a Synadia `AgentService` with:
 - `attachmentsOk: false`
 - metadata describing the configured Flue target
 
-The v1 transport opens a Flue SDK attached-agent connection per prompt, emits lifecycle status chunks, sends one final response chunk, and lets `AgentService` handle ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination. No hand-rolled protocol service plumbing lives here.
+The default transport is `http-stream`. It invokes Flue's real HTTP streaming path, maps Flue `text_delta` events into Synadia `response` chunks as they arrive, and lets `AgentService` handle ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination. `websocket` remains an explicit diagnostic option only; Flue 0.9.1's Node/local WebSocket upgrade path returned server-side 500s on both the Mac mini and M3 Max during verification. No hand-rolled protocol service plumbing lives here.
 
 ## Doctor
 

--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -1,47 +1,77 @@
-# Flue NATS channel
+# Flue NATS Channel
 
-TypeScript sidecar that exposes a running Flue agent as a Synadia Agent Protocol for NATS agent.
+Expose a running [Flue](https://flueframework.com/) agent as a [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) host.
 
-The sidecar sits between Synadia/NATS callers and Flue:
+Every running sidecar instance registers one configured Flue target as a NATS micro service. Protocol callers can discover it, send prompts, receive streamed response chunks, and monitor liveness through the standard `status` and heartbeat surfaces.
 
 ```text
-Synadia client / nats req
+Synadia Agent Protocol caller
   → NATS
-  → AgentService
-  → agents/flue sidecar
+  → Flue NATS Channel
   → @flue/sdk
   → running Flue app / agent
 ```
 
-This package is intentionally **Bun-first** for local commands. Flue's `--target node` flag is a Flue server compatibility target for the attached HTTP/WebSocket surface, not a preference for npm/Node tooling.
+This package is a narrow channel wrapper for Flue. It is not a generic NATS toolkit, a Flue fork, or an LLM provider.
 
-## Status and defaults
+## Prerequisites
 
-- Host-side protocol SDK: `AgentService` from `@synadia-ai/agent-service`.
-- No hand-rolled Synadia Agent Protocol subject plumbing.
-- Default Flue transport: `http-stream`.
-- `websocket` is available as an explicit diagnostic option only.
-- Attachments are rejected (`attachmentsOk: false`).
-- NATS auth supports either a NATS context or URL mode with optional creds file.
-
-`http-stream` is the default because the real Flue faux-echo smoke test verified it against a live Flue dev server. Flue 0.9.1's local Node WebSocket path returned server-side 500s during verification, so WebSocket is not the safe default.
+- [Bun](https://bun.sh/) for local commands.
+- A reachable NATS server, or a NATS CLI context.
+- A running Flue app with an agent reachable through the Flue SDK HTTP surface.
 
 ## Install
+
+From this monorepo:
 
 ```bash
 cd agents/flue
 bun install
 ```
 
-## Configuration model
+## Quickstart
 
-The sidecar can be configured by CLI flags, environment variables, or a small TOML file.
+Start NATS and a Flue app first, then run the sidecar:
 
-Precedence is:
+```bash
+bun src/cli.ts start \
+  --nats-url nats://127.0.0.1:4222 \
+  --owner acme \
+  --name support \
+  --subject-token flue \
+  --flue-base-url http://127.0.0.1:3583 \
+  --flue-agent assistant \
+  --flue-instance customer-123 \
+  --flue-session ticket-123
+```
+
+Expected startup output:
 
 ```text
-CLI flags > environment variables > config file > defaults
+flue agent listening on agents.prompt.flue.<owner>.<name>
+press Ctrl+C to stop
 ```
+
+With the quickstart values above, callers use:
+
+```text
+agents.prompt.flue.acme.support
+agents.status.flue.acme.support
+agents.hb.flue.acme.support
+```
+
+Only `prompt` forwards work to Flue. `status` and `hb` are sidecar-owned protocol liveness surfaces.
+
+## Configuration
+
+The sidecar can be configured with CLI flags, environment variables, or a TOML file.
+
+Effective precedence is:
+
+1. CLI flags
+2. Environment variables
+3. TOML config file
+4. Built-in defaults
 
 Default config path:
 
@@ -64,7 +94,7 @@ context = "local"
 creds = "/path/to/user.creds"
 
 [agent]
-owner = "rene"
+owner = "acme"
 name = "support"
 subject_token = "flue"
 heartbeat_interval_s = 30
@@ -80,46 +110,58 @@ transport = "http-stream"
 
 ### NATS settings
 
-| Field | CLI | Environment | TOML | Notes |
-|---|---|---|---|---|
-| URL | `--nats-url` | `NATS_URL` | `[nats].url` | Defaults to `nats://127.0.0.1:4222`. |
-| Context | `--nats-context` | `NATS_CONTEXT` | `[nats].context` | Preferred when auth is managed by the `nats` CLI. |
-| Creds | `--nats-creds` | `NATS_CREDS` / `NATS_CREDENTIALS` | `[nats].creds` | Used in URL mode via `credsAuthenticator`. |
+| Field | CLI | Environment | TOML | Default | Notes |
+| --- | --- | --- | --- | --- | --- |
+| URL | `--nats-url` | `NATS_URL` | `[nats].url` | `nats://127.0.0.1:4222` | Direct NATS server URL. |
+| Context | `--nats-context` | `NATS_CONTEXT` | `[nats].context` | — | NATS CLI context name. If set, context mode is used. |
+| Creds | `--nats-creds` | `NATS_CREDS` / `NATS_CREDENTIALS` | `[nats].creds` | — | Creds file for URL mode. |
 
-If `context` is set, the NATS CLI context is used and carries its own auth. If URL mode is used and `creds` is set, the sidecar wires the creds file into the NATS connection authenticator.
+If `context` is set, connection details and auth come from the NATS CLI context. If URL mode is used and `creds` is set, the sidecar uses the creds file when opening the NATS connection.
 
-Never commit real creds files or seed-shaped dummy values. Tests deliberately use non-secret-shaped fixture text.
+Do not commit real credentials. Prefer contexts or environment-managed secret paths for deployments.
 
 ### Agent settings
 
-| Field | CLI | Environment | TOML | Notes |
-|---|---|---|---|---|
-| Owner | `--owner` | `SYNADIA_FLUE_OWNER` | `[agent].owner` | Subject owner token; defaults to `$USER` or `unknown`. |
-| Name | `--name` | `SYNADIA_FLUE_NAME` | `[agent].name` | Agent service name; defaults to `main`. |
-| Subject token | `--subject-token` | — | `[agent].subject_token` | Protocol subject token; defaults to `flue`. |
-| Heartbeat | `--heartbeat-interval-s` | — | `[agent].heartbeat_interval_s` | Defaults to `30`. |
-| Keepalive | `--keepalive-interval-s` | — | `[agent].keepalive_interval_s` | Defaults to `30`. |
+| Field | CLI | Environment | TOML | Default | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Owner | `--owner` | `SYNADIA_FLUE_OWNER` | `[agent].owner` | `$USER` or `unknown` | Fourth token in `agents.prompt.<agent>.<owner>.<session>`. |
+| Name | `--name` | `SYNADIA_FLUE_NAME` | `[agent].name` | `main` | Fifth token in `agents.prompt.<agent>.<owner>.<session>`. |
+| Subject token | `--subject-token` | — | `[agent].subject_token` | `flue` | Third token in `agents.prompt.<agent>.<owner>.<session>`. |
+| Heartbeat interval | `--heartbeat-interval-s` | — | `[agent].heartbeat_interval_s` | `30` | Seconds between heartbeat publications. |
+| Keepalive interval | `--keepalive-interval-s` | — | `[agent].keepalive_interval_s` | `30` | Seconds between in-flight keepalive chunks. |
 
 Subject tokens are sanitized to the protocol-safe character set.
 
 ### Flue settings
 
-| Field | CLI | Environment | TOML | Notes |
-|---|---|---|---|---|
-| Base URL | `--flue-base-url` | `FLUE_BASE_URL` | `[flue].base_url` | Defaults to `http://127.0.0.1:3583`. |
-| Agent | `--flue-agent` | `FLUE_AGENT` | `[flue].agent` | Flue agent name, e.g. `assistant` or `echo`. |
-| Instance | `--flue-instance` | `FLUE_INSTANCE` | `[flue].instance` | Flue instance identifier. |
-| Session | `--flue-session` | `FLUE_SESSION` | `[flue].session` | Flue session identifier. |
-| Transport | `--flue-transport` | `FLUE_TRANSPORT` | `[flue].transport` | `http-stream`, `http-sync`, or `websocket`. Defaults to `http-stream`. |
+| Field | CLI | Environment | TOML | Default | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Base URL | `--flue-base-url` | `FLUE_BASE_URL` | `[flue].base_url` | `http://127.0.0.1:3583` | Flue app base URL. |
+| Agent | `--flue-agent` | `FLUE_AGENT` | `[flue].agent` | `assistant` | Flue agent name. |
+| Instance | `--flue-instance` | `FLUE_INSTANCE` | `[flue].instance` | `default` | Flue instance identifier. |
+| Session | `--flue-session` | `FLUE_SESSION` | `[flue].session` | `default` | Flue session identifier sent in the prompt payload. |
+| Transport | `--flue-transport` | `FLUE_TRANSPORT` | `[flue].transport` | `http-stream` | `http-stream`, `http-sync`, or `websocket`. |
+
+`http-stream` is the default transport. Use `http-sync` when you want a single final response. `websocket` is available for deployments that support Flue's WebSocket agent connection path.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `bun src/cli.ts configure --print-template` | Print a TOML config template. |
+| `bun src/cli.ts doctor` | Validate resolved config and probe Flue reachability. |
+| `bun src/cli.ts start` | Start the long-running NATS channel sidecar. |
+
+All commands accept the same config override flags.
 
 ## Run with a NATS context
 
-Use this when your local or deployment environment already manages NATS auth through the `nats` CLI.
+Use this when your environment already manages NATS auth through the `nats` CLI:
 
 ```bash
 bun src/cli.ts start \
-  --nats-context local \
-  --owner rene \
+  --nats-context prod \
+  --owner acme \
   --name support \
   --subject-token flue \
   --flue-base-url http://127.0.0.1:3583 \
@@ -130,13 +172,13 @@ bun src/cli.ts start \
 
 ## Run with URL + creds file
 
-Use this when you want the sidecar to connect directly to a NATS URL with a creds file.
+Use this when the sidecar should connect directly to a NATS URL with a creds file:
 
 ```bash
 bun src/cli.ts start \
   --nats-url nats://127.0.0.1:4222 \
   --nats-creds /path/to/user.creds \
-  --owner rene \
+  --owner acme \
   --name support \
   --subject-token flue \
   --flue-base-url http://127.0.0.1:3583 \
@@ -145,121 +187,76 @@ bun src/cli.ts start \
   --flue-session ticket-123
 ```
 
-Expected startup output:
-
-```text
-flue agent listening on agents.prompt.flue.<owner>.<name>
-press Ctrl+C to stop
-```
-
-For example, `--subject-token flue --owner rene --name support` listens on:
-
-```text
-agents.prompt.flue.rene.support
-```
-
-The sidecar registers a Synadia `AgentService` with:
-
-- `agent: "flue"`
-- configured owner/name/subject token
-- `attachmentsOk: false`
-- metadata describing the configured Flue target
-
-`AgentService` handles ack, keepalive, error mapping, heartbeat/status endpoints, and stream termination.
-
 ## Doctor
 
-Run a local diagnostic before starting or before filing a bug:
+Run a diagnostic before starting the sidecar or filing a bug:
 
 ```bash
 bun src/cli.ts doctor \
   --flue-base-url http://127.0.0.1:3583 \
   --flue-agent echo \
-  --flue-instance real-smoke-dev \
-  --owner rs \
-  --name main
+  --flue-instance demo \
+  --owner acme \
+  --name support
 ```
 
-Expected reachable-Flue output can include HTTP `405`:
+Example output for a reachable Flue app:
 
 ```text
-ok	config	agent flue/rs/main
-ok	flue-http	http://127.0.0.1:3583/agents/echo/real-smoke-dev returned HTTP 405 (reachable; GET probe method unsupported)
+ok	config	agent flue/acme/support
+ok	flue-http	http://127.0.0.1:3583/agents/echo/demo returned HTTP 405 (reachable; GET probe method unsupported)
 ```
 
-That `405` means the Flue server is reachable but does not accept the doctor's GET probe method at that agent route. It is not a connectivity failure.
+HTTP `405` means the Flue server is reachable but does not accept the doctor's GET probe method at that agent route. It is not a connectivity failure.
 
-## Verification
+## Testing
 
-Run the full local ladder before PR handoff:
+Run the package checks:
 
 ```bash
 bun run typecheck
 bun test
-bun run smoke:protocol
-FLUE_BASE_URL=http://127.0.0.1:3583 \
-FLUE_AGENT=echo \
-FLUE_INSTANCE=real-smoke-dev \
-FLUE_SESSION=real-smoke-dev \
-SMOKE_PROMPT=hello-real-flow \
-SMOKE_EXPECTS=echo:hello-real-flow \
-bun run smoke:real-flue
 ```
 
-### Protocol smoke
-
-`smoke:protocol` uses a real local NATS broker and an injected fake Flue client. It verifies the Synadia side: subject shape, discovery, ack, status, response, and terminator behavior.
-
-Start NATS first if it is not already running:
+Run a protocol smoke test against a local NATS server:
 
 ```bash
 nats-server -p 4222
 bun run smoke:protocol
 ```
 
-Expected message shape:
+`smoke:protocol` uses a real local NATS broker and an injected Flue client. It verifies discovery, prompt routing, ack, status, response chunks, and stream termination.
 
-```json
-[
-  { "type": "status", "status": "ack" },
-  { "type": "status", "status": "connected to Flue assistant/fake-instance via http-stream" },
-  { "type": "response", "text": "fake Flue response to hello smoke for assistant/fake-instance/smoke-session" },
-  { "type": "status", "status": "done" }
-]
+Run a real Flue smoke test when you have a Flue dev server with a deterministic echo-style agent available:
+
+```bash
+FLUE_BASE_URL=http://127.0.0.1:3583 \
+FLUE_AGENT=echo \
+FLUE_INSTANCE=demo \
+FLUE_SESSION=demo \
+SMOKE_PROMPT=hello \
+SMOKE_EXPECTS=echo:hello \
+bun run smoke:real-flue
 ```
 
-### Real Flue faux-echo smoke
-
-`smoke:real-flue` exercises the real Flue runtime boundary without using a paid or nondeterministic LLM. The project-level testing docs describe the local probe app in detail, but the short version is:
-
-1. Start NATS on `4222`.
-2. Start a Flue dev server on `3583` with an `echo` agent backed by the Flue faux provider.
-3. Run `bun run smoke:real-flue` with `SMOKE_EXPECTS=echo:hello-real-flow`.
-
-Expected response:
-
-```json
-{ "type": "response", "text": "echo:hello-real-flow" }
-```
-
-The real-Flue smoke is not optional theater. The first real-runtime probe caught the WebSocket compatibility failure that the mock-only smoke could not see.
+`smoke:real-flue` exercises the real `@flue/sdk` and Flue runtime boundary over NATS. The smoke test concatenates streamed response chunks before checking `SMOKE_EXPECTS`, so chunk boundaries do not need to match the expected text exactly.
 
 ## Troubleshooting
 
 ### `doctor` reports HTTP 405
 
-This is okay for the current Flue agent route GET probe. Treat it as reachable-method-unsupported unless the smoke test also fails.
+Treat this as reachable-method-unsupported unless prompt smokes also fail.
 
 ### WebSocket fails with `Flue WebSocket connection failed`
 
-Use `http-stream`. WebSocket remains diagnostic-only until the Flue local Node WebSocket upgrade failure is fixed upstream or proven deployment-specific.
+Use `http-stream` or `http-sync` unless your Flue deployment supports WebSocket agent connections.
 
 ### NATS connection fails with creds
 
 Check whether you are using context mode or URL mode:
 
-- context mode: `--nats-context` / `NATS_CONTEXT`; auth comes from the NATS context.
-- URL mode: `--nats-url` plus optional `--nats-creds`; creds are wired through `credsAuthenticator`.
+- Context mode: `--nats-context` / `NATS_CONTEXT`; auth comes from the NATS context.
+- URL mode: `--nats-url` plus optional `--nats-creds`; creds are wired into the connection options.
 
 If both context and URL are configured, context mode wins.
 
@@ -279,35 +276,11 @@ For owner specifically:
 
 ### Attachments fail
 
-Expected. The adapter currently rejects attachments explicitly because the Flue prompt bridge only maps text prompts.
+Expected. The sidecar currently maps text prompts only and rejects attachments explicitly.
 
 ## Limitations
 
 - Text prompts only; attachments are not supported.
 - One configured Flue target per sidecar process.
-- WebSocket transport is diagnostic-only in the verified local Flue 0.9.1 setup.
-- Real-Flue smoke uses a local faux echo agent; it proves runtime/SDK compatibility, not LLM quality.
-- NATS contexts and URL+creds are supported; do not commit actual credentials or seed-shaped test material.
-
-## Current verified state
-
-Last verified before Phase 6 docs handoff:
-
-```text
-bun run typecheck
-PASS
-
-bun test
-19 pass
-0 fail
-42 expect() calls
-
-bun run smoke:protocol
-PASS
-
-bun run smoke:real-flue
-PASS — echo:hello-real-flow
-
-bun src/cli.ts doctor ...
-PASS — Flue HTTP 405 treated as reachable-method-unsupported
-```
+- `websocket` support depends on the Flue deployment's WebSocket agent connection behavior.
+- Local faux-echo smoke tests prove runtime/SDK compatibility, not model quality.

--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -19,12 +19,13 @@ Print a TOML template:
 bun src/cli.ts configure --print-template
 ```
 
-Core precedence is CLI flags, then environment variables, then config file, then defaults.
+Core precedence is CLI flags, then environment variables, then config file, then defaults. NATS contexts are preferred when you already manage auth with the `nats` CLI; otherwise use `--nats-url`/`NATS_URL` plus `--nats-creds`/`NATS_CREDS` for a credentials file.
 
 Environment variables:
 
 - `NATS_URL`
 - `NATS_CONTEXT`
+- `NATS_CREDS` / `NATS_CREDENTIALS`
 - `SYNADIA_FLUE_OWNER`
 - `SYNADIA_FLUE_NAME`
 - `SYNADIA_FLUE_CONFIG`
@@ -39,6 +40,7 @@ Environment variables:
 ```bash
 bun src/cli.ts start \
   --nats-url nats://127.0.0.1:4222 \
+  --nats-creds /path/to/user.creds \
   --owner rene \
   --name support \
   --subject-token flue \

--- a/agents/flue/bun.lock
+++ b/agents/flue/bun.lock
@@ -6,6 +6,7 @@
       "name": "@synadia-ai/flue-nats-channel",
       "dependencies": {
         "@flue/sdk": "latest",
+        "@nats-io/nats-core": "^3.4.0",
         "@nats-io/transport-node": "^3.4.0",
         "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
         "@synadia-ai/agents": "file:../../client-sdk/typescript",

--- a/agents/flue/bun.lock
+++ b/agents/flue/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@synadia-ai/flue-nats-channel",
       "dependencies": {
-        "@flue/sdk": "latest",
+        "@flue/sdk": "^0.9.1",
         "@nats-io/nats-core": "^3.4.0",
         "@nats-io/transport-node": "^3.4.0",
         "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",

--- a/agents/flue/bun.lock
+++ b/agents/flue/bun.lock
@@ -1,0 +1,733 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@synadia-ai/flue-nats-channel",
+      "dependencies": {
+        "@flue/sdk": "latest",
+        "@nats-io/transport-node": "^3.4.0",
+        "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
+        "@synadia-ai/agents": "file:../../client-sdk/typescript",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^20.16.0",
+        "typescript": "~5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@flue/sdk": ["@flue/sdk@0.9.1", "", {}, "sha512-1r7Yh6iSeyF76mZEBoevlw13pzZbeuydBUmZX/U5hq7HMDLuRQyaO2ZRXJ+v42KDfRV1/A4x9sRTvArIC6Q0pg=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@nats-io/nats-core": ["@nats-io/nats-core@3.4.0", "", { "dependencies": { "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
+
+    "@nats-io/nuid": ["@nats-io/nuid@3.0.0", "", {}, "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg=="],
+
+    "@nats-io/services": ["@nats-io/services@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0" } }, "sha512-hS9l4F5VCbdg4u7/qgEUU9gtQ+ZOLJxtj+lJj0oSw7Okkm0fLkYq6odbobFa50IGkghfLrzag95dWHSF8F8+CA=="],
+
+    "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.61.0", "", { "os": "android", "cpu": "arm" }, "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.61.0", "", { "os": "android", "cpu": "arm64" }, "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.61.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.61.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.61.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.61.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.61.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.61.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.61.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.61.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.61.0", "", { "os": "none", "cpu": "arm64" }, "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.61.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.61.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw=="],
+
+    "@shikijs/core": ["@shikijs/core@1.29.2", "", { "dependencies": { "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "oniguruma-to-es": "^2.2.0" } }, "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1" } }, "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA=="],
+
+    "@shikijs/langs": ["@shikijs/langs@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2" } }, "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ=="],
+
+    "@shikijs/themes": ["@shikijs/themes@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2" } }, "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g=="],
+
+    "@shikijs/types": ["@shikijs/types@1.29.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@synadia-ai/agent-service": ["@synadia-ai/agent-service@file:../../agent-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@synadia-ai/agents": "file:../../client-sdk/typescript" }, "devDependencies": { "@nats-io/transport-node": "^3.4.0", "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
+
+    "@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@nats-io/transport-node": "^3.4.0" }, "devDependencies": { "@synadia-ai/agent-service": "file:../../agent-sdk/typescript", "@types/node": "^20.16.0", "@vitest/coverage-v8": "^3.2.0", "eslint": "^9.0.0", "eslint-config-prettier": "^9.1.0", "prettier": "^3.3.0", "tsup": "^8.3.0", "typedoc": "^0.26.0", "typescript": "~5.6.0", "typescript-eslint": "^8.10.0", "vitest": "^3.2.0" } }],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.60.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.60.1", "@typescript-eslint/type-utils": "8.60.1", "@typescript-eslint/utils": "8.60.1", "@typescript-eslint/visitor-keys": "8.60.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.60.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.60.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.60.1", "@typescript-eslint/types": "8.60.1", "@typescript-eslint/typescript-estree": "8.60.1", "@typescript-eslint/visitor-keys": "8.60.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.60.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.60.1", "@typescript-eslint/types": "^8.60.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.60.1", "", { "dependencies": { "@typescript-eslint/types": "8.60.1", "@typescript-eslint/visitor-keys": "8.60.1" } }, "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.60.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.60.1", "", { "dependencies": { "@typescript-eslint/types": "8.60.1", "@typescript-eslint/typescript-estree": "8.60.1", "@typescript-eslint/utils": "8.60.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.60.1", "", {}, "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.60.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.60.1", "@typescript-eslint/tsconfig-utils": "8.60.1", "@typescript-eslint/types": "8.60.1", "@typescript-eslint/visitor-keys": "8.60.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.60.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.60.1", "@typescript-eslint/types": "8.60.1", "@typescript-eslint/typescript-estree": "8.60.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.1", "", { "dependencies": { "@typescript-eslint/types": "8.60.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.6", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.6", "vitest": "3.2.6" }, "optionalPeers": ["@vitest/browser"] }, "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.6", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.6", "@vitest/utils": "3.2.6", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.6", "", { "dependencies": { "@vitest/spy": "3.2.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.6", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.6", "", { "dependencies": { "@vitest/utils": "3.2.6", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.6", "", { "dependencies": { "@vitest/pretty-format": "3.2.6", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.6", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.6", "", { "dependencies": { "@vitest/pretty-format": "3.2.6", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@2.3.0", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^5.1.1", "regex-recursion": "^5.1.1" } }, "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "regex": ["regex@5.1.1", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw=="],
+
+    "regex-recursion": ["regex-recursion@5.1.1", "", { "dependencies": { "regex": "^5.1.1", "regex-utilities": "^2.3.0" } }, "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "rollup": ["rollup@4.61.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.61.0", "@rollup/rollup-android-arm64": "4.61.0", "@rollup/rollup-darwin-arm64": "4.61.0", "@rollup/rollup-darwin-x64": "4.61.0", "@rollup/rollup-freebsd-arm64": "4.61.0", "@rollup/rollup-freebsd-x64": "4.61.0", "@rollup/rollup-linux-arm-gnueabihf": "4.61.0", "@rollup/rollup-linux-arm-musleabihf": "4.61.0", "@rollup/rollup-linux-arm64-gnu": "4.61.0", "@rollup/rollup-linux-arm64-musl": "4.61.0", "@rollup/rollup-linux-loong64-gnu": "4.61.0", "@rollup/rollup-linux-loong64-musl": "4.61.0", "@rollup/rollup-linux-ppc64-gnu": "4.61.0", "@rollup/rollup-linux-ppc64-musl": "4.61.0", "@rollup/rollup-linux-riscv64-gnu": "4.61.0", "@rollup/rollup-linux-riscv64-musl": "4.61.0", "@rollup/rollup-linux-s390x-gnu": "4.61.0", "@rollup/rollup-linux-x64-gnu": "4.61.0", "@rollup/rollup-linux-x64-musl": "4.61.0", "@rollup/rollup-openbsd-x64": "4.61.0", "@rollup/rollup-openharmony-arm64": "4.61.0", "@rollup/rollup-win32-arm64-msvc": "4.61.0", "@rollup/rollup-win32-ia32-msvc": "4.61.0", "@rollup/rollup-win32-x64-gnu": "4.61.0", "@rollup/rollup-win32-x64-msvc": "4.61.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@1.29.2", "", { "dependencies": { "@shikijs/core": "1.29.2", "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/langs": "1.29.2", "@shikijs/themes": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typedoc": ["typedoc@0.26.11", "", { "dependencies": { "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "shiki": "^1.16.2", "yaml": "^2.5.1" }, "peerDependencies": { "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw=="],
+
+    "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.60.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.60.1", "@typescript-eslint/parser": "8.60.1", "@typescript-eslint/typescript-estree": "8.60.1", "@typescript-eslint/utils": "8.60.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.6", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.6", "@vitest/mocker": "3.2.6", "@vitest/pretty-format": "^3.2.6", "@vitest/runner": "3.2.6", "@vitest/snapshot": "3.2.6", "@vitest/spy": "3.2.6", "@vitest/utils": "3.2.6", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.6", "@vitest/ui": "3.2.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@synadia-ai/agent-service/@synadia-ai/agents": ["@synadia-ai/agents@file:../../client-sdk/typescript", {}],
+
+    "@synadia-ai/agents/@synadia-ai/agent-service": ["@synadia-ai/agent-service@file:../../agent-sdk/typescript", {}],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "test-exclude/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "typedoc/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "typedoc/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/agents/flue/package.json
+++ b/agents/flue/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@synadia-ai/flue-nats-channel",
+  "version": "0.1.0",
+  "description": "Synadia Agent Protocol for NATS sidecar for Flue agents.",
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "agents/flue"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/agents/flue",
+  "type": "module",
+  "bin": {
+    "flue-nats-channel": "./src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun src/cli.ts start",
+    "doctor": "bun src/cli.ts doctor",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "smoke:protocol": "bun scripts/protocol-smoke.ts"
+  },
+  "dependencies": {
+    "@flue/sdk": "latest",
+    "@nats-io/transport-node": "^3.4.0",
+    "@synadia-ai/agents": "file:../../client-sdk/typescript",
+    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^20.16.0",
+    "typescript": "~5.6.0"
+  }
+}

--- a/agents/flue/package.json
+++ b/agents/flue/package.json
@@ -19,7 +19,8 @@
     "doctor": "bun src/cli.ts doctor",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "smoke:protocol": "bun scripts/protocol-smoke.ts"
+    "smoke:protocol": "bun scripts/protocol-smoke.ts",
+    "smoke:real-flue": "bun scripts/real-flue-smoke.ts"
   },
   "dependencies": {
     "@flue/sdk": "latest",

--- a/agents/flue/package.json
+++ b/agents/flue/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@flue/sdk": "latest",
+    "@nats-io/nats-core": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
     "@synadia-ai/agents": "file:../../client-sdk/typescript",
     "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"

--- a/agents/flue/package.json
+++ b/agents/flue/package.json
@@ -2,6 +2,7 @@
   "name": "@synadia-ai/flue-nats-channel",
   "version": "0.1.0",
   "description": "Synadia Agent Protocol for NATS sidecar for Flue agents.",
+  "publishConfig": { "access": "public" },
   "license": "Apache-2.0",
   "author": "Synadia Communications",
   "repository": {
@@ -23,7 +24,7 @@
     "smoke:real-flue": "bun scripts/real-flue-smoke.ts"
   },
   "dependencies": {
-    "@flue/sdk": "latest",
+    "@flue/sdk": "^0.9.1",
     "@nats-io/nats-core": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
     "@synadia-ai/agents": "file:../../client-sdk/typescript",

--- a/agents/flue/scripts/protocol-smoke.ts
+++ b/agents/flue/scripts/protocol-smoke.ts
@@ -21,7 +21,7 @@ const config: FlueChannelConfig = {
     agent: "assistant",
     instance: "fake-instance",
     session: "smoke-session",
-    transport: "websocket",
+    transport: "http-stream",
   },
 };
 

--- a/agents/flue/scripts/protocol-smoke.ts
+++ b/agents/flue/scripts/protocol-smoke.ts
@@ -1,0 +1,60 @@
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { Agents, type StreamMessage } from "@synadia-ai/agents";
+import type { FlueBridgeClient } from "../src/bridge.js";
+import type { FlueChannelConfig } from "../src/config.js";
+import { createFlueAgentService } from "../src/service.js";
+
+const natsUrl = process.env["NATS_URL"] ?? "nats://127.0.0.1:4222";
+const name = `smoke-${Math.random().toString(36).slice(2, 8)}`;
+
+const config: FlueChannelConfig = {
+  nats: { url: natsUrl },
+  agent: {
+    owner: "smoke",
+    name,
+    subjectToken: "flue",
+    heartbeatIntervalS: 1,
+    keepaliveIntervalS: 1,
+  },
+  flue: {
+    baseUrl: "http://127.0.0.1:3583",
+    agent: "assistant",
+    instance: "fake-instance",
+    session: "smoke-session",
+    transport: "websocket",
+  },
+};
+
+const fakeFlueClient: FlueBridgeClient = {
+  async prompt(input) {
+    return `fake Flue response to ${input.message} for ${input.agent}/${input.instance}/${input.session}`;
+  },
+};
+
+const nc = await natsConnect({ servers: natsUrl });
+const callerNc = await natsConnect({ servers: natsUrl });
+const service = createFlueAgentService({ nc, config, version: "0.1.0-smoke", flueClient: fakeFlueClient });
+
+try {
+  await service.start();
+  const agents = new Agents({ nc: callerNc });
+  const found = await agents.discover({ timeoutMs: 1000, filter: { agent: "flue", name } });
+  if (found.length !== 1) throw new Error(`expected one flue smoke agent, found ${found.length}`);
+
+  const messages: StreamMessage[] = [];
+  for await (const msg of await found[0]!.prompt("hello smoke")) messages.push(msg);
+
+  console.log(JSON.stringify({ subject: service.subject.prompt, messages }, null, 2));
+  if (messages[0]?.type !== "status" || messages[0].status !== "ack") throw new Error("missing leading ack status");
+  if (!messages.some((m) => m.type === "status" && m.status.includes("connected to Flue"))) {
+    throw new Error("missing Flue connected status");
+  }
+  if (!messages.some((m) => m.type === "response" && m.text.includes("fake Flue response"))) {
+    throw new Error("missing fake Flue response");
+  }
+  if (messages.at(-1)?.type !== "status" || messages.at(-1)?.status !== "done") throw new Error("missing done terminator status");
+} finally {
+  await service.stop();
+  await nc.close();
+  await callerNc.close();
+}

--- a/agents/flue/scripts/real-flue-smoke.ts
+++ b/agents/flue/scripts/real-flue-smoke.ts
@@ -8,7 +8,7 @@ const flueBaseUrl = process.env["FLUE_BASE_URL"] ?? "http://127.0.0.1:3583";
 const flueAgent = process.env["FLUE_AGENT"] ?? "echo";
 const flueInstance = process.env["FLUE_INSTANCE"] ?? "real-flue-smoke";
 const flueSession = process.env["FLUE_SESSION"] ?? `real-flue-smoke-${Date.now()}`;
-const flueTransport = (process.env["FLUE_TRANSPORT"] ?? "http-sync") as FlueTransport;
+const flueTransport = (process.env["FLUE_TRANSPORT"] ?? "http-stream") as FlueTransport;
 const prompt = process.env["SMOKE_PROMPT"] ?? "hello-real-flow";
 const expected = process.env["SMOKE_EXPECTS"] ?? `echo:${prompt}`;
 const name = `real-flue-${Math.random().toString(36).slice(2, 8)}`;
@@ -50,8 +50,9 @@ try {
   if (!messages.some((m) => m.type === "status" && (m as { status: string }).status.includes("connected to Flue"))) {
     throw new Error("missing Flue connected status");
   }
-  if (!messages.some((m) => m.type === "response" && m.text.includes(expected))) {
-    throw new Error(`missing expected real Flue response ${JSON.stringify(expected)}`);
+  const responseText = messages.filter((m) => m.type === "response").map((m) => m.text).join("");
+  if (!responseText.includes(expected)) {
+    throw new Error(`missing expected real Flue response ${JSON.stringify(expected)} in ${JSON.stringify(responseText)}`);
   }
   const last = messages.at(-1);
   if (last?.type !== "status" || last.status !== "done") throw new Error("missing done terminator status");

--- a/agents/flue/scripts/real-flue-smoke.ts
+++ b/agents/flue/scripts/real-flue-smoke.ts
@@ -1,11 +1,17 @@
 import { connect as natsConnect } from "@nats-io/transport-node";
 import { Agents, type StreamMessage } from "@synadia-ai/agents";
-import type { FlueBridgeClient } from "../src/bridge.js";
-import type { FlueChannelConfig } from "../src/config.js";
+import type { FlueChannelConfig, FlueTransport } from "../src/config.js";
 import { createFlueAgentService } from "../src/service.js";
 
 const natsUrl = process.env["NATS_URL"] ?? "nats://127.0.0.1:4222";
-const name = `smoke-${Math.random().toString(36).slice(2, 8)}`;
+const flueBaseUrl = process.env["FLUE_BASE_URL"] ?? "http://127.0.0.1:3583";
+const flueAgent = process.env["FLUE_AGENT"] ?? "echo";
+const flueInstance = process.env["FLUE_INSTANCE"] ?? "real-flue-smoke";
+const flueSession = process.env["FLUE_SESSION"] ?? `real-flue-smoke-${Date.now()}`;
+const flueTransport = (process.env["FLUE_TRANSPORT"] ?? "http-sync") as FlueTransport;
+const prompt = process.env["SMOKE_PROMPT"] ?? "hello-real-flow";
+const expected = process.env["SMOKE_EXPECTS"] ?? `echo:${prompt}`;
+const name = `real-flue-${Math.random().toString(36).slice(2, 8)}`;
 
 const config: FlueChannelConfig = {
   nats: { url: natsUrl },
@@ -17,23 +23,17 @@ const config: FlueChannelConfig = {
     keepaliveIntervalS: 1,
   },
   flue: {
-    baseUrl: "http://127.0.0.1:3583",
-    agent: "assistant",
-    instance: "fake-instance",
-    session: "smoke-session",
-    transport: "websocket",
-  },
-};
-
-const fakeFlueClient: FlueBridgeClient = {
-  async prompt(input) {
-    return `fake Flue response to ${input.message} for ${input.agent}/${input.instance}/${input.session}`;
+    baseUrl: flueBaseUrl,
+    agent: flueAgent,
+    instance: flueInstance,
+    session: flueSession,
+    transport: flueTransport,
   },
 };
 
 const nc = await natsConnect({ servers: natsUrl });
 const callerNc = await natsConnect({ servers: natsUrl });
-const service = createFlueAgentService({ nc, config, version: "0.1.0-smoke", flueClient: fakeFlueClient });
+const service = createFlueAgentService({ nc, config, version: "0.1.0-real-flue-smoke" });
 
 try {
   await service.start();
@@ -42,16 +42,16 @@ try {
   if (found.length !== 1) throw new Error(`expected one flue smoke agent, found ${found.length}`);
 
   const messages: StreamMessage[] = [];
-  for await (const msg of await found[0]!.prompt("hello smoke")) messages.push(msg);
+  for await (const msg of await found[0]!.prompt(prompt)) messages.push(msg);
 
-  console.log(JSON.stringify({ subject: service.subject.prompt, messages }, null, 2));
+  console.log(JSON.stringify({ subject: service.subject.prompt, flue: config.flue, messages }, null, 2));
   const first = messages[0];
   if (first?.type !== "status" || first.status !== "ack") throw new Error("missing leading ack status");
   if (!messages.some((m) => m.type === "status" && (m as { status: string }).status.includes("connected to Flue"))) {
     throw new Error("missing Flue connected status");
   }
-  if (!messages.some((m) => m.type === "response" && m.text.includes("fake Flue response"))) {
-    throw new Error("missing fake Flue response");
+  if (!messages.some((m) => m.type === "response" && m.text.includes(expected))) {
+    throw new Error(`missing expected real Flue response ${JSON.stringify(expected)}`);
   }
   const last = messages.at(-1);
   if (last?.type !== "status" || last.status !== "done") throw new Error("missing done terminator status");

--- a/agents/flue/src/bridge.ts
+++ b/agents/flue/src/bridge.ts
@@ -52,5 +52,6 @@ export function stringifyFlueResult(result: unknown): string {
   if (result === undefined || result === null) return "";
   if (typeof result === "string") return result;
   if (typeof result === "number" || typeof result === "boolean" || typeof result === "bigint") return String(result);
+  if (typeof result === "object" && "text" in result && typeof result.text === "string") return result.text;
   try { return JSON.stringify(result); } catch { return String(result); }
 }

--- a/agents/flue/src/bridge.ts
+++ b/agents/flue/src/bridge.ts
@@ -55,7 +55,11 @@ export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<
   });
 
   const finalText = stringifyFlueResult(result);
-  if (!streamed || finalText) await response.send({ type: "response", text: finalText });
+  if (finalText) {
+    await response.send({ type: "response", text: finalText });
+  } else if (!streamed) {
+    await response.send({ type: "response", text: "" });
+  }
 }
 
 export function stringifyFlueResult(result: unknown): string {

--- a/agents/flue/src/bridge.ts
+++ b/agents/flue/src/bridge.ts
@@ -14,6 +14,8 @@ export interface FlueBridgeClient {
     readonly instance: string;
     readonly session: string;
     readonly transport: string;
+  }, events?: {
+    readonly onTextDelta?: (text: string) => Promise<void>;
   }): Promise<unknown>;
 }
 
@@ -36,6 +38,7 @@ export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<
     status: `connected to Flue ${target.agent}/${target.instance} via ${target.transport}`,
   });
 
+  let streamed = false;
   const result = await flueClient.prompt({
     message: envelope.prompt,
     baseUrl: target.baseUrl,
@@ -43,9 +46,16 @@ export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<
     instance: target.instance,
     session: target.session,
     transport: target.transport,
+  }, {
+    onTextDelta: async (text) => {
+      if (!text) return;
+      streamed = true;
+      await response.send({ type: "response", text });
+    },
   });
 
-  await response.send({ type: "response", text: stringifyFlueResult(result) });
+  const finalText = stringifyFlueResult(result);
+  if (!streamed || finalText) await response.send({ type: "response", text: finalText });
 }
 
 export function stringifyFlueResult(result: unknown): string {

--- a/agents/flue/src/bridge.ts
+++ b/agents/flue/src/bridge.ts
@@ -1,0 +1,56 @@
+import type { RequestEnvelope } from "@synadia-ai/agents";
+import type { Chunk } from "@synadia-ai/agent-service";
+import type { FlueMapping } from "./config.js";
+
+export interface BridgeResponse {
+  send(chunk: string | Chunk): Promise<void>;
+}
+
+export interface FlueBridgeClient {
+  prompt(input: {
+    readonly message: string;
+    readonly baseUrl: string;
+    readonly agent: string;
+    readonly instance: string;
+    readonly session: string;
+    readonly transport: string;
+  }): Promise<unknown>;
+}
+
+export interface BridgePromptOptions {
+  readonly envelope: RequestEnvelope;
+  readonly response: BridgeResponse;
+  readonly mapping: FlueMapping;
+  readonly flueClient: FlueBridgeClient;
+}
+
+export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<void> {
+  const { envelope, response, mapping, flueClient } = options;
+  if (envelope.attachments && envelope.attachments.length > 0) {
+    throw new Error("attachments are not supported by the Flue NATS channel v1");
+  }
+
+  const target = mapping.flue;
+  await response.send({
+    type: "status",
+    status: `connected to Flue ${target.agent}/${target.instance} via ${target.transport}`,
+  });
+
+  const result = await flueClient.prompt({
+    message: envelope.prompt,
+    baseUrl: target.baseUrl,
+    agent: target.agent,
+    instance: target.instance,
+    session: target.session,
+    transport: target.transport,
+  });
+
+  await response.send({ type: "response", text: stringifyFlueResult(result) });
+}
+
+export function stringifyFlueResult(result: unknown): string {
+  if (result === undefined || result === null) return "";
+  if (typeof result === "string") return result;
+  if (typeof result === "number" || typeof result === "boolean" || typeof result === "bigint") return String(result);
+  try { return JSON.stringify(result); } catch { return String(result); }
+}

--- a/agents/flue/src/cli.ts
+++ b/agents/flue/src/cli.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { helpText, loadConfigFromSources, parseArgs, renderConfigTemplate } from "./config.js";
+import { resolveNatsOptions } from "./nats.js";
+import { createFlueAgentService } from "./service.js";
+import { formatDoctorChecks, runDoctorChecks } from "./doctor.js";
+import pkg from "../package.json" assert { type: "json" };
+
+async function start(): Promise<void> {
+  const config = loadConfigFromSources();
+  const nc = await natsConnect(await resolveNatsOptions(config.nats));
+  const service = createFlueAgentService({ nc, config, version: pkg.version });
+  await service.start();
+  console.log(`flue agent listening on ${service.subject.prompt}`);
+  console.log("press Ctrl+C to stop");
+  const shutdown = async (): Promise<void> => {
+    console.log("\nshutting down…");
+    await service.stop();
+    await nc.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}
+
+async function doctor(): Promise<void> {
+  const config = loadConfigFromSources();
+  const checks = await runDoctorChecks(config);
+  console.log(formatDoctorChecks(checks));
+  if (checks.some((c) => !c.ok)) process.exitCode = 1;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.command === "help") { console.log(helpText()); return; }
+  if (args.command === "configure") {
+    if (args.printTemplate) { console.log(renderConfigTemplate()); return; }
+    console.log(helpText()); return;
+  }
+  if (args.command === "doctor") { await doctor(); return; }
+  if (args.command === "start") { await start(); return; }
+  throw new Error(`unknown command ${args.command}`);
+}
+
+void main().catch((err: unknown) => {
+  console.error(`flue-nats-channel failed: ${(err as Error).message}`);
+  process.exit(1);
+});

--- a/agents/flue/src/config.ts
+++ b/agents/flue/src/config.ts
@@ -1,0 +1,240 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { resolveOwner, requireSubjectToken, sanitizeSubjectToken } from "./subject.js";
+
+export type FlueTransport = "websocket" | "http-sync" | "http-stream";
+
+export interface NatsConfig {
+  readonly url?: string;
+  readonly context?: string;
+  readonly creds?: string;
+}
+
+export interface AgentConfig {
+  readonly owner: string;
+  readonly name: string;
+  readonly subjectToken: string;
+  readonly heartbeatIntervalS: number;
+  readonly keepaliveIntervalS: number;
+}
+
+export interface FlueTargetConfig {
+  readonly baseUrl: string;
+  readonly agent: string;
+  readonly instance: string;
+  readonly session: string;
+  readonly transport: FlueTransport;
+}
+
+export interface FlueChannelConfig {
+  readonly nats: NatsConfig;
+  readonly agent: AgentConfig;
+  readonly flue: FlueTargetConfig;
+}
+
+export interface FlueMapping {
+  readonly owner: string;
+  readonly name: string;
+  readonly subjectToken: string;
+  readonly flue: FlueTargetConfig;
+}
+
+export interface ParsedArgs {
+  readonly command: string;
+  readonly config?: string;
+  readonly natsUrl?: string;
+  readonly natsContext?: string;
+  readonly owner?: string;
+  readonly name?: string;
+  readonly subjectToken?: string;
+  readonly flueBaseUrl?: string;
+  readonly flueAgent?: string;
+  readonly flueInstance?: string;
+  readonly flueSession?: string;
+  readonly flueTransport?: FlueTransport;
+  readonly heartbeatIntervalS?: number;
+  readonly keepaliveIntervalS?: number;
+  readonly printTemplate?: boolean;
+  readonly help?: boolean;
+}
+
+export interface LoadConfigSources {
+  readonly argv?: readonly string[];
+  readonly env?: Record<string, string | undefined>;
+  readonly readFile?: (path: string) => string;
+}
+
+export const DEFAULT_CONFIG_PATH = join(homedir(), ".config", "synadia", "flue-nats-channel.toml");
+
+const flagMap: Record<string, keyof Omit<ParsedArgs, "command">> = {
+  "--config": "config",
+  "--nats-url": "natsUrl",
+  "--nats-context": "natsContext",
+  "--owner": "owner",
+  "--name": "name",
+  "--subject-token": "subjectToken",
+  "--flue-base-url": "flueBaseUrl",
+  "--flue-agent": "flueAgent",
+  "--flue-instance": "flueInstance",
+  "--flue-session": "flueSession",
+  "--flue-transport": "flueTransport",
+  "--heartbeat-interval-s": "heartbeatIntervalS",
+  "--keepalive-interval-s": "keepaliveIntervalS",
+};
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const [command = "help", ...rest] = argv;
+  const out: Record<string, unknown> = { command };
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === undefined) continue;
+    if (arg === "--help" || arg === "-h") { out.help = true; continue; }
+    if (arg === "--print-template") { out.printTemplate = true; continue; }
+    const key = flagMap[arg];
+    if (!key) throw new Error(`unknown flag ${arg}`);
+    const value = rest[++i];
+    if (value === undefined) throw new Error(`${arg} requires a value`);
+    if (key === "heartbeatIntervalS" || key === "keepaliveIntervalS") {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n <= 0) throw new Error(`${arg} must be a positive number`);
+      out[key] = n;
+    } else if (key === "flueTransport") {
+      if (!isFlueTransport(value)) throw new Error(`${arg} must be websocket, http-sync, or http-stream`);
+      out[key] = value;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out as unknown as ParsedArgs;
+}
+
+function isFlueTransport(value: string): value is FlueTransport {
+  return value === "websocket" || value === "http-sync" || value === "http-stream";
+}
+
+type TomlTree = Record<string, Record<string, string>>;
+
+function parseTinyToml(source: string): TomlTree {
+  const tree: TomlTree = {};
+  let section = "";
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const sec = /^\[([^\]]+)\]$/.exec(line);
+    if (sec) { section = sec[1] ?? ""; tree[section] ??= {}; continue; }
+    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+)$/.exec(line);
+    if (!kv || !section) continue;
+    const key = kv[1] ?? "";
+    let value = (kv[2] ?? "").trim();
+    value = value.replace(/^"|"$/g, "");
+    tree[section]![key] = value;
+  }
+  return tree;
+}
+
+function readConfig(path: string, readFile: (path: string) => string): TomlTree {
+  try {
+    return parseTinyToml(readFile(path));
+  } catch {
+    return {};
+  }
+}
+
+const get = (...values: Array<string | undefined>): string | undefined => values.find((v) => v !== undefined && v !== "");
+
+export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChannelConfig {
+  const env = sources.env ?? process.env;
+  const args = parseArgs(sources.argv ?? process.argv.slice(2));
+  const configPath = args.config ?? env.SYNADIA_FLUE_CONFIG ?? DEFAULT_CONFIG_PATH;
+  const readFile = sources.readFile ?? ((p: string) => existsSync(p) ? readFileSync(p, "utf8") : "");
+  const file = readConfig(configPath, readFile);
+  const natsSection = file.nats ?? {};
+  const agentSection = file.agent ?? {};
+  const flueSection = file.flue ?? {};
+
+  const owner = resolveOwner(args.owner ?? agentSection.owner, env.SYNADIA_FLUE_OWNER, env.USER);
+  const name = requireSubjectToken(get(args.name, env.SYNADIA_FLUE_NAME, agentSection.name, "main")!, "agent.name");
+  const subjectToken = requireSubjectToken(get(args.subjectToken, agentSection.subject_token, "flue")!, "agent.subject_token");
+  const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "websocket")!;
+  if (!isFlueTransport(transport)) throw new Error(`invalid flue transport ${transport}`);
+
+  const nats: Record<string, string> = {};
+  const natsUrl = get(args.natsUrl, env.NATS_URL, natsSection.url, "nats://127.0.0.1:4222");
+  const natsContext = get(args.natsContext, env.NATS_CONTEXT, natsSection.context);
+  const natsCreds = get(natsSection.creds);
+  if (natsUrl) nats.url = natsUrl;
+  if (natsContext) nats.context = natsContext;
+  if (natsCreds) nats.creds = natsCreds;
+
+  return {
+    nats,
+    agent: {
+      owner,
+      name,
+      subjectToken,
+      heartbeatIntervalS: Number(get(args.heartbeatIntervalS?.toString(), agentSection.heartbeat_interval_s, "30")),
+      keepaliveIntervalS: Number(get(args.keepaliveIntervalS?.toString(), agentSection.keepalive_interval_s, "30")),
+    },
+    flue: {
+      baseUrl: get(args.flueBaseUrl, env.FLUE_BASE_URL, flueSection.base_url, "http://127.0.0.1:3583")!,
+      agent: get(args.flueAgent, env.FLUE_AGENT, flueSection.agent, "assistant")!,
+      instance: get(args.flueInstance, env.FLUE_INSTANCE, flueSection.instance, "default")!,
+      session: get(args.flueSession, env.FLUE_SESSION, flueSection.session, "default")!,
+      transport,
+    },
+  };
+}
+
+export function mappingFromConfig(config: FlueChannelConfig): FlueMapping {
+  return {
+    owner: config.agent.owner,
+    name: config.agent.name,
+    subjectToken: sanitizeSubjectToken(config.agent.subjectToken) || "flue",
+    flue: config.flue,
+  };
+}
+
+export function renderConfigTemplate(): string {
+  return `[nats]
+url = "nats://127.0.0.1:4222"
+context = "local"
+
+[agent]
+owner = "rene"
+name = "support"
+subject_token = "flue"
+heartbeat_interval_s = 30
+keepalive_interval_s = 30
+
+[flue]
+base_url = "http://127.0.0.1:3583"
+agent = "assistant"
+instance = "customer-123"
+session = "ticket-123"
+transport = "websocket"
+`;
+}
+
+export function helpText(): string {
+  return `Usage: flue-nats-channel <start|doctor|configure> [options]
+
+Commands:
+  start                 Register the Flue-backed agent on NATS
+  doctor                Check config and Flue reachability
+  configure --print-template
+
+Options:
+  --config PATH
+  --nats-url URL
+  --nats-context NAME
+  --owner TOKEN
+  --name TOKEN
+  --subject-token TOKEN
+  --flue-base-url URL
+  --flue-agent NAME
+  --flue-instance ID
+  --flue-session SESSION
+  --flue-transport websocket|http-sync|http-stream
+`;
+}

--- a/agents/flue/src/config.ts
+++ b/agents/flue/src/config.ts
@@ -45,6 +45,7 @@ export interface ParsedArgs {
   readonly config?: string;
   readonly natsUrl?: string;
   readonly natsContext?: string;
+  readonly natsCreds?: string;
   readonly owner?: string;
   readonly name?: string;
   readonly subjectToken?: string;
@@ -71,6 +72,7 @@ const flagMap: Record<string, keyof Omit<ParsedArgs, "command">> = {
   "--config": "config",
   "--nats-url": "natsUrl",
   "--nats-context": "natsContext",
+  "--nats-creds": "natsCreds",
   "--owner": "owner",
   "--name": "name",
   "--subject-token": "subjectToken",
@@ -153,7 +155,7 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
   const agentSection = file.agent ?? {};
   const flueSection = file.flue ?? {};
 
-  const owner = resolveOwner(args.owner ?? agentSection.owner, env.SYNADIA_FLUE_OWNER, env.USER);
+  const owner = resolveOwner(get(args.owner, env.SYNADIA_FLUE_OWNER, agentSection.owner, env.USER), undefined, undefined);
   const name = requireSubjectToken(get(args.name, env.SYNADIA_FLUE_NAME, agentSection.name, "main")!, "agent.name");
   const subjectToken = requireSubjectToken(get(args.subjectToken, agentSection.subject_token, "flue")!, "agent.subject_token");
   const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "http-stream")!;
@@ -162,7 +164,7 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
   const nats: Record<string, string> = {};
   const natsUrl = get(args.natsUrl, env.NATS_URL, natsSection.url, "nats://127.0.0.1:4222");
   const natsContext = get(args.natsContext, env.NATS_CONTEXT, natsSection.context);
-  const natsCreds = get(natsSection.creds);
+  const natsCreds = get(args.natsCreds, env.NATS_CREDS, env.NATS_CREDENTIALS, natsSection.creds);
   if (natsUrl) nats.url = natsUrl;
   if (natsContext) nats.context = natsContext;
   if (natsCreds) nats.creds = natsCreds;
@@ -199,6 +201,7 @@ export function renderConfigTemplate(): string {
   return `[nats]
 url = "nats://127.0.0.1:4222"
 context = "local"
+creds = "/path/to/user.creds"
 
 [agent]
 owner = "rene"
@@ -228,6 +231,7 @@ Options:
   --config PATH
   --nats-url URL
   --nats-context NAME
+  --nats-creds PATH
   --owner TOKEN
   --name TOKEN
   --subject-token TOKEN

--- a/agents/flue/src/config.ts
+++ b/agents/flue/src/config.ts
@@ -156,7 +156,7 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
   const owner = resolveOwner(args.owner ?? agentSection.owner, env.SYNADIA_FLUE_OWNER, env.USER);
   const name = requireSubjectToken(get(args.name, env.SYNADIA_FLUE_NAME, agentSection.name, "main")!, "agent.name");
   const subjectToken = requireSubjectToken(get(args.subjectToken, agentSection.subject_token, "flue")!, "agent.subject_token");
-  const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "http-sync")!;
+  const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "http-stream")!;
   if (!isFlueTransport(transport)) throw new Error(`invalid flue transport ${transport}`);
 
   const nats: Record<string, string> = {};
@@ -212,7 +212,7 @@ base_url = "http://127.0.0.1:3583"
 agent = "assistant"
 instance = "customer-123"
 session = "ticket-123"
-transport = "http-sync"
+transport = "http-stream"
 `;
 }
 

--- a/agents/flue/src/config.ts
+++ b/agents/flue/src/config.ts
@@ -156,7 +156,7 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
   const owner = resolveOwner(args.owner ?? agentSection.owner, env.SYNADIA_FLUE_OWNER, env.USER);
   const name = requireSubjectToken(get(args.name, env.SYNADIA_FLUE_NAME, agentSection.name, "main")!, "agent.name");
   const subjectToken = requireSubjectToken(get(args.subjectToken, agentSection.subject_token, "flue")!, "agent.subject_token");
-  const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "websocket")!;
+  const transport = get(args.flueTransport, env.FLUE_TRANSPORT, flueSection.transport, "http-sync")!;
   if (!isFlueTransport(transport)) throw new Error(`invalid flue transport ${transport}`);
 
   const nats: Record<string, string> = {};
@@ -212,7 +212,7 @@ base_url = "http://127.0.0.1:3583"
 agent = "assistant"
 instance = "customer-123"
 session = "ticket-123"
-transport = "websocket"
+transport = "http-sync"
 `;
 }
 

--- a/agents/flue/src/config.ts
+++ b/agents/flue/src/config.ts
@@ -125,7 +125,7 @@ function parseTinyToml(source: string): TomlTree {
     if (!line || line.startsWith("#")) continue;
     const sec = /^\[([^\]]+)\]$/.exec(line);
     if (sec) { section = sec[1] ?? ""; tree[section] ??= {}; continue; }
-    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+)$/.exec(line);
+    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+?)(?:\s+#.*)?$/.exec(line);
     if (!kv || !section) continue;
     const key = kv[1] ?? "";
     let value = (kv[2] ?? "").trim();
@@ -175,8 +175,8 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
       owner,
       name,
       subjectToken,
-      heartbeatIntervalS: Number(get(args.heartbeatIntervalS?.toString(), agentSection.heartbeat_interval_s, "30")),
-      keepaliveIntervalS: Number(get(args.keepaliveIntervalS?.toString(), agentSection.keepalive_interval_s, "30")),
+      heartbeatIntervalS: parsePositiveNumber(get(args.heartbeatIntervalS?.toString(), agentSection.heartbeat_interval_s, "30")!, "agent.heartbeat_interval_s"),
+      keepaliveIntervalS: parsePositiveNumber(get(args.keepaliveIntervalS?.toString(), agentSection.keepalive_interval_s, "30")!, "agent.keepalive_interval_s"),
     },
     flue: {
       baseUrl: get(args.flueBaseUrl, env.FLUE_BASE_URL, flueSection.base_url, "http://127.0.0.1:3583")!,
@@ -186,6 +186,12 @@ export function loadConfigFromSources(sources: LoadConfigSources = {}): FlueChan
       transport,
     },
   };
+}
+
+function parsePositiveNumber(value: string, field: string): number {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) throw new Error(`${field} must be a positive number`);
+  return number;
 }
 
 export function mappingFromConfig(config: FlueChannelConfig): FlueMapping {

--- a/agents/flue/src/doctor.ts
+++ b/agents/flue/src/doctor.ts
@@ -17,7 +17,9 @@ export async function runDoctorChecks(config: FlueChannelConfig, deps: DoctorDep
   try {
     const url = new URL(`/agents/${encodeURIComponent(config.flue.agent)}/${encodeURIComponent(config.flue.instance)}`, config.flue.baseUrl);
     const res = await fetchImpl(url, { method: "GET" });
-    checks.push({ name: "flue-http", ok: res.ok || res.status === 426 || res.status === 404, message: `${url.toString()} returned HTTP ${res.status}` });
+    const reachable = res.ok || res.status === 426 || res.status === 404 || res.status === 405;
+    const methodNote = res.status === 405 ? " (reachable; GET probe method unsupported)" : "";
+    checks.push({ name: "flue-http", ok: reachable, message: `${url.toString()} returned HTTP ${res.status}${methodNote}` });
   } catch (err) {
     checks.push({ name: "flue-http", ok: false, message: (err as Error).message });
   }

--- a/agents/flue/src/doctor.ts
+++ b/agents/flue/src/doctor.ts
@@ -1,0 +1,29 @@
+import type { FlueChannelConfig } from "./config.js";
+
+export interface DoctorCheck {
+  readonly name: string;
+  readonly ok: boolean;
+  readonly message: string;
+}
+
+export interface DoctorDeps {
+  readonly fetch?: typeof fetch;
+}
+
+export async function runDoctorChecks(config: FlueChannelConfig, deps: DoctorDeps = {}): Promise<DoctorCheck[]> {
+  const fetchImpl = deps.fetch ?? fetch;
+  const checks: DoctorCheck[] = [];
+  checks.push({ name: "config", ok: true, message: `agent flue/${config.agent.owner}/${config.agent.name}` });
+  try {
+    const url = new URL(`/agents/${encodeURIComponent(config.flue.agent)}/${encodeURIComponent(config.flue.instance)}`, config.flue.baseUrl);
+    const res = await fetchImpl(url, { method: "GET" });
+    checks.push({ name: "flue-http", ok: res.ok || res.status === 426 || res.status === 404, message: `${url.toString()} returned HTTP ${res.status}` });
+  } catch (err) {
+    checks.push({ name: "flue-http", ok: false, message: (err as Error).message });
+  }
+  return checks;
+}
+
+export function formatDoctorChecks(checks: readonly DoctorCheck[]): string {
+  return checks.map((check) => `${check.ok ? "ok" : "fail"}	${check.name}	${check.message}`).join("\n");
+}

--- a/agents/flue/src/flue-client.ts
+++ b/agents/flue/src/flue-client.ts
@@ -23,7 +23,7 @@ export class SdkFlueBridgeClient implements FlueBridgeClient {
         }
       }
       const text = textParts.join("");
-      return events?.onTextDelta ? "" : text || eventsSeen;
+      return events?.onTextDelta ? "" : text;
     }
 
     const socket = client.agents.connect(input.agent, input.instance);

--- a/agents/flue/src/flue-client.ts
+++ b/agents/flue/src/flue-client.ts
@@ -1,0 +1,36 @@
+import { createFlueClient, type AttachedAgentEvent } from "@flue/sdk";
+import type { FlueBridgeClient } from "./bridge.js";
+
+/** Flue SDK-backed bridge client. Opens a direct agent connection per prompt. */
+export class SdkFlueBridgeClient implements FlueBridgeClient {
+  async prompt(input: Parameters<FlueBridgeClient["prompt"]>[0]): Promise<unknown> {
+    const client = createFlueClient({ baseUrl: input.baseUrl });
+    const payload = { message: input.message, session: input.session };
+
+    if (input.transport === "http-sync") {
+      const { result } = await client.agents.invoke(input.agent, input.instance, { mode: "sync", payload });
+      return result;
+    }
+
+    if (input.transport === "http-stream") {
+      const events: AttachedAgentEvent[] = [];
+      for await (const event of client.agents.invoke(input.agent, input.instance, { mode: "stream", payload })) {
+        events.push(event);
+      }
+      const text = events
+        .filter((event): event is Extract<AttachedAgentEvent, { type: "text_delta" }> => event.type === "text_delta")
+        .map((event) => event.text)
+        .join("");
+      return text || events;
+    }
+
+    const socket = client.agents.connect(input.agent, input.instance);
+    try {
+      await socket.ready;
+      const { result } = await socket.prompt(input.message, { session: input.session });
+      return result;
+    } finally {
+      socket.close();
+    }
+  }
+}

--- a/agents/flue/src/flue-client.ts
+++ b/agents/flue/src/flue-client.ts
@@ -3,7 +3,7 @@ import type { FlueBridgeClient } from "./bridge.js";
 
 /** Flue SDK-backed bridge client. Opens a direct agent connection per prompt. */
 export class SdkFlueBridgeClient implements FlueBridgeClient {
-  async prompt(input: Parameters<FlueBridgeClient["prompt"]>[0]): Promise<unknown> {
+  async prompt(input: Parameters<FlueBridgeClient["prompt"]>[0], events?: Parameters<FlueBridgeClient["prompt"]>[1]): Promise<unknown> {
     const client = createFlueClient({ baseUrl: input.baseUrl });
     const payload = { message: input.message, session: input.session };
 
@@ -13,15 +13,17 @@ export class SdkFlueBridgeClient implements FlueBridgeClient {
     }
 
     if (input.transport === "http-stream") {
-      const events: AttachedAgentEvent[] = [];
+      const eventsSeen: AttachedAgentEvent[] = [];
+      const textParts: string[] = [];
       for await (const event of client.agents.invoke(input.agent, input.instance, { mode: "stream", payload })) {
-        events.push(event);
+        eventsSeen.push(event);
+        if (event.type === "text_delta") {
+          textParts.push(event.text);
+          await events?.onTextDelta?.(event.text);
+        }
       }
-      const text = events
-        .filter((event): event is Extract<AttachedAgentEvent, { type: "text_delta" }> => event.type === "text_delta")
-        .map((event) => event.text)
-        .join("");
-      return text || events;
+      const text = textParts.join("");
+      return events?.onTextDelta ? "" : text || eventsSeen;
     }
 
     const socket = client.agents.connect(input.agent, input.instance);

--- a/agents/flue/src/flue-client.ts
+++ b/agents/flue/src/flue-client.ts
@@ -1,4 +1,4 @@
-import { createFlueClient, type AttachedAgentEvent } from "@flue/sdk";
+import { createFlueClient } from "@flue/sdk";
 import type { FlueBridgeClient } from "./bridge.js";
 
 /** Flue SDK-backed bridge client. Opens a direct agent connection per prompt. */
@@ -13,10 +13,8 @@ export class SdkFlueBridgeClient implements FlueBridgeClient {
     }
 
     if (input.transport === "http-stream") {
-      const eventsSeen: AttachedAgentEvent[] = [];
       const textParts: string[] = [];
       for await (const event of client.agents.invoke(input.agent, input.instance, { mode: "stream", payload })) {
-        eventsSeen.push(event);
         if (event.type === "text_delta") {
           textParts.push(event.text);
           await events?.onTextDelta?.(event.text);

--- a/agents/flue/src/index.ts
+++ b/agents/flue/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./subject.js";
+export * from "./config.js";
+export * from "./bridge.js";
+export * from "./service.js";
+export * from "./doctor.js";

--- a/agents/flue/src/nats.ts
+++ b/agents/flue/src/nats.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { credsAuthenticator } from "@nats-io/nats-core";
 import { loadContextOptions, parseNatsUrl, withAgentReconnectDefaults } from "@synadia-ai/agents";
 import type { NodeConnectionOptions } from "@nats-io/transport-node";
 import type { NatsConfig } from "./config.js";
@@ -6,5 +8,10 @@ export async function resolveNatsOptions(config: NatsConfig): Promise<NodeConnec
   const base = config.context
     ? await loadContextOptions(config.context)
     : parseNatsUrl(config.url ?? "nats://127.0.0.1:4222");
+
+  if (!config.context && config.creds) {
+    base.authenticator = credsAuthenticator(readFileSync(config.creds));
+  }
+
   return withAgentReconnectDefaults(base);
 }

--- a/agents/flue/src/nats.ts
+++ b/agents/flue/src/nats.ts
@@ -1,0 +1,10 @@
+import { loadContextOptions, parseNatsUrl, withAgentReconnectDefaults } from "@synadia-ai/agents";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import type { NatsConfig } from "./config.js";
+
+export async function resolveNatsOptions(config: NatsConfig): Promise<NodeConnectionOptions> {
+  const base = config.context
+    ? await loadContextOptions(config.context)
+    : parseNatsUrl(config.url ?? "nats://127.0.0.1:4222");
+  return withAgentReconnectDefaults(base);
+}

--- a/agents/flue/src/service.ts
+++ b/agents/flue/src/service.ts
@@ -1,0 +1,46 @@
+import type { NatsConnection } from "@nats-io/nats-core";
+import { AgentService, type AgentServiceOptions } from "@synadia-ai/agent-service";
+import type { FlueBridgeClient } from "./bridge.js";
+import { bridgePromptToFlue } from "./bridge.js";
+import type { FlueChannelConfig } from "./config.js";
+import { mappingFromConfig } from "./config.js";
+import { SdkFlueBridgeClient } from "./flue-client.js";
+
+export interface BuildAgentServiceOptionsInput {
+  readonly nc: NatsConnection;
+  readonly config: FlueChannelConfig;
+  readonly version: string;
+}
+
+export function buildAgentServiceOptions(input: BuildAgentServiceOptionsInput): AgentServiceOptions {
+  const mapping = mappingFromConfig(input.config);
+  return {
+    nc: input.nc,
+    agent: "flue",
+    subjectToken: mapping.subjectToken,
+    owner: mapping.owner,
+    name: mapping.name,
+    description: `Flue agent ${mapping.flue.agent}/${mapping.flue.instance}`,
+    version: input.version,
+    attachmentsOk: false,
+    heartbeatIntervalS: input.config.agent.heartbeatIntervalS,
+    keepaliveIntervalS: input.config.agent.keepaliveIntervalS,
+    extraMetadata: {
+      flue_base_url: mapping.flue.baseUrl,
+      flue_agent: mapping.flue.agent,
+      flue_instance: mapping.flue.instance,
+      flue_session: mapping.flue.session,
+      flue_transport: mapping.flue.transport,
+    },
+  };
+}
+
+export function createFlueAgentService(input: BuildAgentServiceOptionsInput & { readonly flueClient?: FlueBridgeClient }): AgentService {
+  const service = new AgentService(buildAgentServiceOptions(input));
+  const mapping = mappingFromConfig(input.config);
+  const flueClient = input.flueClient ?? new SdkFlueBridgeClient();
+  service.onPrompt(async (envelope, response) => {
+    await bridgePromptToFlue({ envelope, response, mapping, flueClient });
+  });
+  return service;
+}

--- a/agents/flue/src/subject.ts
+++ b/agents/flue/src/subject.ts
@@ -1,0 +1,27 @@
+// Pure subject-token helpers. Kept import-free for focused tests.
+
+/**
+ * Sanitize a subject token per protocol SHOULD rules: lowercase [a-z0-9_-],
+ * replacing disallowed runs with a single dash and trimming edge dashes.
+ */
+export function sanitizeSubjectToken(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Resolve owner precedence, then sanitize the selected value. */
+export function resolveOwner(
+  configOwner: string | undefined,
+  envOwner: string | undefined,
+  envUser: string | undefined,
+): string {
+  return sanitizeSubjectToken(configOwner ?? envOwner ?? envUser ?? "unknown") || "unknown";
+}
+
+export function requireSubjectToken(value: string, label: string): string {
+  const token = sanitizeSubjectToken(value);
+  if (!token) throw new Error(`${label} must contain at least one subject-safe character`);
+  return token;
+}

--- a/agents/flue/test/bridge.test.ts
+++ b/agents/flue/test/bridge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { bridgePromptToFlue, type BridgeResponse, type FlueBridgeClient } from "../src/bridge.js";
+import type { FlueMapping } from "../src/config.js";
+
+function mapping(): FlueMapping {
+  return {
+    owner: "rene",
+    name: "support",
+    subjectToken: "flue",
+    flue: {
+      baseUrl: "http://127.0.0.1:3583",
+      agent: "assistant",
+      instance: "customer-123",
+      session: "ticket-123",
+      transport: "websocket",
+    },
+  };
+}
+
+class RecordingResponse implements BridgeResponse {
+  chunks: unknown[] = [];
+  async send(chunk: unknown): Promise<void> { this.chunks.push(chunk); }
+}
+
+describe("bridgePromptToFlue", () => {
+  test("sends status and final response for a string result", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = { prompt: async () => "hello from flue" };
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+    expect(response.chunks).toEqual([
+      { type: "status", status: "connected to Flue assistant/customer-123 via websocket" },
+      { type: "response", text: "hello from flue" },
+    ]);
+  });
+
+  test("stringifies object results predictably", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = { prompt: async () => ({ answer: "ok", count: 2 }) };
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+    expect(response.chunks.at(-1)).toEqual({ type: "response", text: '{"answer":"ok","count":2}' });
+  });
+
+  test("rejects attachments explicitly", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = { prompt: async () => "should not be called" };
+    await expect(bridgePromptToFlue({
+      envelope: { prompt: "hello", attachments: [{ filename: "x.txt", content: new Uint8Array([1]) }] },
+      response,
+      mapping: mapping(),
+      flueClient: client,
+    })).rejects.toThrow("attachments are not supported");
+  });
+});

--- a/agents/flue/test/bridge.test.ts
+++ b/agents/flue/test/bridge.test.ts
@@ -12,7 +12,7 @@ function mapping(): FlueMapping {
       agent: "assistant",
       instance: "customer-123",
       session: "ticket-123",
-      transport: "websocket",
+      transport: "http-stream",
     },
   };
 }
@@ -28,8 +28,27 @@ describe("bridgePromptToFlue", () => {
     const client: FlueBridgeClient = { prompt: async () => "hello from flue" };
     await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
     expect(response.chunks).toEqual([
-      { type: "status", status: "connected to Flue assistant/customer-123 via websocket" },
+      { type: "status", status: "connected to Flue assistant/customer-123 via http-stream" },
       { type: "response", text: "hello from flue" },
+    ]);
+  });
+
+  test("forwards streaming text deltas as response chunks without duplicating the final result", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = {
+      prompt: async (_input, events) => {
+        await events?.onTextDelta?.("hello ");
+        await events?.onTextDelta?.("stream");
+        return "";
+      },
+    };
+
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+
+    expect(response.chunks).toEqual([
+      { type: "status", status: "connected to Flue assistant/customer-123 via http-stream" },
+      { type: "response", text: "hello " },
+      { type: "response", text: "stream" },
     ]);
   });
 

--- a/agents/flue/test/bridge.test.ts
+++ b/agents/flue/test/bridge.test.ts
@@ -40,6 +40,13 @@ describe("bridgePromptToFlue", () => {
     expect(response.chunks.at(-1)).toEqual({ type: "response", text: '{"answer":"ok","count":2}' });
   });
 
+  test("uses text from Flue sync result objects", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = { prompt: async () => ({ text: "echo:hello", usage: { totalTokens: 1 } }) };
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+    expect(response.chunks.at(-1)).toEqual({ type: "response", text: "echo:hello" });
+  });
+
   test("rejects attachments explicitly", async () => {
     const response = new RecordingResponse();
     const client: FlueBridgeClient = { prompt: async () => "should not be called" };

--- a/agents/flue/test/bridge.test.ts
+++ b/agents/flue/test/bridge.test.ts
@@ -52,6 +52,35 @@ describe("bridgePromptToFlue", () => {
     ]);
   });
 
+  test("does not emit an empty final response after streamed chunks", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = {
+      prompt: async (_input, events) => {
+        await events?.onTextDelta?.("chunk");
+        return "";
+      },
+    };
+
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+
+    expect(response.chunks).toEqual([
+      { type: "status", status: "connected to Flue assistant/customer-123 via http-stream" },
+      { type: "response", text: "chunk" },
+    ]);
+  });
+
+  test("emits a single empty response for non-streaming empty results", async () => {
+    const response = new RecordingResponse();
+    const client: FlueBridgeClient = { prompt: async () => "" };
+
+    await bridgePromptToFlue({ envelope: { prompt: "hello" }, response, mapping: mapping(), flueClient: client });
+
+    expect(response.chunks).toEqual([
+      { type: "status", status: "connected to Flue assistant/customer-123 via http-stream" },
+      { type: "response", text: "" },
+    ]);
+  });
+
   test("stringifies object results predictably", async () => {
     const response = new RecordingResponse();
     const client: FlueBridgeClient = { prompt: async () => ({ answer: "ok", count: 2 }) };

--- a/agents/flue/test/config.test.ts
+++ b/agents/flue/test/config.test.ts
@@ -42,4 +42,38 @@ describe("config", () => {
     const cfg = loadConfigFromSources({ argv: ["start"], env: { USER: "rene" }, readFile: () => "" });
     expect(cfg.flue.transport).toBe("http-stream");
   });
+
+  test("env owner overrides file owner and CLI owner overrides both", () => {
+    const file = `[agent]\nowner = "file-owner"\nname = "file-name"\n`;
+    const envWins = loadConfigFromSources({
+      argv: ["start"],
+      env: { SYNADIA_FLUE_OWNER: "env-owner", USER: "user-owner" },
+      readFile: () => file,
+    });
+    expect(envWins.agent.owner).toBe("env-owner");
+
+    const cliWins = loadConfigFromSources({
+      argv: ["start", "--owner", "cli-owner"],
+      env: { SYNADIA_FLUE_OWNER: "env-owner", USER: "user-owner" },
+      readFile: () => file,
+    });
+    expect(cliWins.agent.owner).toBe("cli-owner");
+  });
+
+  test("loads NATS creds from CLI, env, or config file precedence", () => {
+    const file = `[nats]\ncreds = "/file.creds"\n`;
+    const envWins = loadConfigFromSources({
+      argv: ["start"],
+      env: { USER: "rene", NATS_CREDS: "/env.creds" },
+      readFile: () => file,
+    });
+    expect(envWins.nats.creds).toBe("/env.creds");
+
+    const cliWins = loadConfigFromSources({
+      argv: ["start", "--nats-creds", "/cli.creds"],
+      env: { USER: "rene", NATS_CREDS: "/env.creds" },
+      readFile: () => file,
+    });
+    expect(cliWins.nats.creds).toBe("/cli.creds");
+  });
 });

--- a/agents/flue/test/config.test.ts
+++ b/agents/flue/test/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG_PATH, loadConfigFromSources, parseArgs, renderConfigTemplate } from "../src/config.js";
+
+describe("config", () => {
+  test("parses CLI flags", () => {
+    const flags = parseArgs(["start", "--owner", "rene", "--name", "support", "--flue-agent", "assistant"]);
+    expect(flags.command).toBe("start");
+    expect(flags.owner).toBe("rene");
+    expect(flags.name).toBe("support");
+    expect(flags.flueAgent).toBe("assistant");
+  });
+
+  test("CLI overrides env and defaults", () => {
+    const cfg = loadConfigFromSources({
+      argv: ["start", "--owner", "cli-owner", "--name", "cli-name", "--flue-agent", "cli-agent"],
+      env: {
+        SYNADIA_FLUE_OWNER: "env-owner",
+        SYNADIA_FLUE_NAME: "env-name",
+        FLUE_BASE_URL: "http://env.example",
+        FLUE_AGENT: "env-agent",
+        FLUE_INSTANCE: "env-instance",
+      },
+      readFile: () => "",
+    });
+    expect(cfg.agent.owner).toBe("cli-owner");
+    expect(cfg.agent.name).toBe("cli-name");
+    expect(cfg.flue.agent).toBe("cli-agent");
+    expect(cfg.flue.baseUrl).toBe("http://env.example");
+    expect(cfg.flue.instance).toBe("env-instance");
+  });
+
+  test("renders a config template", () => {
+    const template = renderConfigTemplate();
+    expect(template).toContain("[nats]");
+    expect(template).toContain("[agent]");
+    expect(template).toContain("[flue]");
+    expect(DEFAULT_CONFIG_PATH).toContain("flue-nats-channel.toml");
+  });
+});

--- a/agents/flue/test/config.test.ts
+++ b/agents/flue/test/config.test.ts
@@ -76,4 +76,25 @@ describe("config", () => {
     });
     expect(cliWins.nats.creds).toBe("/cli.creds");
   });
+
+  test("strips inline TOML comments before parsing numeric fields", () => {
+    const file = `[agent]\nheartbeat_interval_s = 30 # seconds\nkeepalive_interval_s = 45 # seconds\n`;
+    const cfg = loadConfigFromSources({
+      argv: ["start"],
+      env: { USER: "rene" },
+      readFile: () => file,
+    });
+
+    expect(cfg.agent.heartbeatIntervalS).toBe(30);
+    expect(cfg.agent.keepaliveIntervalS).toBe(45);
+  });
+
+  test("rejects invalid numeric config values", () => {
+    const file = `[agent]\nheartbeat_interval_s = not-a-number\n`;
+    expect(() => loadConfigFromSources({
+      argv: ["start"],
+      env: { USER: "rene" },
+      readFile: () => file,
+    })).toThrow("agent.heartbeat_interval_s must be a positive number");
+  });
 });

--- a/agents/flue/test/config.test.ts
+++ b/agents/flue/test/config.test.ts
@@ -34,12 +34,12 @@ describe("config", () => {
     expect(template).toContain("[nats]");
     expect(template).toContain("[agent]");
     expect(template).toContain("[flue]");
-    expect(template).toContain('transport = "http-sync"');
+    expect(template).toContain('transport = "http-stream"');
     expect(DEFAULT_CONFIG_PATH).toContain("flue-nats-channel.toml");
   });
 
-  test("defaults to HTTP sync Flue transport", () => {
+  test("defaults to HTTP stream Flue transport", () => {
     const cfg = loadConfigFromSources({ argv: ["start"], env: { USER: "rene" }, readFile: () => "" });
-    expect(cfg.flue.transport).toBe("http-sync");
+    expect(cfg.flue.transport).toBe("http-stream");
   });
 });

--- a/agents/flue/test/config.test.ts
+++ b/agents/flue/test/config.test.ts
@@ -34,6 +34,12 @@ describe("config", () => {
     expect(template).toContain("[nats]");
     expect(template).toContain("[agent]");
     expect(template).toContain("[flue]");
+    expect(template).toContain('transport = "http-sync"');
     expect(DEFAULT_CONFIG_PATH).toContain("flue-nats-channel.toml");
+  });
+
+  test("defaults to HTTP sync Flue transport", () => {
+    const cfg = loadConfigFromSources({ argv: ["start"], env: { USER: "rene" }, readFile: () => "" });
+    expect(cfg.flue.transport).toBe("http-sync");
   });
 });

--- a/agents/flue/test/doctor.test.ts
+++ b/agents/flue/test/doctor.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { runDoctorChecks } from "../src/doctor.js";
+import type { FlueChannelConfig } from "../src/config.js";
+
+describe("doctor", () => {
+  test("reports Flue HTTP reachability through injected fetch", async () => {
+    const cfg: FlueChannelConfig = {
+      nats: { url: "nats://127.0.0.1:4222" },
+      agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
+      flue: { baseUrl: "http://flue.local", agent: "assistant", instance: "customer-123", session: "default", transport: "websocket" },
+    };
+    const checks = await runDoctorChecks(cfg, { fetch: (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch });
+    expect(checks.some((c) => c.name === "flue-http" && c.ok)).toBe(true);
+  });
+});

--- a/agents/flue/test/doctor.test.ts
+++ b/agents/flue/test/doctor.test.ts
@@ -7,7 +7,7 @@ describe("doctor", () => {
     const cfg: FlueChannelConfig = {
       nats: { url: "nats://127.0.0.1:4222" },
       agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
-      flue: { baseUrl: "http://flue.local", agent: "assistant", instance: "customer-123", session: "default", transport: "websocket" },
+      flue: { baseUrl: "http://flue.local", agent: "assistant", instance: "customer-123", session: "default", transport: "http-stream" },
     };
     const checks = await runDoctorChecks(cfg, { fetch: (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch });
     expect(checks.some((c) => c.name === "flue-http" && c.ok)).toBe(true);

--- a/agents/flue/test/doctor.test.ts
+++ b/agents/flue/test/doctor.test.ts
@@ -12,4 +12,16 @@ describe("doctor", () => {
     const checks = await runDoctorChecks(cfg, { fetch: (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch });
     expect(checks.some((c) => c.name === "flue-http" && c.ok)).toBe(true);
   });
+
+  test("treats HTTP 405 as reachable Flue server with unsupported probe method", async () => {
+    const cfg: FlueChannelConfig = {
+      nats: { url: "nats://127.0.0.1:4222" },
+      agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
+      flue: { baseUrl: "http://flue.local", agent: "assistant", instance: "customer-123", session: "default", transport: "http-stream" },
+    };
+    const checks = await runDoctorChecks(cfg, { fetch: (async () => new Response("method", { status: 405 })) as unknown as typeof fetch });
+    const flue = checks.find((c) => c.name === "flue-http");
+    expect(flue?.ok).toBe(true);
+    expect(flue?.message).toContain("reachable");
+  });
 });

--- a/agents/flue/test/flue-client.test.ts
+++ b/agents/flue/test/flue-client.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const invoke = mock(async function* () {
+  yield { type: "status", status: "started" };
+  yield { type: "done" };
+});
+
+mock.module("@flue/sdk", () => ({
+  createFlueClient: () => ({
+    agents: {
+      invoke,
+      connect: () => { throw new Error("websocket not used in this test"); },
+    },
+  }),
+}));
+
+const { SdkFlueBridgeClient } = await import("../src/flue-client.js");
+
+describe("SdkFlueBridgeClient", () => {
+  afterEach(() => {
+    invoke.mockClear();
+  });
+
+  test("does not leak raw Flue event arrays when HTTP stream has no text deltas", async () => {
+    const client = new SdkFlueBridgeClient();
+
+    const result = await client.prompt({
+      message: "empty",
+      baseUrl: "http://127.0.0.1:3583",
+      agent: "echo",
+      instance: "test",
+      session: "session",
+      transport: "http-stream",
+    });
+
+    expect(result).toBe("");
+    expect(invoke).toHaveBeenCalledWith("echo", "test", {
+      mode: "stream",
+      payload: { message: "empty", session: "session" },
+    });
+  });
+});

--- a/agents/flue/test/nats.test.ts
+++ b/agents/flue/test/nats.test.ts
@@ -1,0 +1,24 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { resolveNatsOptions } from "../src/nats.js";
+
+const DUMMY_CREDS = `-----BEGIN NATS USER JWT-----\nabc\n------END NATS USER JWT------\n\n-----BEGIN USER NKEY SEED-----\nnot-a-real-seed-fixture\n------END USER NKEY SEED------\n`;
+
+describe("resolveNatsOptions", () => {
+  test("test creds fixture does not embed NKEY seed-shaped material", () => {
+    expect(DUMMY_CREDS).not.toMatch(/S[A-Z0-9]{57}/);
+  });
+
+  test("wires [nats].creds into URL-based connection options", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flue-nats-creds-"));
+    const creds = join(dir, "user.creds");
+    writeFileSync(creds, DUMMY_CREDS, "utf8");
+
+    const opts = await resolveNatsOptions({ url: "nats://demo.example:4222", creds });
+
+    expect(opts.servers).toEqual(["nats://demo.example:4222"]);
+    expect(opts.authenticator).toBeDefined();
+  });
+});

--- a/agents/flue/test/service.test.ts
+++ b/agents/flue/test/service.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { buildAgentServiceOptions } from "../src/service.js";
+import type { FlueChannelConfig } from "../src/config.js";
+
+describe("service construction", () => {
+  test("builds AgentService options for flue using canonical subject token and metadata", () => {
+    const cfg: FlueChannelConfig = {
+      nats: { url: "nats://127.0.0.1:4222" },
+      agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
+      flue: { baseUrl: "http://127.0.0.1:3583", agent: "assistant", instance: "customer-123", session: "ticket-123", transport: "websocket" },
+    };
+    const opts = buildAgentServiceOptions({ nc: {} as never, config: cfg, version: "0.1.0" });
+    expect(opts.agent).toBe("flue");
+    expect(opts.subjectToken).toBe("flue");
+    expect(opts.owner).toBe("rene");
+    expect(opts.name).toBe("support");
+    expect(opts.attachmentsOk).toBe(false);
+    expect(opts.extraMetadata).toEqual({
+      flue_base_url: "http://127.0.0.1:3583",
+      flue_agent: "assistant",
+      flue_instance: "customer-123",
+      flue_session: "ticket-123",
+      flue_transport: "websocket",
+    });
+  });
+});

--- a/agents/flue/test/service.test.ts
+++ b/agents/flue/test/service.test.ts
@@ -7,7 +7,7 @@ describe("service construction", () => {
     const cfg: FlueChannelConfig = {
       nats: { url: "nats://127.0.0.1:4222" },
       agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
-      flue: { baseUrl: "http://127.0.0.1:3583", agent: "assistant", instance: "customer-123", session: "ticket-123", transport: "websocket" },
+      flue: { baseUrl: "http://127.0.0.1:3583", agent: "assistant", instance: "customer-123", session: "ticket-123", transport: "http-stream" },
     };
     const opts = buildAgentServiceOptions({ nc: {} as never, config: cfg, version: "0.1.0" });
     expect(opts.agent).toBe("flue");
@@ -20,7 +20,7 @@ describe("service construction", () => {
       flue_agent: "assistant",
       flue_instance: "customer-123",
       flue_session: "ticket-123",
-      flue_transport: "websocket",
+      flue_transport: "http-stream",
     });
   });
 });

--- a/agents/flue/test/subject.test.ts
+++ b/agents/flue/test/subject.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { resolveOwner, sanitizeSubjectToken } from "../src/subject.js";
+
+describe("subject helpers", () => {
+  test("sanitizes recommended subject tokens", () => {
+    expect(sanitizeSubjectToken("Rene Rocks AI!")).toBe("rene-rocks-ai");
+    expect(sanitizeSubjectToken("--Already_OK--")).toBe("already_ok");
+  });
+
+  test("falls back to unknown when selected owner sanitizes empty", () => {
+    expect(resolveOwner("!!!", "env-owner", "user")).toBe("unknown");
+  });
+
+  test("uses explicit/env/user owner precedence", () => {
+    expect(resolveOwner("Explicit Owner", "env-owner", "user")).toBe("explicit-owner");
+    expect(resolveOwner(undefined, "Env Owner", "user")).toBe("env-owner");
+    expect(resolveOwner(undefined, undefined, "Local User")).toBe("local-user");
+  });
+});

--- a/agents/flue/tsconfig.json
+++ b/agents/flue/tsconfig.json
@@ -12,5 +12,5 @@
     "exactOptionalPropertyTypes": true,
     "types": ["node", "bun-types"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
 }

--- a/agents/flue/tsconfig.json
+++ b/agents/flue/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node", "bun-types"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `agents/flue`, a Bun-first TypeScript sidecar that exposes a running Flue agent through the Synadia Agent Protocol for NATS using `AgentService`.

Key pieces:

- Adds a Flue-backed `AgentService` adapter under `agents/flue`.
- Supports NATS context mode and URL mode with optional creds-file auth.
- Implements config loading with `CLI > env > file > defaults` precedence.
- Defaults Flue transport to `http-stream` after real-runtime verification.
- Keeps WebSocket as explicit diagnostic-only because local Flue 0.9.1 WebSocket failed during real-runtime smoke probing.
- Adds CLI commands: `configure`, `doctor`, and `start`.
- Adds unit tests plus local protocol and real-Flue smoke scripts.
- Documents install/config/start/doctor/troubleshooting/limitations in `agents/flue/README.md`.

## Validation

Ran from `agents/flue` on branch `feat/flue-nats-adapter` at `770e8d1`:

```text
bun run typecheck
PASS: tsc --noEmit

bun test
19 pass
0 fail
42 expect() calls

bun run smoke:protocol
PASS: real local NATS + injected fake Flue client returned ack → connected → response → done

FLUE_BASE_URL=http://127.0.0.1:3583 \
FLUE_AGENT=echo \
FLUE_INSTANCE=real-smoke-dev \
FLUE_SESSION=real-smoke-dev \
SMOKE_PROMPT=hello-real-flow \
SMOKE_EXPECTS=echo:hello-real-flow \
bun run smoke:real-flue
PASS: real local Flue faux echo over http-stream; chunks concatenated to echo:hello-real-flow

git diff --check
PASS
```

Security hygiene:

```text
git grep -n -E "S[A-Z0-9]{57}" HEAD -- agents/flue
PASS: no matches

git grep -n -E "S[A-Z0-9]{57}" $(git rev-list origin/main..HEAD) -- agents/flue
PASS: no matches
```

## Notes

- The real-Flue smoke uses a deterministic faux/echo provider so it exercises the real Flue runtime/SDK boundary without requiring LLM credentials.
- Attachments are intentionally not supported yet; the service registers `attachmentsOk: false`.
- WebSocket remains available for diagnosis, but `http-stream` is the safe default based on the verified local runtime behavior.
