### PR TITLE
docs: list Flue in agent directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ compatibility between the two SDKs.
 | `agents/openclaw/` | `@synadia-ai/nats-channel` | npm (public) | OpenClaw plugin |
 | `agents/claude-code/` | `claude-channel-nats` | npm (public) | Claude Code MCP plugin |
 | `agents/hermes/` | — | not in repo | README only; ships from upstream Hermes |
+| `agents/flue/` | `@synadia-ai/flue-nats-channel` | npm (public) | Flue sidecar channel |
 | `examples/pi-headless/` | `@synadia-ai/nats-pi-headless` | npm (public) | depends on `@synadia-ai/agents@^0.5.x` |
 | `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | github only | local-clone test client; `private: true` so it never publishes |
 | `examples/dspy/` | `@synadia-ai/nats-dspy-agent` | private | uses `file:` link to local SDK |

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -81,7 +81,7 @@ bun client-sdk/typescript/examples/_run-reference-agent.ts
 bun agent-sdk/typescript/examples/01-echo.ts
 ```
 
-## Installing the agent plugins locally (PI, OpenClaw, Claude Code)
+## Installing extension-style agent plugins locally (PI, OpenClaw, Claude Code)
 
 `agents/pi/`, `agents/openclaw/`, and `agents/claude-code/` are
 extension/plugin packages that get loaded by their host application
@@ -89,6 +89,10 @@ extension/plugin packages that get loaded by their host application
 the extension it follows the `file:` link in the extension's
 `package.json` back to the SDK source — so both SDKs need a current
 `dist/` when the extension is installed.
+
+Other agent packages in `agents/`, including `agents/flue/`, run as
+sidecars or wrappers rather than host-loaded extensions; follow their
+per-agent READMEs for local startup.
 
 ```sh
 # Build the SDKs, then install the extension into its host application.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **SDKs and ready-to-run agent plugins for the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).**
 
-The Synadia Agent Protocol for NATS lets any AI agent — Claude Code, OpenClaw, PI, Hermes, or your own — register itself as a NATS micro service named `agents`, and be discovered, prompted, and streamed from by any caller speaking the same wire format. This repo is the home of the official **caller** and **host** SDKs (TypeScript and Python — see [SDKs](#sdks) below), plus pre-built channel plugins that put popular AI harnesses on NATS without writing code.
+The Synadia Agent Protocol for NATS lets any AI agent — Claude Code, OpenClaw, PI, Hermes, Flue, or your own — register itself as a NATS micro service named `agents`, and be discovered, prompted, and streamed from by any caller speaking the same wire format. This repo is the home of the official **caller** and **host** SDKs (TypeScript and Python — see [SDKs](#sdks) below), plus pre-built channel plugins that put popular AI harnesses on NATS without writing code.
 
 ## Get started — pick your path
 
 | You want to… | Go to | Install |
 | --- | --- | --- |
-| **Put an existing AI agent on NATS** (Claude Code, OpenClaw, PI, Hermes, DSPy ReAct) | [`agents/`](agents/) — pick the agent | per-agent README |
+| **Put an existing AI agent on NATS** (Claude Code, OpenClaw, PI, Hermes, Flue, DSPy ReAct) | [`agents/`](agents/) — pick the agent | per-agent README |
 | **Build a caller** that discovers and prompts agents | [`client-sdk/typescript/`](client-sdk/typescript/) · [`client-sdk/python/`](client-sdk/python/) | `npm i @synadia-ai/agents` · `pip install synadia-ai-agents` |
 | **Host a brand-new agent** built from scratch | [`agent-sdk/typescript/`](agent-sdk/typescript/) · [`agent-sdk/python/`](agent-sdk/python/) | `npm i @synadia-ai/agent-service` · `pip install synadia-ai-agent-service` |
 
@@ -23,6 +23,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [PI Agent](agents/pi/) | `pi` | `@synadia-ai/nats-pi-channel` |
 | [Hermes](agents/hermes/) | `hermes` | upstream fork — see [`agents/hermes/`](agents/hermes/) (work in progress) |
 | [DeerFlow](agents/deerflow/) | `df` | `synadia-ai-nats-deerflow-channel` — external Python wrapper for a running DeerFlow Gateway |
+| [Flue](agents/flue/) | `flue` | `@synadia-ai/flue-nats-channel` — sidecar for a running Flue app / agent |
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 
@@ -151,6 +152,7 @@ synadia-agents/
 │   ├── pi/
 │   ├── hermes/
 │   ├── deerflow/
+│   ├── flue/
 │   └── open-agent/              ← inbound bridge for vercel-labs/open-agents
 └── examples/              ← apps built with the SDKs (callers and agents)
     ├── agent-web-ui/             ← Vue 3 + Bun browser client

--- a/agent-sdk/typescript/README.md
+++ b/agent-sdk/typescript/README.md
@@ -103,7 +103,7 @@ The SDK exports the chunk and heartbeat encoders for harnesses that need them ou
 | `encodeHeartbeatPayload(payload)`                              | Encode that payload to wire JSON bytes.                                    |
 | `DEFAULT_MAX_PAYLOAD` / `DEFAULT_*` constants                  | Fallback values when no broker `INFO.max_payload` is reported, etc.        |
 
-The `agents/openclaw`, `agents/pi`, and `agents/claude-code` harnesses in this monorepo use these primitives directly today; the controller agents in `examples/pi-headless` and `examples/claude-code-headless` are the obvious migration candidates for `AgentService`.
+The `agents/openclaw`, `agents/pi`, and `agents/claude-code` harnesses in this monorepo use these primitives directly today; `agents/flue` uses `AgentService` directly as a sidecar for a running Flue app, and the controller agents in `examples/pi-headless` and `examples/claude-code-headless` are obvious migration candidates for `AgentService`.
 
 ## Reference agent (`@synadia-ai/agent-service/testing`)
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-Plugins that wrap existing AI harnesses — PI, OpenClaw, Claude Code, Hermes, DeerFlow, and open-agent — as NATS micro services speaking the **Synadia Agent Protocol for NATS**, so any SDK in `../client-sdk/` can drive them the same way.
+Plugins that wrap existing AI harnesses — PI, OpenClaw, Claude Code, Hermes, DeerFlow, Flue, and open-agent — as NATS micro services speaking the **Synadia Agent Protocol for NATS**, so any SDK in `../client-sdk/` can drive them the same way.
 
 The plugins are built on the SDK pair: caller-side primitives from [`../client-sdk/`](../client-sdk/) for subjects, envelope types, and the error hierarchy; server-side helpers from [`../agent-sdk/`](../agent-sdk/) (`encodeChunk`, `splitResponseText`, the heartbeat-payload encoders, and — when the harness fits — `AgentService`) for putting an agent on the wire. The OpenClaw, PI, and Claude Code harnesses currently call the encoders directly; the controller agents in [`../examples/pi-headless/`](../examples/pi-headless/) and [`../examples/claude-code-headless/`](../examples/claude-code-headless/) are obvious migration candidates for `AgentService` once their custom `spawn` / `stop` / `list` endpoints land on `extraEndpoints`.
 
@@ -16,6 +16,7 @@ For an example of *building* a fresh agent from scratch with the host SDK, see [
 | `hermes/`           | `hermes`   | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `agents.prompt.hermes.<owner>.<name>`          | server-negotiated (config can request a smaller cap) | true |
 | `open-agent/`       | `open-agent` | [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) | `agents.prompt.open-agent.<owner>.<session>` | server-negotiated | false |
 | `deerflow/`         | `df`       | [DeerFlow](https://deerflow.tech/) Gateway | `agents.prompt.df.<owner>.<session>` | server-negotiated by default; optional smaller configured cap | true |
+| `flue/`             | `flue`     | [Flue](https://flueframework.com/) app / agent | `agents.prompt.flue.<owner>.<name>` | server-negotiated | false |
 
 Most agents read `max_payload` from the NATS connection's `INFO` block at startup and advertise that server limit formatted into the §2.1 `\d+(B|KB|MB|GB)` grammar. A `nats-server` running the default 1 MB advertises `1MB`; bump `--max_payload 8MB` and server-negotiated agents track it. Agents with their own configured cap, such as Hermes or DeerFlow when `max_payload` is explicitly set, advertise that configured cap unless the NATS server is smaller, in which case they clamp down to the server limit.
 
@@ -33,6 +34,7 @@ Every agent registers a NATS micro service called `agents` with an endpoint name
 - **`open-agent/`** - inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents). Vendors `packages/agent` verbatim and ships a `LocalSandbox` so the harness runs without a Vercel account; first agent in the repo built directly on `AgentService` from `@synadia-ai/agent-service`. The companion [`../examples/open-agent-vercel/`](../examples/open-agent-vercel/) swaps in `@vercel/sandbox` to prove the sandbox seam is interchangeable. v1 is single-process / single-session (one bridge handles one `(owner, session)` pair).
 - **`hermes/`** - full Hermes Agent (CLI + TUI + messaging gateway). Unlike the others, each gateway registers **one** identity and multiplexes conversations via the envelope's optional `session` field (§5.1); subject stays stable per instance. Images route through Hermes's `vision_analyze` tool so the model actually sees them. Currently installed from [`synadia-ai/hermes-agent`, branch `nats-gateway`](https://github.com/synadia-ai/hermes-agent/tree/nats-gateway) - upstream PR pending.
 - **`deerflow/`** - external Python wrapper around a running DeerFlow Gateway. Built on `synadia-ai-agent-service`, uploads protocol attachments to DeerFlow's thread uploads API, includes the returned upload metadata in `additional_kwargs.files` for the Gateway run, streams Gateway SSE responses as protocol chunks, and bridges DeerFlow clarification requests to protocol `query` chunks.
+- **`flue/`** - sidecar for a running Flue app / agent. Built on `@synadia-ai/agent-service`, forwards prompts through `@flue/sdk`, streams Flue HTTP events as protocol response chunks, and keeps liveness (`status` / `hb`) owned by the sidecar. Attachments are rejected until Flue-side upload semantics are mapped.
 
 Most agents that accept attachments decode them to disk and prepend the absolute paths to the prompt text like so. DeerFlow is the exception: it uploads attachments to the Gateway and sends the returned upload metadata as `additional_kwargs.files`.
 

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -304,7 +304,7 @@ asyncio.run(main())
 
 ## See also
 
-- Sibling channel plugins: [`pi`](../pi), [`openclaw`](../openclaw), [`claude-code`](../claude-code), and [`hermes`](../hermes).
+- Sibling channel plugins: [`pi`](../pi), [`openclaw`](../openclaw), [`claude-code`](../claude-code), [`hermes`](../hermes), and [`flue`](../flue).
 - Python caller SDK: [`../../client-sdk/python`](../../client-sdk/python).
 - Python host SDK: [`../../agent-sdk/python`](../../agent-sdk/python).
 - Wire protocol: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).

--- a/agents/flue/README.md
+++ b/agents/flue/README.md
@@ -284,3 +284,9 @@ Expected. The sidecar currently maps text prompts only and rejects attachments e
 - One configured Flue target per sidecar process.
 - `websocket` support depends on the Flue deployment's WebSocket agent connection behavior.
 - Local faux-echo smoke tests prove runtime/SDK compatibility, not model quality.
+
+## See also
+
+- Sibling channel plugins: [`pi`](../pi), [`openclaw`](../openclaw), [`claude-code`](../claude-code), [`hermes`](../hermes), [`deerflow`](../deerflow), and [`open-agent`](../open-agent).
+- TypeScript host SDK: [`../../agent-sdk/typescript`](../../agent-sdk/typescript).
+- Wire protocol: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -292,7 +292,7 @@ The plugin pulls `@synadia-ai/agents` (caller-side primitives) and `@synadia-ai/
 
 ## See also
 
-- Sibling channel plugins: [`pi`](../pi) (PI Agent), [`claude-code`](../claude-code) (Claude Code).
+- Sibling channel plugins: [`pi`](../pi) (PI Agent), [`claude-code`](../claude-code) (Claude Code), [`deerflow`](../deerflow) (DeerFlow), and [`flue`](../flue) (Flue).
 - The wire-level protocol behind it all: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).
 
 ## License

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -230,7 +230,7 @@ Deliberate deferrals:
 
 ## See also
 
-- Sibling channel plugins: [`openclaw`](../openclaw) (OpenClaw), [`claude-code`](../claude-code) (Claude Code).
+- Sibling channel plugins: [`openclaw`](../openclaw) (OpenClaw), [`claude-code`](../claude-code) (Claude Code), [`deerflow`](../deerflow) (DeerFlow), and [`flue`](../flue) (Flue).
 - The wire-level protocol behind it all: [`synadia-ai/synadia-agent-sdk-docs`](https://github.com/synadia-ai/synadia-agent-sdk-docs).
 
 ## License

--- a/docs/using-nats-cli.md
+++ b/docs/using-nats-cli.md
@@ -146,6 +146,6 @@ The `cc-headless` controller has the same three verbs. See `examples/pi-headless
 ## See also
 
 - The protocol spec: <https://github.com/synadia-ai/synadia-agent-sdk-docs>
-- Per-agent READMEs with agent-specific subject layouts: `agents/{pi,openclaw,claude-code,open-agent}/README.md`
+- Per-agent READMEs with agent-specific subject layouts: `agents/{claude-code,deerflow,flue,hermes,open-agent,openclaw,pi}/README.md`
 - Headless examples with control-plane endpoints: `examples/{pi,claude-code}-headless/README.md`
 - SDK-driven equivalents: `client-sdk/typescript/examples/`, `client-sdk/python/examples/`

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -9,7 +9,8 @@ prompt, and manage sessions from the browser.
 Primary use: manually poking at the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs)
 implementations - [`pi`](../../agents/pi), [`claude-code`](../../agents/claude-code),
 [`openclaw`](../../agents/openclaw), [`hermes`](../../agents/hermes),
-[`pi-headless`](../pi-headless), and the SDK's own reference agent.
+[`deerflow`](../../agents/deerflow), [`flue`](../../agents/flue),
+[`open-agent`](../../agents/open-agent), [`pi-headless`](../pi-headless), and the SDK's own reference agent.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Add Flue to the root available-agent overview, package table, and repository layout.
- Add Flue to `agents/README.md` with token, subject, package, attachment support, and per-agent notes.
- Add Flue to sibling/usage references in agent READMEs, the web UI README, NATS CLI docs, dev docs, and the TS host SDK README.
- Add a `See also` section to `agents/flue/README.md` and make the web UI target list complete for DeerFlow and open-agent too.

## Verification

```text
git diff --check
PASS

link target check
PASS

cd agents/flue && bun run typecheck
PASS

cd agents/flue && bun test
24 pass
0 fail
49 expect() calls
```
