### PR TITLE
fix: align Flue channel with conformance checklist

### DIFF
--- a/agent-sdk/typescript/CHANGELOG.md
+++ b/agent-sdk/typescript/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `AgentService` now maps handler-raised `ProtocolError`s to
+  `Nats-Service-Error-Code: 400` responses while preserving the existing
+  `500` mapping for ordinary handler failures. This lets agent adapters reject
+  decoded-but-unsupported client input, such as attachments for an
+  `attachments_ok=false` endpoint, without misreporting the request as a server
+  failure.
+
 ## [0.5.2] - 2026-05-11
 
 ### Changed

--- a/agent-sdk/typescript/src/service.ts
+++ b/agent-sdk/typescript/src/service.ts
@@ -620,6 +620,8 @@ export class AgentService {
       try {
         const desc = err instanceof Error ? err.message : String(err);
         const isProtocolError =
+          // Cross-realm / duplicate-module guard: adapters may throw a
+          // ProtocolError class from another installed SDK copy.
           err instanceof ProtocolError || (err instanceof Error && err.name === "ProtocolError");
         msg.respondError(
           isProtocolError ? 400 : 500,

--- a/agent-sdk/typescript/src/service.ts
+++ b/agent-sdk/typescript/src/service.ts
@@ -24,7 +24,8 @@
 //   - Emits the spec-mandated empty-body no-headers terminator after
 //     every prompt — successful or errored (§6.5, §9.3).
 //   - Translates handler exceptions into `Nats-Service-Error-Code: 500`
-//     responses; envelope decode failures into `400` (§9.1).
+//     responses, while envelope decode failures and handler-raised
+//     `ProtocolError`s become `400` (§9.1).
 //
 // Mirrors the Python SDK's `AgentService` (`client-sdk/python/src/synadia_ai/agents/service.py`)
 // — wire-equivalent behaviour, idiomatic TS API.
@@ -618,7 +619,12 @@ export class AgentService {
       stopKeepalive();
       try {
         const desc = err instanceof Error ? err.message : String(err);
-        msg.respondError(500, sanitizeErrorDesc(`handler error: ${desc}`));
+        const isProtocolError =
+          err instanceof ProtocolError || (err instanceof Error && err.name === "ProtocolError");
+        msg.respondError(
+          isProtocolError ? 400 : 500,
+          sanitizeErrorDesc(isProtocolError ? desc : `handler error: ${desc}`),
+        );
       } catch {
         /* connection may already be gone */
       }

--- a/agent-sdk/typescript/test/integration/agent-service.test.ts
+++ b/agent-sdk/typescript/test/integration/agent-service.test.ts
@@ -5,6 +5,7 @@ import {
   Agents,
   decodeBase64,
   decodeHeartbeatPayload,
+  ProtocolError,
   type StreamMessage,
 } from "@synadia-ai/agents";
 import { AgentService } from "../../src/service.js";
@@ -232,6 +233,36 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     expect(errorMsg).toBeDefined();
     const terminator = messages.find((m) => !m.headers && m.data.length === 0);
     expect(terminator).toBeDefined();
+  });
+
+  it("maps handler-raised ProtocolError to a 400 response plus terminator", async () => {
+    const service = startService();
+    service.onPrompt(() => {
+      throw new ProtocolError("attachments are not supported by this agent");
+    });
+    await service.start();
+
+    const reply = `_INBOX.agents.svc-test-${Math.random().toString(36).slice(2, 8)}`;
+    const sub = nc.subscribe(reply);
+    await nc.flush();
+    nc.publish(service.subject.prompt, new TextEncoder().encode("plain prompt"), { reply });
+
+    const messages: Msg[] = [];
+    for await (const m of sub) {
+      messages.push(m);
+      if (
+        messages.some((mm) => mm.headers?.get("Nats-Service-Error-Code") === "400") &&
+        messages.some((mm) => !mm.headers && mm.data.length === 0)
+      ) {
+        sub.unsubscribe();
+        break;
+      }
+    }
+
+    const errorMsg = messages.find((m) => m.headers?.get("Nats-Service-Error-Code") === "400");
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg?.headers?.get("Nats-Service-Error")).toContain("attachments are not supported");
+    expect(messages.find((m) => !m.headers && m.data.length === 0)).toBeDefined();
   });
 
   it("answers the v0.3 status endpoint with a heartbeat-shaped payload", async () => {

--- a/agent-sdk/typescript/test/integration/agent-service.test.ts
+++ b/agent-sdk/typescript/test/integration/agent-service.test.ts
@@ -165,6 +165,32 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     expect(receivedAttachmentCount).toBe(0);
   });
 
+  it("routes the §5.3 plain-text shorthand to the handler", async () => {
+    let receivedPrompt: string | null = null;
+    const service = startService();
+    service.onPrompt(async (envelope, response) => {
+      receivedPrompt = envelope.prompt;
+      await response.send("plain text routed");
+    });
+    await service.start();
+
+    const reply = `_INBOX.agents.svc-test-${Math.random().toString(36).slice(2, 8)}`;
+    const sub = nc.subscribe(reply);
+    await nc.flush();
+    nc.publish(service.subject.prompt, new TextEncoder().encode("plain prompt"), { reply });
+
+    const messages: Msg[] = [];
+    for await (const m of sub) {
+      messages.push(m);
+      if (messages.some((mm) => !mm.headers && mm.data.length === 0)) {
+        sub.unsubscribe();
+        break;
+      }
+    }
+
+    expect(receivedPrompt).toBe("plain prompt");
+  });
+
   it("decodes attachments via the SDK's strict base64 + filename guard", async () => {
     let receivedFilename: string | null = null;
     let receivedBytes: Uint8Array | null = null;
@@ -236,8 +262,10 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
   });
 
   it("maps handler-raised ProtocolError to a 400 response plus terminator", async () => {
+    let handlerCalled = false;
     const service = startService();
     service.onPrompt(() => {
+      handlerCalled = true;
       throw new ProtocolError("attachments are not supported by this agent");
     });
     await service.start();
@@ -245,7 +273,13 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
     const reply = `_INBOX.agents.svc-test-${Math.random().toString(36).slice(2, 8)}`;
     const sub = nc.subscribe(reply);
     await nc.flush();
-    nc.publish(service.subject.prompt, new TextEncoder().encode("plain prompt"), { reply });
+    nc.publish(
+      service.subject.prompt,
+      new TextEncoder().encode(JSON.stringify({ prompt: "plain prompt" })),
+      {
+        reply,
+      },
+    );
 
     const messages: Msg[] = [];
     for await (const m of sub) {
@@ -259,6 +293,7 @@ describe.skipIf(!natsUrl)("AgentService — round-trip via real broker", () => {
       }
     }
 
+    expect(handlerCalled).toBe(true);
     const errorMsg = messages.find((m) => m.headers?.get("Nats-Service-Error-Code") === "400");
     expect(errorMsg).toBeDefined();
     expect(errorMsg?.headers?.get("Nats-Service-Error")).toContain("attachments are not supported");

--- a/agents/flue/scripts/protocol-smoke.ts
+++ b/agents/flue/scripts/protocol-smoke.ts
@@ -89,15 +89,36 @@ try {
     { reply: attachmentReply },
   );
   const attachmentFrames = [];
-  for await (const frame of attachmentSub) {
-    attachmentFrames.push(frame);
-    if (
-      attachmentFrames.some((m) => m.headers?.get("Nats-Service-Error-Code")) &&
-      attachmentFrames.some((m) => !m.headers && m.data.length === 0)
-    ) {
-      attachmentSub.unsubscribe();
-      break;
+  const attachmentIterator = attachmentSub[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const result = await Promise.race([
+        attachmentIterator.next(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error("timed out waiting for attachment rejection frames"),
+              ),
+            5000,
+          );
+        }),
+      ]);
+      if (timer) clearTimeout(timer);
+      if (result.done) break;
+      attachmentFrames.push(result.value);
+      if (
+        attachmentFrames.some((m) =>
+          m.headers?.get("Nats-Service-Error-Code"),
+        ) &&
+        attachmentFrames.some((m) => !m.headers && m.data.length === 0)
+      ) {
+        break;
+      }
     }
+  } finally {
+    attachmentSub.unsubscribe();
   }
   const attachmentError = attachmentFrames.find((m) =>
     m.headers?.get("Nats-Service-Error-Code"),

--- a/agents/flue/scripts/protocol-smoke.ts
+++ b/agents/flue/scripts/protocol-smoke.ts
@@ -33,28 +33,115 @@ const fakeFlueClient: FlueBridgeClient = {
 
 const nc = await natsConnect({ servers: natsUrl });
 const callerNc = await natsConnect({ servers: natsUrl });
-const service = createFlueAgentService({ nc, config, version: "0.1.0-smoke", flueClient: fakeFlueClient });
+const service = createFlueAgentService({
+  nc,
+  config,
+  version: "0.1.0-smoke",
+  flueClient: fakeFlueClient,
+});
 
 try {
   await service.start();
   const agents = new Agents({ nc: callerNc });
-  const found = await agents.discover({ timeoutMs: 1000, filter: { agent: "flue", name } });
-  if (found.length !== 1) throw new Error(`expected one flue smoke agent, found ${found.length}`);
+  const found = await agents.discover({
+    timeoutMs: 1000,
+    filter: { agent: "flue", name },
+  });
+  if (found.length !== 1)
+    throw new Error(`expected one flue smoke agent, found ${found.length}`);
+  const agent = found[0]!;
+  if (agent.metadata["agent"] !== "flue")
+    throw new Error("service metadata missing agent=flue");
+  if (agent.metadata["owner"] !== "smoke")
+    throw new Error("service metadata missing owner=smoke");
+  if (agent.metadata["session"] !== name)
+    throw new Error(`service metadata missing session=${name}`);
+  if (agent.metadata["protocol_version"] !== "0.3")
+    throw new Error("service metadata missing protocol_version=0.3");
+  if (agent.promptEndpoint.subject !== service.subject.prompt)
+    throw new Error("prompt endpoint subject mismatch");
+  if (agent.promptEndpoint.queueGroup !== "agents")
+    throw new Error("prompt endpoint queue group mismatch");
+  if (agent.promptEndpoint.attachmentsOk !== false)
+    throw new Error("prompt endpoint must advertise attachments_ok=false");
+  if (!agent.promptEndpoint.metadata["max_payload"])
+    throw new Error("prompt endpoint missing max_payload");
+  const statusEndpoint = agent.endpoints.find((e) => e.name === "status");
+  if (statusEndpoint?.subject !== service.subject.status)
+    throw new Error("status endpoint subject mismatch");
+  if (statusEndpoint.queueGroup !== "agents")
+    throw new Error("status endpoint queue group mismatch");
 
   const messages: StreamMessage[] = [];
-  for await (const msg of await found[0]!.prompt("hello smoke")) messages.push(msg);
+  for await (const msg of await agent.prompt("hello smoke")) messages.push(msg);
 
-  console.log(JSON.stringify({ subject: service.subject.prompt, messages }, null, 2));
+  const attachmentReply = `_INBOX.flue-attachment-${Math.random().toString(36).slice(2, 8)}`;
+  const attachmentSub = callerNc.subscribe(attachmentReply);
+  await callerNc.flush();
+  callerNc.publish(
+    service.subject.prompt,
+    new TextEncoder().encode(
+      JSON.stringify({
+        prompt: "attachment should be rejected",
+        attachments: [{ filename: "note.txt", content: "QUJD" }],
+      }),
+    ),
+    { reply: attachmentReply },
+  );
+  const attachmentFrames = [];
+  for await (const frame of attachmentSub) {
+    attachmentFrames.push(frame);
+    if (
+      attachmentFrames.some((m) => m.headers?.get("Nats-Service-Error-Code")) &&
+      attachmentFrames.some((m) => !m.headers && m.data.length === 0)
+    ) {
+      attachmentSub.unsubscribe();
+      break;
+    }
+  }
+  const attachmentError = attachmentFrames.find((m) =>
+    m.headers?.get("Nats-Service-Error-Code"),
+  );
+  if (attachmentError?.headers?.get("Nats-Service-Error-Code") !== "400") {
+    throw new Error(
+      `valid-but-unsupported attachment envelope returned ${attachmentError?.headers?.get("Nats-Service-Error-Code") ?? "no error"}, expected 400`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        subject: service.subject.prompt,
+        metadata: agent.metadata,
+        promptEndpoint: agent.promptEndpoint,
+        messages,
+      },
+      null,
+      2,
+    ),
+  );
   const first = messages[0];
-  if (first?.type !== "status" || first.status !== "ack") throw new Error("missing leading ack status");
-  if (!messages.some((m) => m.type === "status" && (m as { status: string }).status.includes("connected to Flue"))) {
+  if (first?.type !== "status" || first.status !== "ack")
+    throw new Error("missing leading ack status");
+  if (
+    !messages.some(
+      (m) =>
+        m.type === "status" &&
+        (m as { status: string }).status.includes("connected to Flue"),
+    )
+  ) {
     throw new Error("missing Flue connected status");
   }
-  if (!messages.some((m) => m.type === "response" && m.text.includes("fake Flue response"))) {
+  if (
+    !messages.some(
+      (m) => m.type === "response" && m.text.includes("fake Flue response"),
+    )
+  ) {
     throw new Error("missing fake Flue response");
   }
   const last = messages.at(-1);
-  if (last?.type !== "status" || last.status !== "done") throw new Error("missing done terminator status");
+  if (last?.type !== "status" || last.status !== "done")
+    throw new Error("missing done terminator status");
 } finally {
   await service.stop();
   await nc.close();

--- a/agents/flue/src/bridge.ts
+++ b/agents/flue/src/bridge.ts
@@ -1,4 +1,4 @@
-import type { RequestEnvelope } from "@synadia-ai/agents";
+import { ProtocolError, type RequestEnvelope } from "@synadia-ai/agents";
 import type { Chunk } from "@synadia-ai/agent-service";
 import type { FlueMapping } from "./config.js";
 
@@ -7,16 +7,19 @@ export interface BridgeResponse {
 }
 
 export interface FlueBridgeClient {
-  prompt(input: {
-    readonly message: string;
-    readonly baseUrl: string;
-    readonly agent: string;
-    readonly instance: string;
-    readonly session: string;
-    readonly transport: string;
-  }, events?: {
-    readonly onTextDelta?: (text: string) => Promise<void>;
-  }): Promise<unknown>;
+  prompt(
+    input: {
+      readonly message: string;
+      readonly baseUrl: string;
+      readonly agent: string;
+      readonly instance: string;
+      readonly session: string;
+      readonly transport: string;
+    },
+    events?: {
+      readonly onTextDelta?: (text: string) => Promise<void>;
+    },
+  ): Promise<unknown>;
 }
 
 export interface BridgePromptOptions {
@@ -26,10 +29,14 @@ export interface BridgePromptOptions {
   readonly flueClient: FlueBridgeClient;
 }
 
-export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<void> {
+export async function bridgePromptToFlue(
+  options: BridgePromptOptions,
+): Promise<void> {
   const { envelope, response, mapping, flueClient } = options;
   if (envelope.attachments && envelope.attachments.length > 0) {
-    throw new Error("attachments are not supported by the Flue NATS channel v1");
+    throw new ProtocolError(
+      "attachments are not supported by the Flue NATS channel v1",
+    );
   }
 
   const target = mapping.flue;
@@ -39,20 +46,23 @@ export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<
   });
 
   let streamed = false;
-  const result = await flueClient.prompt({
-    message: envelope.prompt,
-    baseUrl: target.baseUrl,
-    agent: target.agent,
-    instance: target.instance,
-    session: target.session,
-    transport: target.transport,
-  }, {
-    onTextDelta: async (text) => {
-      if (!text) return;
-      streamed = true;
-      await response.send({ type: "response", text });
+  const result = await flueClient.prompt(
+    {
+      message: envelope.prompt,
+      baseUrl: target.baseUrl,
+      agent: target.agent,
+      instance: target.instance,
+      session: target.session,
+      transport: target.transport,
     },
-  });
+    {
+      onTextDelta: async (text) => {
+        if (!text) return;
+        streamed = true;
+        await response.send({ type: "response", text });
+      },
+    },
+  );
 
   const finalText = stringifyFlueResult(result);
   if (finalText) {
@@ -65,7 +75,21 @@ export async function bridgePromptToFlue(options: BridgePromptOptions): Promise<
 export function stringifyFlueResult(result: unknown): string {
   if (result === undefined || result === null) return "";
   if (typeof result === "string") return result;
-  if (typeof result === "number" || typeof result === "boolean" || typeof result === "bigint") return String(result);
-  if (typeof result === "object" && "text" in result && typeof result.text === "string") return result.text;
-  try { return JSON.stringify(result); } catch { return String(result); }
+  if (
+    typeof result === "number" ||
+    typeof result === "boolean" ||
+    typeof result === "bigint"
+  )
+    return String(result);
+  if (
+    typeof result === "object" &&
+    "text" in result &&
+    typeof result.text === "string"
+  )
+    return result.text;
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
 }

--- a/agents/flue/src/service.ts
+++ b/agents/flue/src/service.ts
@@ -1,5 +1,8 @@
 import type { NatsConnection } from "@nats-io/nats-core";
-import { AgentService, type AgentServiceOptions } from "@synadia-ai/agent-service";
+import {
+  AgentService,
+  type AgentServiceOptions,
+} from "@synadia-ai/agent-service";
 import type { FlueBridgeClient } from "./bridge.js";
 import { bridgePromptToFlue } from "./bridge.js";
 import type { FlueChannelConfig } from "./config.js";
@@ -12,7 +15,9 @@ export interface BuildAgentServiceOptionsInput {
   readonly version: string;
 }
 
-export function buildAgentServiceOptions(input: BuildAgentServiceOptionsInput): AgentServiceOptions {
+export function buildAgentServiceOptions(
+  input: BuildAgentServiceOptionsInput,
+): AgentServiceOptions {
   const mapping = mappingFromConfig(input.config);
   return {
     nc: input.nc,
@@ -20,6 +25,7 @@ export function buildAgentServiceOptions(input: BuildAgentServiceOptionsInput): 
     subjectToken: mapping.subjectToken,
     owner: mapping.owner,
     name: mapping.name,
+    session: mapping.name,
     description: `Flue agent ${mapping.flue.agent}/${mapping.flue.instance}`,
     version: input.version,
     attachmentsOk: false,
@@ -35,7 +41,11 @@ export function buildAgentServiceOptions(input: BuildAgentServiceOptionsInput): 
   };
 }
 
-export function createFlueAgentService(input: BuildAgentServiceOptionsInput & { readonly flueClient?: FlueBridgeClient }): AgentService {
+export function createFlueAgentService(
+  input: BuildAgentServiceOptionsInput & {
+    readonly flueClient?: FlueBridgeClient;
+  },
+): AgentService {
   const service = new AgentService(buildAgentServiceOptions(input));
   const mapping = mappingFromConfig(input.config);
   const flueClient = input.flueClient ?? new SdkFlueBridgeClient();

--- a/agents/flue/test/service.test.ts
+++ b/agents/flue/test/service.test.ts
@@ -6,14 +6,31 @@ describe("service construction", () => {
   test("builds AgentService options for flue using canonical subject token and metadata", () => {
     const cfg: FlueChannelConfig = {
       nats: { url: "nats://127.0.0.1:4222" },
-      agent: { owner: "rene", name: "support", subjectToken: "flue", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
-      flue: { baseUrl: "http://127.0.0.1:3583", agent: "assistant", instance: "customer-123", session: "ticket-123", transport: "http-stream" },
+      agent: {
+        owner: "rene",
+        name: "support",
+        subjectToken: "flue",
+        heartbeatIntervalS: 30,
+        keepaliveIntervalS: 30,
+      },
+      flue: {
+        baseUrl: "http://127.0.0.1:3583",
+        agent: "assistant",
+        instance: "customer-123",
+        session: "ticket-123",
+        transport: "http-stream",
+      },
     };
-    const opts = buildAgentServiceOptions({ nc: {} as never, config: cfg, version: "0.1.0" });
+    const opts = buildAgentServiceOptions({
+      nc: {} as never,
+      config: cfg,
+      version: "0.1.0",
+    });
     expect(opts.agent).toBe("flue");
     expect(opts.subjectToken).toBe("flue");
     expect(opts.owner).toBe("rene");
     expect(opts.name).toBe("support");
+    expect(opts.session).toBe("support");
     expect(opts.attachmentsOk).toBe(false);
     expect(opts.extraMetadata).toEqual({
       flue_base_url: "http://127.0.0.1:3583",


### PR DESCRIPTION
## Summary

- Set Flue-hosted agents' protocol `session` metadata to the advertised instance name.
- Let `AgentService` map handler-raised `ProtocolError`s to `400` service errors while preserving `500` for ordinary handler failures.
- Reject decoded-but-unsupported Flue attachments as `ProtocolError` and extend protocol smoke coverage to validate metadata, endpoint shape, queue groups, `attachments_ok=false`, `max_payload`, status endpoint, prompt stream, and attachment rejection.

## Verification

- `cd agent-sdk/typescript && npm run typecheck && npm run test`
- `cd agents/flue && bun run typecheck && bun test && bun run smoke:protocol`
- `cd agents/flue && FLUE_BASE_URL=http://127.0.0.1:3583 FLUE_AGENT=echo FLUE_INSTANCE=conformance FLUE_SESSION=conformance SMOKE_PROMPT=conformance SMOKE_EXPECTS=echo:conformance bun run smoke:real-flue`
- `git diff --check`

Not pushed yet by request.
