### PR TITLE
docs(examples): sync TS examples from synadia-agents-labs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ discovery, prompting (text + attachments), mid-stream queries, and
 liveness against the reference agent — useful both as documentation
 and as a smoke surface:
 
-- TS: `client-sdk/typescript/examples/01-discover.ts` … `05-liveness.ts`.
+- TS: `client-sdk/typescript/examples/01-discover.ts` … `05-liveness.ts`,
+  plus `06-chat.ts` (interactive REPL).
 - Python: `client-sdk/python/examples/01-discover.py` … `05-liveness.py`,
   plus `06-chat.py` (interactive REPL). See
   `client-sdk/python/examples/README.md` for the full table.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Both SDKs ship a **spec-compliant reference agent** that implements the full §1
 
 | SDK | Reference agent | Demo scripts |
 | --- | --- | --- |
-| TypeScript | [`ReferenceAgent`](agent-sdk/typescript/src/testing/reference-agent.ts) — importable as `@synadia-ai/agent-service/testing`. Runnable: [`_run-reference-agent.ts`](client-sdk/typescript/examples/_run-reference-agent.ts). | [`client-sdk/typescript/examples/`](client-sdk/typescript/examples/) — `01-discover.ts` … `05-liveness.ts`. |
+| TypeScript | [`ReferenceAgent`](agent-sdk/typescript/src/testing/reference-agent.ts) — importable as `@synadia-ai/agent-service/testing`. Runnable: [`_run-reference-agent.ts`](client-sdk/typescript/examples/_run-reference-agent.ts). | [`client-sdk/typescript/examples/`](client-sdk/typescript/examples/) — `01-discover.ts` … `05-liveness.ts`, plus `06-chat.ts` (interactive REPL). |
 | Python | [`_reference_agent.py`](agent-sdk/python/examples/_reference_agent.py) — runnable echo agent with conversation memory. | [`client-sdk/python/examples/`](client-sdk/python/examples/) — `01-discover.py` … `05-liveness.py`, plus `06-chat.py` (interactive REPL). |
 
 <details>

--- a/agent-sdk/typescript/examples/02-ollama.ts
+++ b/agent-sdk/typescript/examples/02-ollama.ts
@@ -65,11 +65,14 @@ async function main(): Promise<void> {
       : { servers: "nats://127.0.0.1:4222" };
   const nc = await natsConnect(opts);
 
+  // Identity and heartbeat cadence are env-overridable (see 01-echo.ts).
+  const heartbeatIntervalS = Number(process.env["NATS_AGENT_HEARTBEAT_INTERVAL"]) || undefined;
   const service = new AgentService({
     nc,
     agent: "ollama",
-    owner: process.env["USER"] ?? "anon",
-    name: "main",
+    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
+    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: `LLM agent — answers prompts with the local Ollama '${MODEL}' model`,
   });
 

--- a/agent-sdk/typescript/examples/03-openrouter.ts
+++ b/agent-sdk/typescript/examples/03-openrouter.ts
@@ -1,0 +1,122 @@
+// LLM agent — forwards each prompt to OpenRouter and streams the reply.
+//
+// Step 3 of the example ladder. Same shape as `02-ollama.ts`, but the backend
+// is the hosted, OpenAI-compatible OpenRouter API instead of a local Ollama.
+// Needs an API key; no GPU required.
+//
+// Prerequisites: an OpenRouter API key (https://openrouter.ai/keys):
+//   export OPENROUTER_API_KEY=sk-or-...
+//   # optional: export OPENROUTER_MODEL=openai/gpt-4o-mini
+//
+// Connection resolution (same as 01-echo.ts):
+//   1. $NATS_CONTEXT — name of a NATS CLI context under ~/.config/nats/context/
+//   2. $NATS_URL     — raw URL (credentials in userinfo are honored)
+//   3. nats://127.0.0.1:4222
+
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
+import { AgentService } from "@synadia-ai/agent-service";
+
+const API_KEY = process.env["OPENROUTER_API_KEY"];
+const MODEL = process.env["OPENROUTER_MODEL"] ?? "openai/gpt-4o-mini";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+/**
+ * Stream a chat completion from OpenRouter, yielding each token as it arrives.
+ *
+ * OpenRouter speaks the OpenAI SSE format: lines of `data: {json}` (plus keep-
+ * alive comments), ending with `data: [DONE]`. Each JSON frame carries the next
+ * fragment at `choices[0].delta.content`. As in `02-ollama.ts`, a network read
+ * may split mid-line, so we keep the trailing partial in `buffer`.
+ */
+async function* openRouterTokens(prompt: string): AsyncGenerator<string> {
+  const res = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [{ role: "user", content: prompt }],
+      stream: true,
+    }),
+  });
+  if (!res.ok || res.body === null) {
+    throw new Error(`OpenRouter request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const bytes of res.body) {
+    buffer += decoder.decode(bytes as Uint8Array, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue; // skip SSE keep-alive comments
+      const data = trimmed.slice(5).trim();
+      if (data === "" || data === "[DONE]") continue;
+      try {
+        const token =
+          (JSON.parse(data) as { choices?: { delta?: { content?: string } }[] }).choices?.[0]?.delta
+            ?.content ?? "";
+        if (token) yield token;
+      } catch {
+        /* ignore the rare non-JSON keep-alive line */
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  if (!API_KEY) {
+    console.error("OPENROUTER_API_KEY is not set — get one at https://openrouter.ai/keys");
+    process.exit(1);
+  }
+
+  const opts = process.env["NATS_CONTEXT"]
+    ? await loadContextOptions(process.env["NATS_CONTEXT"])
+    : process.env["NATS_URL"]
+      ? parseNatsUrl(process.env["NATS_URL"])
+      : { servers: "nats://127.0.0.1:4222" };
+  const nc = await natsConnect(opts);
+
+  // Identity and heartbeat cadence are env-overridable (see 01-echo.ts).
+  const heartbeatIntervalS = Number(process.env["NATS_AGENT_HEARTBEAT_INTERVAL"]) || undefined;
+  const service = new AgentService({
+    nc,
+    agent: "openrouter",
+    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
+    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
+    description: `LLM agent — answers prompts with OpenRouter '${MODEL}'`,
+  });
+
+  // Same handler shape as the echo agent: instead of one reply, we `send(...)`
+  // each token as OpenRouter emits it. The SDK closes the stream when we return.
+  service.onPrompt(async (envelope, response) => {
+    for await (const token of openRouterTokens(envelope.prompt)) {
+      await response.send(token);
+    }
+  });
+
+  await service.start();
+  console.log(`openrouter agent listening on ${service.subject.prompt}`);
+  console.log(`prompting model '${MODEL}' via OpenRouter`);
+  console.log("press Ctrl+C to stop");
+
+  const shutdown = async (): Promise<void> => {
+    console.log("\nshutting down…");
+    await service.stop();
+    await nc.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+}
+
+void main().catch((err: unknown) => {
+  console.error("openrouter agent failed:", err);
+  process.exit(1);
+});

--- a/agent-sdk/typescript/examples/04-combined.ts
+++ b/agent-sdk/typescript/examples/04-combined.ts
@@ -41,8 +41,9 @@ async function main(): Promise<void> {
     description: `LLM agent — answers prompts via ${llm.label}`,
   });
 
-  // Wrap the prompt as a single user message and stream the model's reply. This
-  // handler is the only thing a tool-calling agent (see 05-tools.ts) changes.
+  // Wrap the prompt as a single user message and stream the model's reply. A
+  // tool-calling agent (see 05-tools.ts) extends this same pattern — adding a
+  // non-streamed round-trip for tool dispatch before the final streamed answer.
   service.onPrompt(async (envelope, response) => {
     for await (const token of llm.chatStream([{ role: "user", content: envelope.prompt }])) {
       await response.send(token);

--- a/agent-sdk/typescript/examples/04-combined.ts
+++ b/agent-sdk/typescript/examples/04-combined.ts
@@ -1,10 +1,16 @@
-// Minimal echo agent — replies to every prompt with `echo: <prompt text>`.
+// LLM agent (combined) — answers prompts with Ollama OR OpenRouter.
 //
-// The shortest runnable demonstration of the `AgentService` host API.
-// Use this as a smoke target while iterating on a caller, or as a
-// starting shape when writing your own agent.
+// Step 4 of the example ladder, and the reusable base later agents build on. It
+// defers all model access to ./llm.ts, which auto-selects a backend from the
+// environment:
 //
-// Connection resolution:
+//   OPENROUTER_API_KEY set  → OpenRouter (OPENROUTER_MODEL)
+//   otherwise               → local Ollama (OLLAMA_MODEL, OLLAMA_URL)
+//
+// The agent itself is unchanged from 01-echo's shape — connect, construct,
+// onPrompt, start — except the handler streams LLM tokens instead of an echo.
+//
+// Connection resolution (same as 01-echo.ts):
 //   1. $NATS_CONTEXT — name of a NATS CLI context under ~/.config/nats/context/
 //   2. $NATS_URL     — raw URL (credentials in userinfo are honored)
 //   3. nats://127.0.0.1:4222
@@ -12,8 +18,11 @@
 import { connect as natsConnect } from "@nats-io/transport-node";
 import { loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
 import { AgentService } from "@synadia-ai/agent-service";
+import { createLlmClient } from "./llm";
 
 async function main(): Promise<void> {
+  const llm = createLlmClient();
+
   const opts = process.env["NATS_CONTEXT"]
     ? await loadContextOptions(process.env["NATS_CONTEXT"])
     : process.env["NATS_URL"]
@@ -21,30 +30,28 @@ async function main(): Promise<void> {
       : { servers: "nats://127.0.0.1:4222" };
   const nc = await natsConnect(opts);
 
-  // Identity → subject `agents.prompt.echo.<owner>.<name>`. Owner and name are
-  // overridable (NATS_AGENT_OWNER / NATS_AGENT_NAME) so several people can run
-  // this against one server without colliding; `agent` ("echo") is what this
-  // example *is*, so it stays fixed. NATS_AGENT_HEARTBEAT_INTERVAL (seconds)
-  // tunes the heartbeat cadence — unset falls back to the SDK default (30s).
+  // Identity and heartbeat cadence are env-overridable (see 01-echo.ts).
   const heartbeatIntervalS = Number(process.env["NATS_AGENT_HEARTBEAT_INTERVAL"]) || undefined;
   const service = new AgentService({
     nc,
-    agent: "echo",
+    agent: "llm",
     owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
     name: process.env["NATS_AGENT_NAME"] ?? "main",
-    // Spread the key in only when set: exactOptionalPropertyTypes forbids passing
-    // `heartbeatIntervalS: undefined` explicitly, and an absent key is exactly
-    // what tells the SDK to apply its 30s default.
     ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
-    description: "Echo agent — replies with the prompt prefixed by 'echo: '",
+    description: `LLM agent — answers prompts via ${llm.label}`,
   });
 
+  // Wrap the prompt as a single user message and stream the model's reply. This
+  // handler is the only thing a tool-calling agent (see 05-tools.ts) changes.
   service.onPrompt(async (envelope, response) => {
-    await response.send(`echo: ${envelope.prompt}`);
+    for await (const token of llm.chatStream([{ role: "user", content: envelope.prompt }])) {
+      await response.send(token);
+    }
   });
 
   await service.start();
-  console.log(`echo agent listening on ${service.subject.prompt}`);
+  console.log(`llm agent listening on ${service.subject.prompt}`);
+  console.log(`backend: ${llm.label}`);
   console.log("press Ctrl+C to stop");
 
   const shutdown = async (): Promise<void> => {
@@ -58,6 +65,6 @@ async function main(): Promise<void> {
 }
 
 void main().catch((err: unknown) => {
-  console.error("echo agent failed:", err);
+  console.error("llm agent failed:", err);
   process.exit(1);
 });

--- a/agent-sdk/typescript/examples/05-tools.ts
+++ b/agent-sdk/typescript/examples/05-tools.ts
@@ -191,6 +191,8 @@ async function main(): Promise<void> {
     // loop until the model stops requesting tools.)
     for (const call of decision.tool_calls ?? []) {
       const result = await runTool(nc, call.function.name, call.function.arguments);
+      // tool_call_id omitted — llama3.1 tolerates it; stricter models may need
+      // it added to correlate the result back to the originating tool_call.
       messages.push({ role: "tool", content: result });
     }
 

--- a/agent-sdk/typescript/examples/05-tools.ts
+++ b/agent-sdk/typescript/examples/05-tools.ts
@@ -191,8 +191,11 @@ async function main(): Promise<void> {
     // loop until the model stops requesting tools.)
     for (const call of decision.tool_calls ?? []) {
       const result = await runTool(nc, call.function.name, call.function.arguments);
-      // tool_call_id omitted — llama3.1 tolerates it; stricter models may need
-      // it added to correlate the result back to the originating tool_call.
+      // No tool_call_id: Ollama's /api/chat doesn't return tool-call ids and
+      // correlates each result to its call by order. (OpenAI-style APIs return
+      // an `id` per call that the result must echo back as `tool_call_id` — and
+      // there you'd also need the assistant message, pushed above as `decision`,
+      // to carry the matching `tool_calls`.)
       messages.push({ role: "tool", content: result });
     }
 

--- a/agent-sdk/typescript/examples/05-tools.ts
+++ b/agent-sdk/typescript/examples/05-tools.ts
@@ -1,7 +1,8 @@
-// 03-tools.ts — an LLM agent whose tool calls a NATS microservice.
+// 05-tools.ts — an LLM agent whose tool calls a NATS microservice.
 //
-// Step 3 of the ladder. Example 2 gave the agent a model; this gives it a
-// *tool*, and wires that tool to a NATS microservice. The point of the demo:
+// Examples 2–4 gave the agent a model (Ollama,
+// OpenRouter, or either); this gives it a *tool*, and wires that tool to a
+// NATS microservice. The point of the demo:
 //
 //   any microservice already on your NATS network can become an agent
 //   capability — the agent need not embed the database, device, or
@@ -23,7 +24,7 @@
 // Prereqs: a local Ollama with a tool-capable model:
 //   ollama pull llama3.1:8b
 //
-// Connection resolution (same as 01/02):
+// Connection resolution (same as the other agents):
 //   $NATS_CONTEXT > $NATS_URL > nats://127.0.0.1:4222
 
 import { connect as natsConnect, type NatsConnection } from "@nats-io/transport-node";
@@ -167,11 +168,14 @@ async function main(): Promise<void> {
   // separate process somewhere on the network — here it just shares `nc`.
   await startSensorService(nc);
 
+  // Identity and heartbeat cadence are env-overridable (see 01-echo.ts).
+  const heartbeatIntervalS = Number(process.env["NATS_AGENT_HEARTBEAT_INTERVAL"]) || undefined;
   const service = new AgentService({
     nc,
     agent: "tools",
-    owner: process.env["USER"] ?? "anon",
-    name: "main",
+    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
+    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: "LLM agent with a read_sensor tool backed by a NATS microservice",
   });
 

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -5,11 +5,31 @@ speaking the [Synadia Agent Protocol for NATS](https://github.com/synadia-ai/syn
 Counterpart to the caller-side numbered demos in
 [`client-sdk/typescript/examples/`](../../../client-sdk/typescript/examples/).
 
-| Example                        | What it shows                                                                                   |
-| ------------------------------ | ----------------------------------------------------------------------------------------------- |
-| [`01-echo.ts`](01-echo.ts)     | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`.                         |
-| [`02-ollama.ts`](02-ollama.ts) | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply.      |
-| [`03-tools.ts`](03-tools.ts)   | Gives the LLM a `read_sensor` tool wired to a NATS microservice, then reasons over the reading. |
+They form a ladder — each rung is the one before plus a little more:
+
+| Example                                | What it shows                                                                                    |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [`01-echo.ts`](01-echo.ts)             | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`.                          |
+| [`02-ollama.ts`](02-ollama.ts)         | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply.       |
+| [`03-openrouter.ts`](03-openrouter.ts) | Same shape again, but the backend is the hosted, OpenAI-compatible OpenRouter API (needs a key). |
+| [`04-combined.ts`](04-combined.ts)     | Ollama **or** OpenRouter, auto-selected from the env; model access factored into `llm.ts`.       |
+| [`05-tools.ts`](05-tools.ts)           | Gives the LLM a `read_sensor` tool wired to a NATS microservice, then reasons over the reading.  |
+
+## Environment variables
+
+Every example resolves its NATS connection and identity the same way; none of
+these are required (the defaults connect to a local server as your `$USER`).
+
+| Variable                        | Default                    | Purpose                                                                                                                                            |
+| ------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NATS_CONTEXT`                  | _(unset)_                  | Connect via a named [NATS CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Wins when set.                          |
+| `NATS_URL`                      | `nats://127.0.0.1:4222`    | Connect via a raw URL; credentials in the userinfo are honored.                                                                                    |
+| `NATS_AGENT_OWNER`              | your `$USER` (else `anon`) | The `owner` token in `agents.prompt.<agent>.<owner>.<name>`. Set it so several people running this against one server don't collide.               |
+| `NATS_AGENT_NAME`               | `main`                     | The instance `name` token in the subject. Use different names to run several instances at once.                                                    |
+| `NATS_AGENT_HEARTBEAT_INTERVAL` | `30`                       | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier [`05-liveness`](../../../client-sdk/typescript/examples/05-liveness.ts) demo. |
+
+Per-backend variables (`OLLAMA_URL`, `OLLAMA_MODEL`, `OPENROUTER_API_KEY`,
+`OPENROUTER_MODEL`) are documented in the relevant sections below.
 
 ## Run
 
@@ -26,6 +46,9 @@ NATS_CONTEXT=my-context bun examples/01-echo.ts
 NATS_URL=tls://connect.ngs.global bun examples/01-echo.ts
 # or:
 bun examples/01-echo.ts   # localhost fallback
+
+# run as a uniquely-named instance with fast heartbeats:
+NATS_AGENT_OWNER=alice NATS_AGENT_NAME=demo NATS_AGENT_HEARTBEAT_INTERVAL=2 bun examples/01-echo.ts
 ```
 
 You should see:
@@ -52,6 +75,8 @@ Output:
 (empty terminator)
 ```
 
+(The owner defaults to your `$USER` unless you set `NATS_AGENT_OWNER`.)
+
 ### `02-ollama.ts` — prompt a local LLM
 
 Needs a running [Ollama](https://ollama.com) with the model pulled:
@@ -61,6 +86,11 @@ ollama pull llama3.2
 bun examples/02-ollama.ts            # uses llama3.2 by default
 OLLAMA_MODEL=qwen2.5 bun examples/02-ollama.ts   # or pick another model
 ```
+
+| Variable       | Default                  | Purpose                    |
+| -------------- | ------------------------ | -------------------------- |
+| `OLLAMA_URL`   | `http://localhost:11434` | Where Ollama is listening. |
+| `OLLAMA_MODEL` | `llama3.2`               | Which model to prompt.     |
 
 The agent registers as `ollama` and streams the model's answer back token by
 token. Drive it the same way, but point `nats req` at the `ollama` subject:
@@ -81,7 +111,48 @@ Output (one `response` chunk per token, then the terminator):
 (empty terminator)
 ```
 
-### `03-tools.ts` — give the agent a tool backed by a microservice
+### `03-openrouter.ts` — prompt a hosted LLM
+
+The same LLM agent as `02`, but powered by the hosted, OpenAI-compatible
+[OpenRouter](https://openrouter.ai) API instead of a local model. Needs an API
+key; no GPU required. The only thing that changes from `02-ollama` is how the
+backend streams (OpenAI **SSE**: `data: {json}` … `data: [DONE]`).
+
+```sh
+export OPENROUTER_API_KEY=sk-or-...
+bun examples/03-openrouter.ts
+OPENROUTER_MODEL=anthropic/claude-3.5-haiku bun examples/03-openrouter.ts
+```
+
+| Variable             | Default              | Purpose                                               |
+| -------------------- | -------------------- | ----------------------------------------------------- |
+| `OPENROUTER_API_KEY` | _(required)_         | Your [OpenRouter key](https://openrouter.ai/keys).    |
+| `OPENROUTER_MODEL`   | `openai/gpt-4o-mini` | Any [OpenRouter model](https://openrouter.ai/models). |
+
+The agent registers as `openrouter`; drive it at the `openrouter` subject.
+
+### `04-combined.ts` — Ollama **or** OpenRouter (the reusable base)
+
+Answers with **either** a local Ollama **or** OpenRouter, chosen automatically.
+Model access is factored into [`llm.ts`](llm.ts) — a small backend-agnostic chat
+client behind one `chatStream(messages)` API. That file is the reusable base a
+tool-calling agent would build on (see `05-tools.ts`).
+
+| Condition                   | Backend                                                             |
+| --------------------------- | ------------------------------------------------------------------- |
+| `OPENROUTER_API_KEY` is set | **OpenRouter** (`OPENROUTER_MODEL`, default `openai/gpt-4o-mini`)   |
+| otherwise                   | **local Ollama** (`OLLAMA_MODEL`, default `llama3.2`; `OLLAMA_URL`) |
+
+The chosen backend is printed on startup, e.g. `backend: ollama/llama3.2`.
+
+```sh
+bun examples/04-combined.ts                                # local Ollama
+OPENROUTER_API_KEY=sk-or-... bun examples/04-combined.ts   # OpenRouter
+```
+
+The agent registers as `llm`; drive it at the `llm` subject.
+
+### `05-tools.ts` — give the agent a tool backed by a microservice
 
 The agent gains a `read_sensor` **tool**, and that tool is wired to a NATS
 microservice. This is the whole point in one file:
@@ -107,7 +178,7 @@ don't do native tool-calls, and `qwen3` works but clutters the output with
 
 ```sh
 ollama pull llama3.1:8b
-bun examples/03-tools.ts
+bun examples/05-tools.ts
 ```
 
 Then ask it something that needs the sensor:

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -20,13 +20,13 @@ They form a ladder — each rung is the one before plus a little more:
 Every example resolves its NATS connection and identity the same way; none of
 these are required (the defaults connect to a local server as your `$USER`).
 
-| Variable                        | Default                    | Purpose                                                                                                                                            |
-| ------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NATS_CONTEXT`                  | _(unset)_                  | Connect via a named [NATS CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Wins when set.                          |
-| `NATS_URL`                      | `nats://127.0.0.1:4222`    | Connect via a raw URL; credentials in the userinfo are honored.                                                                                    |
-| `NATS_AGENT_OWNER`              | your `$USER` (else `anon`) | The `owner` token in `agents.prompt.<agent>.<owner>.<name>`. Set it so several people running this against one server don't collide.               |
-| `NATS_AGENT_NAME`               | `main`                     | The instance `name` token in the subject. Use different names to run several instances at once.                                                    |
-| `NATS_AGENT_HEARTBEAT_INTERVAL` | `30`                       | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier [`05-liveness`](../../../client-sdk/typescript/examples/05-liveness.ts) demo. |
+| Variable                        | Default                    | Purpose                                                                                                                                                                                         |
+| ------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NATS_CONTEXT`                  | _(unset)_                  | Connect via a named [NATS CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Wins when set.                                                                       |
+| `NATS_URL`                      | `nats://127.0.0.1:4222`    | Connect via a raw URL; credentials in the userinfo are honored.                                                                                                                                 |
+| `NATS_AGENT_OWNER`              | your `$USER` (else `anon`) | The `owner` token in `agents.prompt.<agent>.<owner>.<name>`. Set it so several people running this against one server don't collide.                                                            |
+| `NATS_AGENT_NAME`               | `main`                     | The instance `name` token in the subject. Use different names to run several instances at once.                                                                                                 |
+| `NATS_AGENT_HEARTBEAT_INTERVAL` | `30`                       | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier [`05-liveness`](../../../client-sdk/typescript/examples/05-liveness.ts) demo. (`0` is treated as unset → the 30s default.) |
 
 Per-backend variables (`OLLAMA_URL`, `OLLAMA_MODEL`, `OPENROUTER_API_KEY`,
 `OPENROUTER_MODEL`) are documented in the relevant sections below.
@@ -136,7 +136,8 @@ The agent registers as `openrouter`; drive it at the `openrouter` subject.
 Answers with **either** a local Ollama **or** OpenRouter, chosen automatically.
 Model access is factored into [`llm.ts`](llm.ts) — a small backend-agnostic chat
 client behind one `chatStream(messages)` API. That file is the reusable base a
-tool-calling agent would build on (see `05-tools.ts`).
+tool-calling agent would copy and extend; the next rung, `05-tools.ts`, shows
+the tool-calling pattern (with its own self-contained model client).
 
 | Condition                   | Backend                                                             |
 | --------------------------- | ------------------------------------------------------------------- |

--- a/agent-sdk/typescript/examples/llm.ts
+++ b/agent-sdk/typescript/examples/llm.ts
@@ -1,0 +1,103 @@
+// llm.ts — a tiny streaming chat client that targets EITHER a local Ollama or
+// OpenRouter, chosen automatically from the environment.
+//
+// This is the "reusable base" behind `04-combined.ts`: it reduces both backends
+// to a single chat shape, so the agent — and any future tool-calling — looks the
+// same regardless of provider. Keep it small and dependency-free (just `fetch`).
+//
+//   OPENROUTER_API_KEY set?  → OpenRouter   (OPENROUTER_MODEL, default openai/gpt-4o-mini)
+//   otherwise                → local Ollama (OLLAMA_MODEL, default llama3.2; OLLAMA_URL)
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+}
+
+export interface LlmClient {
+  /** Human-readable "backend/model", handy for logging. */
+  readonly label: string;
+  /** Stream the assistant's reply to `messages`, yielding text as it arrives. */
+  chatStream(messages: ChatMessage[]): AsyncGenerator<string>;
+}
+
+/** Pick a backend from the environment: OpenRouter if a key is present, else Ollama. */
+export function createLlmClient(): LlmClient {
+  const apiKey = process.env["OPENROUTER_API_KEY"];
+  return apiKey ? openRouter(apiKey) : ollama();
+}
+
+// --- Ollama (local) ---------------------------------------------------------
+function ollama(): LlmClient {
+  const url = process.env["OLLAMA_URL"] ?? "http://localhost:11434";
+  const model = process.env["OLLAMA_MODEL"] ?? "llama3.2";
+  return {
+    label: `ollama/${model}`,
+    async *chatStream(messages) {
+      const res = await fetch(`${url}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model, messages, stream: true }),
+      });
+      if (!res.ok || res.body === null) {
+        throw new Error(`Ollama request failed: ${res.status} ${res.statusText}`);
+      }
+      // /api/chat returns newline-delimited JSON, each line `{message:{content}}`.
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for await (const bytes of res.body) {
+        buffer += decoder.decode(bytes as Uint8Array, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (line.trim() === "") continue;
+          const token =
+            (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
+          if (token) yield token;
+        }
+      }
+    },
+  };
+}
+
+// --- OpenRouter (hosted, OpenAI-compatible) ---------------------------------
+function openRouter(apiKey: string): LlmClient {
+  const model = process.env["OPENROUTER_MODEL"] ?? "openai/gpt-4o-mini";
+  return {
+    label: `openrouter/${model}`,
+    async *chatStream(messages) {
+      const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model, messages, stream: true }),
+      });
+      if (!res.ok || res.body === null) {
+        throw new Error(`OpenRouter request failed: ${res.status} ${res.statusText}`);
+      }
+      // OpenAI SSE: `data: {json}` lines (+ keep-alive comments), then `data: [DONE]`.
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for await (const bytes of res.body) {
+        buffer += decoder.decode(bytes as Uint8Array, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) continue;
+          const data = trimmed.slice(5).trim();
+          if (data === "" || data === "[DONE]") continue;
+          try {
+            const token =
+              (JSON.parse(data) as { choices?: { delta?: { content?: string } }[] }).choices?.[0]
+                ?.delta?.content ?? "";
+            if (token) yield token;
+          } catch {
+            /* ignore the rare non-JSON keep-alive line */
+          }
+        }
+      }
+    },
+  };
+}

--- a/agent-sdk/typescript/examples/llm.ts
+++ b/agent-sdk/typescript/examples/llm.ts
@@ -50,9 +50,15 @@ function ollama(): LlmClient {
         buffer = lines.pop() ?? "";
         for (const line of lines) {
           if (line.trim() === "") continue;
-          const token =
-            (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
-          if (token) yield token;
+          // Tolerate a rare malformed line instead of throwing out of the
+          // generator (same guard as the OpenRouter branch and 05-tools.ts).
+          try {
+            const token =
+              (JSON.parse(line) as { message?: { content?: string } }).message?.content ?? "";
+            if (token) yield token;
+          } catch {
+            /* skip malformed line */
+          }
         }
       }
     },

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -108,7 +108,7 @@ The host-side `ReferenceAgent` previously available at `@synadia-ai/agents/testi
 
 - [Getting started](./docs/getting-started.md) - end-to-end walkthrough with error handling, cancellation, and liveness.
 - [Protocol mapping](./docs/protocol-mapping.md) - every SDK call cross-referenced to the spec.
-- [`examples/`](./examples) - five runnable scripts (discover, prompt-text, prompt-attachment, query-reply, liveness).
+- [`examples/`](./examples) - six runnable scripts (discover, prompt-text, prompt-attachment, query-reply, liveness, chat).
 
 Browser support is planned but not shipped yet - the core validation and parsing layers are already runtime-agnostic.
 

--- a/client-sdk/typescript/examples/06-chat.ts
+++ b/client-sdk/typescript/examples/06-chat.ts
@@ -1,0 +1,103 @@
+// Interactive multi-turn chat REPL against the first discovered agent.
+//
+// A thin REPL: ONE NATS connection and ONE agent, many prompt() calls. Each turn
+// is still an independent protocol request — but because one chat = one session =
+// one subject (under v0.3 the 5th subject token IS the session), repeated prompts
+// to the same agent read as a conversation. Point it at a *stateful* agent —
+// one that keys memory off the session — and the turns build on each other. The
+// bundled reference agent (`_run-reference-agent.ts`) is stateless, so it answers
+// each turn independently; it's still the simplest target to try the REPL on.
+//
+// Dependency-light: only the SDK + Node's built-in readline. No UI libraries.
+// (The Python counterpart, examples/06-chat.py, wraps the same model in a
+// rich-powered TUI.)
+//
+// Commands:  /help · /clear · /quit  (also /q, /exit, or Ctrl-D)
+//
+// Connection resolution:
+//   1. $NATS_CONTEXT — name of a NATS CLI context under ~/.config/nats/context/
+//   2. $NATS_URL     — raw URL (credentials in userinfo are honored)
+//   3. nats://127.0.0.1:4222
+
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { Agents, loadContextOptions, parseNatsUrl } from "@synadia-ai/agents";
+
+const HELP = "commands:  /help · /clear · /quit  (also /q, /exit, or Ctrl-D)";
+
+async function main(): Promise<void> {
+  const opts = process.env["NATS_CONTEXT"]
+    ? await loadContextOptions(process.env["NATS_CONTEXT"])
+    : process.env["NATS_URL"]
+      ? parseNatsUrl(process.env["NATS_URL"])
+      : { servers: "nats://127.0.0.1:4222" };
+  const nc = await natsConnect(opts);
+  const agents = new Agents({ nc });
+
+  try {
+    const [agent] = await agents.discover();
+    if (!agent) {
+      console.error("no agents found — start an agent first (e.g. _run-reference-agent.ts).");
+      process.exit(2);
+    }
+    console.log(`chatting with ${agent.agent}/${agent.owner}/${agent.name}`);
+    console.log(`${HELP}\n`);
+
+    // Create the interface only now (after discovery), and read it as an async
+    // iterator: that buffers input with proper backpressure, so it works the same
+    // whether you type interactively or pipe lines in — and ends cleanly at EOF.
+    const rl = createInterface({ input: stdin, output: stdout });
+    rl.on("SIGINT", () => rl.close()); // Ctrl-C ends the loop
+
+    let turns = 0;
+    stdout.write("❯ ");
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (!line) {
+        stdout.write("❯ ");
+        continue;
+      }
+      if (line.startsWith("/")) {
+        const cmd = line.replace(/^\/+/, "").toLowerCase();
+        if (cmd === "quit" || cmd === "q" || cmd === "exit") break;
+        if (cmd === "clear")
+          stdout.write("\x1b[2J\x1b[H"); // ANSI clear; harmless if unsupported
+        else console.log(HELP); // /help and any unknown command
+        stdout.write("❯ ");
+        continue;
+      }
+
+      let printed = false;
+      for await (const msg of await agent.prompt(line)) {
+        switch (msg.type) {
+          case "response":
+            stdout.write(msg.text);
+            printed = true;
+            break;
+          case "query":
+            // A chat REPL isn't the place for interactive queries — send a safe
+            // default so the agent's stream can finish. See 04-query-reply.ts.
+            stdout.write(`\n[agent asked: ${msg.prompt}; replying 'ok']\n`);
+            await msg.reply("ok");
+            break;
+          case "status":
+            break; // informational (leading ack / keep-alive / done)
+        }
+      }
+      if (printed) stdout.write("\n");
+      turns++;
+      stdout.write("❯ ");
+    }
+    rl.close();
+    console.log(`\nchat ended — ${turns} turn(s).`);
+  } finally {
+    await agents.close();
+    await nc.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error("chat failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Bring the TypeScript examples in line with the upstream workshop repo (synadia-agents-labs), where they are developed first.

Agent examples (agent-sdk/typescript/examples):
- 01-echo, 02-ollama: add env-var ergonomics — NATS_AGENT_OWNER, NATS_AGENT_NAME, and NATS_AGENT_HEARTBEAT_INTERVAL.
- 03-openrouter: new — hosted, OpenAI-compatible OpenRouter backend.
- 04-combined + llm.ts: new — Ollama or OpenRouter auto-selected from the env; model access factored into the reusable llm.ts base.
- 03-tools -> 05-tools: rename to fit the ladder (echo -> ollama -> openrouter -> combined -> tools); also gains the env-var ergonomics.

Client examples (client-sdk/typescript/examples):
- 06-chat: new — interactive multi-turn REPL.

Heartbeat is wired with a conditional spread rather than the labs' inline `|| undefined`, because this repo sets exactOptionalPropertyTypes (an absent key is what makes the SDK apply its 30s default).

Docs: rewrite the agent-sdk examples README (ladder table, an environment-variables section, sections per example); update the client-sdk README, root README, and CLAUDE.md to list 06-chat.ts.

No new dependencies (fetch + node:readline + the SDK). typecheck, lint, and format:check pass in both packages.