### PR TITLE
examples(agent-sdk/python): add the Python agent ladder (01-echo … 05-tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ await service.stop();
 await nc.close();
 ```
 
-**Try it now:** [`agent-sdk/typescript/examples/01-echo.ts`](agent-sdk/typescript/examples/01-echo.ts) is this code packaged as a runnable script — `bun agent-sdk/typescript/examples/01-echo.ts` (with `$NATS_CONTEXT`, `$NATS_URL`, or localhost fallback).
+**Try it now:** [`agent-sdk/typescript/examples/01-echo.ts`](agent-sdk/typescript/examples/01-echo.ts) is this code packaged as a runnable script — `bun agent-sdk/typescript/examples/01-echo.ts` (with `$NATS_CONTEXT`, `$NATS_URL`, or localhost fallback). Both SDKs ship a parallel **agent ladder** (`01-echo` → `05-tools`: echo, Ollama, OpenRouter, combined, tool-calling) — TS in [`agent-sdk/typescript/examples/`](agent-sdk/typescript/examples/), Python in [`agent-sdk/python/examples/`](agent-sdk/python/examples/).
 
 For full install, error handling, and longer examples see the per-package READMEs: caller — [`client-sdk/typescript/`](client-sdk/typescript/) · [`client-sdk/python/`](client-sdk/python/); host — [`agent-sdk/typescript/`](agent-sdk/typescript/) · [`agent-sdk/python/`](agent-sdk/python/).
 

--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -8,6 +8,21 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+### Added
+
+- **Agent-ladder examples** (`examples/01-echo.py` … `05-tools.py`,
+  plus the shared `examples/llm.py` base) — the Python mirror of
+  `agent-sdk/typescript/examples/`: echo, Ollama, OpenRouter, a
+  combined auto-selecting agent, and a tool-calling agent backed by a
+  NATS microservice. Identity and heartbeat are flags that default to
+  the `NATS_AGENT_OWNER` / `NATS_AGENT_NAME` /
+  `NATS_AGENT_HEARTBEAT_INTERVAL` env vars (env-first, flag-overridable);
+  connection uses the shared `_connect_cli.py` resolver. The
+  `_reference_agent.py` flags now likewise default to those env vars
+  (non-breaking — explicit flags still win).
+- **`examples` extra** — `httpx`, used by the LLM/tool example scripts
+  (`uv sync --extra examples`). Not part of the published SDK surface.
+
 ## [0.4.1] - 2026-05-12
 
 ### Changed

--- a/agent-sdk/python/README.md
+++ b/agent-sdk/python/README.md
@@ -60,6 +60,13 @@ both as the test harness for the client-side numbered demos in
 `../../client-sdk/python/examples/` and as the wire-compat counterparty
 for cross-SDK interop.
 
+Alongside it, [`examples/`](examples/) carries a numbered **agent
+ladder** — `01-echo.py` → `05-tools.py` (echo, Ollama, OpenRouter,
+combined, and a tool-calling agent backed by a NATS microservice) —
+the Python mirror of `../typescript/examples/`. See
+[`examples/README.md`](examples/README.md) for the full table and how
+to run them.
+
 ## Where things live
 
 - This package — `synadia_ai.agent_service`: `AgentService`,

--- a/agent-sdk/python/examples/01-echo.py
+++ b/agent-sdk/python/examples/01-echo.py
@@ -1,0 +1,82 @@
+# 01 · Echo agent — the smallest Synadia Agent Protocol agent (Python).
+#
+# Replies to every prompt with `echo: <prompt text>`. No LLM, no state — just
+# enough to show the shape of an agent built on AgentService: connect to NATS,
+# construct the service, handle prompts, start, shut down. Python mirror of
+# agent-sdk/typescript/examples/01-echo.ts.
+#
+# Identity → subject agents.prompt.echo.<owner>.<session_name>. Owner and the
+# session name are overridable (--owner / --session-name, or $NATS_AGENT_OWNER /
+# $NATS_AGENT_NAME) so several people can run this against one server without
+# colliding. --heartbeat-interval / $NATS_AGENT_HEARTBEAT_INTERVAL tunes the
+# heartbeat cadence (default 30s).
+#
+# Connection: --context / --url, else $NATS_CONTEXT / $NATS_URL, else the
+# selected `nats` context. Run with -h for the full flag list.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import signal
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from synadia_ai.agents import Envelope
+
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
+from synadia_ai.agent_service import AgentService, PromptStream
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Echo agent — replies with the prompt prefixed by 'echo: '."
+    )
+    add_connection_flags(parser)
+    add_agent_identity_flags(parser)
+    args = parser.parse_args()
+
+    nc = await connect_from_cli(args)
+
+    service = AgentService(
+        agent="echo",
+        owner=args.owner,
+        session_name=args.session_name,
+        nc=nc,
+        description="Echo agent — replies with the prompt prefixed by 'echo: '",
+        heartbeat_interval_s=args.heartbeat_interval,
+    )
+
+    # The whole agent. Every incoming prompt runs this handler; whatever we
+    # stream.send(...) is the reply. Here we send one chunk; an LLM agent would
+    # send many, token by token.
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        await stream.send(f"echo: {envelope.prompt}")
+
+    service.on_prompt(handler)
+    await service.start()
+    print(f"echo agent listening on {service.subject.prompt}")
+    print("press Ctrl+C to stop")
+
+    # add_signal_handler is the asyncio-safe way to wake `await stop.wait()`;
+    # signal.signal + Event.set() does not reliably notify the running loop.
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        print("\nshutting down…")
+        await service.stop()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk/python/examples/02-ollama.py
+++ b/agent-sdk/python/examples/02-ollama.py
@@ -1,0 +1,113 @@
+# 02 · LLM agent (Ollama) — forward each prompt to a local Ollama, stream the reply.
+#
+# Step 2 of the ladder: take 01-echo and swap the one-line `echo:` reply for a
+# real LLM round-trip. The agent shape is identical — only the handler body
+# changes. Python mirror of agent-sdk/typescript/examples/02-ollama.ts.
+#
+# Prerequisites: a local Ollama (https://ollama.com) with a model pulled:
+#   ollama pull llama3.2
+# Backend config via env: OLLAMA_URL (default http://localhost:11434),
+# OLLAMA_MODEL (default llama3.2).
+#
+# Identity/heartbeat via --owner/--session-name/--heartbeat-interval or the
+# matching NATS_AGENT_* env vars. Connection: --context/--url, else
+# $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import signal
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from synadia_ai.agents import Envelope
+
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
+from synadia_ai.agent_service import AgentService, PromptStream
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+MODEL = os.environ.get("OLLAMA_MODEL", "llama3.2")
+
+
+async def ollama_tokens(prompt: str) -> AsyncGenerator[str, None]:
+    # Ollama's /api/generate returns newline-delimited JSON — one object per line,
+    # each carrying the next `response` fragment. httpx.aiter_lines() hands us
+    # those lines as they arrive, so tokens flow out as the model produces them.
+    async with (
+        httpx.AsyncClient(timeout=None) as client,
+        client.stream(
+            "POST",
+            f"{OLLAMA_URL}/api/generate",
+            json={"model": MODEL, "prompt": prompt, "stream": True},
+        ) as resp,
+    ):
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if not line.strip():
+                continue
+            # A rare malformed line shouldn't crash the stream — skip it.
+            try:
+                token = json.loads(line).get("response", "")
+            except json.JSONDecodeError:
+                continue
+            if token:
+                yield token
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LLM agent — streams replies from a local Ollama model."
+    )
+    add_connection_flags(parser)
+    add_agent_identity_flags(parser)
+    args = parser.parse_args()
+
+    nc = await connect_from_cli(args)
+
+    service = AgentService(
+        agent="ollama",
+        owner=args.owner,
+        session_name=args.session_name,
+        nc=nc,
+        description=f"LLM agent — answers prompts with the local Ollama '{MODEL}' model",
+        heartbeat_interval_s=args.heartbeat_interval,
+    )
+
+    # Same handler shape as the echo agent: instead of one reply, we send each
+    # token as Ollama emits it.
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        async for token in ollama_tokens(envelope.prompt):
+            await stream.send(token)
+
+    service.on_prompt(handler)
+    await service.start()
+    print(f"ollama agent listening on {service.subject.prompt}")
+    print(f"prompting model '{MODEL}' at {OLLAMA_URL}")
+    print("press Ctrl+C to stop")
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        print("\nshutting down…")
+        await service.stop()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk/python/examples/02-ollama.py
+++ b/agent-sdk/python/examples/02-ollama.py
@@ -45,6 +45,8 @@ async def ollama_tokens(prompt: str) -> AsyncGenerator[str, None]:
     # Ollama's /api/generate returns newline-delimited JSON — one object per line,
     # each carrying the next `response` fragment. httpx.aiter_lines() hands us
     # those lines as they arrive, so tokens flow out as the model produces them.
+    # timeout=None: LLM streams can run arbitrarily long; in production prefer a
+    # per-request read timeout over disabling timeouts wholesale.
     async with (
         httpx.AsyncClient(timeout=None) as client,
         client.stream(

--- a/agent-sdk/python/examples/03-openrouter.py
+++ b/agent-sdk/python/examples/03-openrouter.py
@@ -1,0 +1,127 @@
+# 03 · LLM agent (OpenRouter) — forward each prompt to OpenRouter, stream the reply.
+#
+# Same shape as 02-ollama, but the backend is the hosted, OpenAI-compatible
+# OpenRouter API instead of a local Ollama. Requires an API key; no GPU needed.
+# Python mirror of agent-sdk/typescript/examples/03-openrouter.ts.
+#
+# Prerequisites: an OpenRouter API key (https://openrouter.ai/keys):
+#   export OPENROUTER_API_KEY=sk-or-...
+# Backend config via env: OPENROUTER_API_KEY (required), OPENROUTER_MODEL
+# (default openai/gpt-4o-mini).
+#
+# Identity/heartbeat via --owner/--session-name/--heartbeat-interval or the
+# matching NATS_AGENT_* env vars. Connection: --context/--url, else
+# $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import signal
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from synadia_ai.agents import Envelope
+
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
+from synadia_ai.agent_service import AgentService, PromptStream
+
+API_KEY = os.environ.get("OPENROUTER_API_KEY")
+MODEL = os.environ.get("OPENROUTER_MODEL", "openai/gpt-4o-mini")
+ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
+
+
+async def openrouter_tokens(prompt: str) -> AsyncGenerator[str, None]:
+    # OpenAI SSE: `data: {json}` lines (+ keep-alive comments), then `data: [DONE]`.
+    headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+    async with (
+        httpx.AsyncClient(timeout=None) as client,
+        client.stream(
+            "POST",
+            ENDPOINT,
+            headers=headers,
+            json={
+                "model": MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": True,
+            },
+        ) as resp,
+    ):
+        resp.raise_for_status()
+        async for raw in resp.aiter_lines():
+            line = raw.strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:") :].strip()
+            if data in ("", "[DONE]"):
+                continue
+            try:
+                token = json.loads(data)["choices"][0]["delta"].get("content")
+            except (json.JSONDecodeError, KeyError, IndexError):
+                continue
+            if token:
+                yield token
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LLM agent — streams replies from a hosted OpenRouter model."
+    )
+    add_connection_flags(parser)
+    add_agent_identity_flags(parser)
+    args = parser.parse_args()
+
+    # Checked after parse_args so `--help` works without a key.
+    if not API_KEY:
+        print(
+            "OPENROUTER_API_KEY is not set — get one at https://openrouter.ai/keys",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    nc = await connect_from_cli(args)
+
+    service = AgentService(
+        agent="openrouter",
+        owner=args.owner,
+        session_name=args.session_name,
+        nc=nc,
+        description=f"LLM agent — answers prompts with OpenRouter '{MODEL}'",
+        heartbeat_interval_s=args.heartbeat_interval,
+    )
+
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        async for token in openrouter_tokens(envelope.prompt):
+            await stream.send(token)
+
+    service.on_prompt(handler)
+    await service.start()
+    print(f"openrouter agent listening on {service.subject.prompt}")
+    print(f"prompting model '{MODEL}' via OpenRouter")
+    print("press Ctrl+C to stop")
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        print("\nshutting down…")
+        await service.stop()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk/python/examples/04-combined.py
+++ b/agent-sdk/python/examples/04-combined.py
@@ -1,0 +1,81 @@
+# 04 · LLM agent (combined) — answers prompts with Ollama OR OpenRouter.
+#
+# Step 4 of the ladder, and the reusable base later agents build on. It defers
+# all model access to llm.py, which auto-selects a backend from the environment.
+# Python mirror of agent-sdk/typescript/examples/04-combined.ts.
+#
+#   OPENROUTER_API_KEY set  → OpenRouter (OPENROUTER_MODEL)
+#   otherwise               → local Ollama (OLLAMA_MODEL, OLLAMA_URL)
+#
+# Identity/heartbeat via --owner/--session-name/--heartbeat-interval or the
+# matching NATS_AGENT_* env vars. Connection: --context/--url, else
+# $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import signal
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from synadia_ai.agents import Envelope
+
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
+from examples.llm import create_llm_client
+from synadia_ai.agent_service import AgentService, PromptStream
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LLM agent — answers prompts via Ollama or OpenRouter (auto-selected)."
+    )
+    add_connection_flags(parser)
+    add_agent_identity_flags(parser)
+    args = parser.parse_args()
+
+    llm = create_llm_client()
+    nc = await connect_from_cli(args)
+
+    service = AgentService(
+        agent="llm",
+        owner=args.owner,
+        session_name=args.session_name,
+        nc=nc,
+        description=f"LLM agent — answers prompts via {llm.label}",
+        heartbeat_interval_s=args.heartbeat_interval,
+    )
+
+    # Wrap the prompt as a single user message and stream the model's reply. A
+    # tool-calling agent (see 05-tools.py) extends this same pattern — adding a
+    # non-streamed round-trip for tool dispatch before the final streamed answer.
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        async for token in llm.chat_stream([{"role": "user", "content": envelope.prompt}]):
+            await stream.send(token)
+
+    service.on_prompt(handler)
+    await service.start()
+    print(f"llm agent listening on {service.subject.prompt}")
+    print(f"backend: {llm.label}")
+    print("press Ctrl+C to stop")
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        print("\nshutting down…")
+        await service.stop()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk/python/examples/05-tools.py
+++ b/agent-sdk/python/examples/05-tools.py
@@ -120,7 +120,10 @@ async def run_tool(nc: NATSClient, name: str, args: Any) -> str:
     if name != "read_sensor":
         return f"error: unknown tool '{name}'"
     # Most models hand back parsed arguments; some return a JSON string instead.
-    parsed: Any = json.loads(args) if isinstance(args, str) else args
+    try:
+        parsed: Any = json.loads(args) if isinstance(args, str) else args
+    except json.JSONDecodeError:
+        parsed = {}
     location = ""
     if isinstance(parsed, dict):
         loc = parsed.get("location")

--- a/agent-sdk/python/examples/05-tools.py
+++ b/agent-sdk/python/examples/05-tools.py
@@ -1,0 +1,239 @@
+# 05 · LLM agent with a tool backed by a NATS microservice (Python).
+#
+# The top of the ladder. Examples 2-4 gave the agent a model; this gives it a
+# *tool*, and wires that tool to a NATS microservice. Python mirror of
+# agent-sdk/typescript/examples/05-tools.ts. The point of the demo:
+#
+#   any microservice already on your NATS network can become an agent
+#   capability — the agent need not embed the database, device, or credential
+#   that sits behind it.
+#
+# The agent here holds only an LLM and a NATS connection; it can't read a sensor
+# itself. When the model needs live data it calls the tool, the tool makes a
+# single nc.request(...), and a microservice answers. For a self-contained demo
+# the service is faked in this same file; in production it runs elsewhere.
+#
+# Two round-trips with Ollama (/api/chat with tools): first the model asks to
+# call read_sensor(location); then — once we feed the reading back — it streams
+# its final answer. Needs a tool-capable model (default llama3.1:8b).
+#
+# Identity/heartbeat via --owner/--session-name/--heartbeat-interval or the
+# matching NATS_AGENT_* env vars. Connection: --context/--url, else
+# $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import signal
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from nats.micro import ServiceConfig, add_service
+from nats.micro.service import EndpointConfig
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from synadia_ai.agents import Envelope
+
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
+from synadia_ai.agent_service import AgentService, PromptStream
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATSClient
+    from nats.micro.service import Request
+
+MODEL = os.environ.get("OLLAMA_MODEL", "llama3.1:8b")
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+
+# Subject the sensor microservice listens on. The agent's tool sends requests
+# here; nothing else couples the agent to the service.
+SENSOR_SUBJECT = "sensors.read"
+
+# The microservice's data — a stand-in for "some service already on your
+# network". Room 3 is deliberately too warm, so the agent has something to flag.
+READINGS: dict[str, float] = {
+    "cold-storage-1": 3.4,
+    "cold-storage-2": 2.8,
+    "cold-storage-3": 6.2,
+}
+
+# What we advertise to the model. The handler body is the whole point: one NATS
+# request to the microservice (see run_tool).
+TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_sensor",
+            "description": "Read the current temperature in Celsius at a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "sensor location, e.g. 'cold-storage-3'",
+                    },
+                },
+                "required": ["location"],
+            },
+        },
+    },
+]
+
+
+async def start_sensor_service(nc: NATSClient) -> None:
+    """Register a NATS micro service that answers SENSOR_SUBJECT with a reading.
+
+    In production this is a separate process somewhere on the network — here it
+    just shares the agent's connection so the demo is self-contained.
+    """
+    service = await add_service(
+        nc,
+        ServiceConfig(
+            name="sensors",
+            version="0.1.0",
+            description="Returns the current temperature (°C) for a location",
+        ),
+    )
+
+    async def handler(req: Request) -> None:
+        location = req.data.decode()  # request body is the bare location
+        reading = READINGS.get(location)
+        await req.respond(b"unknown" if reading is None else str(reading).encode())
+
+    await service.add_endpoint(
+        EndpointConfig(name="read", subject=SENSOR_SUBJECT, handler=handler),
+    )
+
+
+async def run_tool(nc: NATSClient, name: str, args: Any) -> str:
+    """Run a tool the model asked for. The whole point: one request to the service."""
+    if name != "read_sensor":
+        return f"error: unknown tool '{name}'"
+    # Most models hand back parsed arguments; some return a JSON string instead.
+    parsed: Any = json.loads(args) if isinstance(args, str) else args
+    location = ""
+    if isinstance(parsed, dict):
+        loc = parsed.get("location")
+        if isinstance(loc, str):
+            location = loc
+    reply = await nc.request(SENSOR_SUBJECT, location.encode(), timeout=5.0)
+    value = reply.data.decode()
+    return f"no sensor at '{location}'" if value == "unknown" else f"{location} is {value}°C"
+
+
+async def chat(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """One non-streamed turn — used for the tool-decision round, for a clean tool_calls array."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        resp = await client.post(
+            f"{OLLAMA_URL}/api/chat",
+            json={"model": MODEL, "messages": messages, "tools": TOOLS, "stream": False},
+        )
+        resp.raise_for_status()
+        body: dict[str, Any] = resp.json()
+        message: dict[str, Any] = body.get("message", {})
+        return message
+
+
+async def chat_stream(messages: list[dict[str, Any]]) -> AsyncGenerator[str, None]:
+    """Final turn — stream the model's answer token by token (no tools needed)."""
+    async with (
+        httpx.AsyncClient(timeout=None) as client,
+        client.stream(
+            "POST",
+            f"{OLLAMA_URL}/api/chat",
+            json={"model": MODEL, "messages": messages, "stream": True},
+        ) as resp,
+    ):
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if not line.strip():
+                continue
+            # A rare malformed line shouldn't crash the stream — skip it.
+            try:
+                token = (json.loads(line).get("message") or {}).get("content", "")
+            except json.JSONDecodeError:
+                continue
+            if token:
+                yield token
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LLM agent with a read_sensor tool backed by a NATS microservice."
+    )
+    add_connection_flags(parser)
+    add_agent_identity_flags(parser)
+    args = parser.parse_args()
+
+    nc = await connect_from_cli(args)
+
+    # Start the microservice the agent's tool will call. In production this is a
+    # separate process somewhere on the network — here it just shares `nc`.
+    await start_sensor_service(nc)
+
+    service = AgentService(
+        agent="tools",
+        owner=args.owner,
+        session_name=args.session_name,
+        nc=nc,
+        description="LLM agent with a read_sensor tool backed by a NATS microservice",
+        heartbeat_interval_s=args.heartbeat_interval,
+    )
+
+    async def handler(envelope: Envelope, stream: PromptStream) -> None:
+        messages: list[dict[str, Any]] = [{"role": "user", "content": envelope.prompt}]
+
+        # Round 1 — does the model want a tool? (non-streamed, for clean tool_calls)
+        decision = await chat(messages)
+        messages.append(decision)
+
+        # Run whatever tools the model asked for, appending each result. (One
+        # round is plenty for this demo; a fuller agent would loop until the
+        # model stops requesting tools.)
+        tool_calls = decision.get("tool_calls") or []
+        for call in tool_calls:
+            fn = call.get("function", {})
+            result = await run_tool(nc, fn.get("name", ""), fn.get("arguments", {}))
+            # No tool_call_id: Ollama's /api/chat returns no tool-call ids and
+            # correlates each result to its call by order.
+            messages.append({"role": "tool", "content": result})
+
+        # No tool needed → round 1 was already the answer.
+        if not tool_calls:
+            await stream.send(decision.get("content", ""))
+            return
+
+        # Round 2 — the model now has the sensor reading; stream its final answer.
+        async for token in chat_stream(messages):
+            await stream.send(token)
+
+    service.on_prompt(handler)
+    await service.start()
+    print(f"tools agent listening on {service.subject.prompt}")
+    print(f"sensor service on '{SENSOR_SUBJECT}', model '{MODEL}' at {OLLAMA_URL}")
+    print("press Ctrl+C to stop")
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        print("\nshutting down…")
+        await service.stop()
+        await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk/python/examples/README.md
+++ b/agent-sdk/python/examples/README.md
@@ -1,0 +1,157 @@
+# `synadia-ai-agent-service` examples
+
+Runnable host-side examples — minimal scripts that spin up an agent speaking the
+[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs).
+Python mirror of
+[`agent-sdk/typescript/examples/`](../../../agent-sdk/typescript/examples/), and
+the host-side counterpart to the caller demos in
+[`client-sdk/python/examples/`](../../../client-sdk/python/examples/).
+
+They form a ladder — each rung is the one before plus a little more:
+
+| Example | What it shows |
+| --- | --- |
+| [`01-echo.py`](01-echo.py) | Minimal echo agent on top of `AgentService` — replies `echo: <prompt>`. |
+| [`02-ollama.py`](02-ollama.py) | Same shape as `01-echo`, but forwards each prompt to a local Ollama and streams the reply. |
+| [`03-openrouter.py`](03-openrouter.py) | Same shape again, but the backend is the hosted, OpenAI-compatible OpenRouter API (needs a key). |
+| [`04-combined.py`](04-combined.py) | Ollama **or** OpenRouter, auto-selected from the env; model access factored into [`llm.py`](llm.py). |
+| [`05-tools.py`](05-tools.py) | Gives the LLM a `read_sensor` tool wired to a NATS microservice, then reasons over the reading. |
+
+The spec-compliant [`_reference_agent.py`](_reference_agent.py) (a stateful echo
+with per-session memory) lives here too — it's what the
+[`client-sdk/python/examples/`](../../../client-sdk/python/examples/) demos and
+the agent-sdk's tests discover and prompt.
+
+## Install
+
+```sh
+uv sync --extra examples   # the `examples` extra pulls in httpx (used by 02–05)
+```
+
+`01-echo.py` needs only the base install; `02`–`05` stream over HTTP with
+`httpx`, so they need the `examples` extra.
+
+## Configuration
+
+Every example resolves its **connection** the same way (via the shared
+`_connect_cli.py`), in order: `--context <name>` → `--url <url>` → `$NATS_URL` →
+the selected `nats` context (`$NATS_CONTEXT` / `nats context select`). If none
+resolve, the script exits with a pointed message.
+
+**Identity and heartbeat** are flags that each default to a `NATS_AGENT_*`
+environment variable, so the examples are env-driven like the TS ladder — and an
+explicit flag overrides the env:
+
+| Flag | Env var | Default | Purpose |
+| --- | --- | --- | --- |
+| `--owner` | `NATS_AGENT_OWNER` | `$USER`, else `anon` | 4th subject token. Set it so several people on one server don't collide. |
+| `--session-name` | `NATS_AGENT_NAME` | `main` | 5th subject token / session this agent serves. |
+| `--heartbeat-interval` | `NATS_AGENT_HEARTBEAT_INTERVAL` | `30` | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier `05-liveness` demo. (`0` is treated as unset → the 30s default.) |
+
+Backend config is read from the environment (its natural home for an API key):
+`OLLAMA_URL` / `OLLAMA_MODEL` for the Ollama agents, `OPENROUTER_API_KEY` /
+`OPENROUTER_MODEL` for the OpenRouter ones.
+
+## Run
+
+```sh
+# localhost, env-driven identity:
+NATS_AGENT_OWNER=alice NATS_AGENT_NAME=demo uv run python examples/01-echo.py --url nats://127.0.0.1:4222
+# or pass identity as flags instead:
+uv run python examples/01-echo.py --url nats://127.0.0.1:4222 --owner alice --session-name demo
+# fast heartbeats, to make the liveness demo lively:
+uv run python examples/01-echo.py --url nats://127.0.0.1:4222 --heartbeat-interval 2
+```
+
+You should see:
+
+```
+echo agent listening on agents.prompt.echo.<owner>.<session-name>
+press Ctrl+C to stop
+```
+
+Drive it from another terminal with the caller-side
+[`client-sdk/python/examples/`](../../../client-sdk/python/examples/) demos, or
+directly with the `nats` CLI:
+
+```sh
+nats req agents.prompt.echo.alice.demo "hello!" --replies=0 --reply-timeout=30s --timeout=60s
+```
+
+Output (leading ack, one response chunk, then the empty terminator):
+
+```
+{"type": "status", "data": "ack"}
+{"type": "response", "data": "echo: hello!"}
+(nil body)
+```
+
+### `02-ollama.py` — prompt a local LLM
+
+Needs a running [Ollama](https://ollama.com) with the model pulled:
+
+```sh
+ollama pull llama3.2
+uv run python examples/02-ollama.py --url nats://127.0.0.1:4222
+OLLAMA_MODEL=qwen2.5 uv run python examples/02-ollama.py --url nats://127.0.0.1:4222
+```
+
+Registers as `ollama`; streams the model's answer token by token.
+
+### `03-openrouter.py` — prompt a hosted LLM
+
+The same agent as `02`, powered by the hosted, OpenAI-compatible
+[OpenRouter](https://openrouter.ai) API. Needs an API key; no GPU required.
+
+```sh
+export OPENROUTER_API_KEY=sk-or-...
+uv run python examples/03-openrouter.py --url nats://127.0.0.1:4222
+OPENROUTER_MODEL=anthropic/claude-3.5-haiku uv run python examples/03-openrouter.py
+```
+
+Registers as `openrouter`.
+
+### `04-combined.py` — Ollama **or** OpenRouter (the reusable base)
+
+Answers with **either** a local Ollama **or** OpenRouter, chosen automatically.
+Model access is factored into [`llm.py`](llm.py) — a small backend-agnostic chat
+client behind one `chat_stream(messages)` API.
+
+| Condition | Backend |
+| --- | --- |
+| `OPENROUTER_API_KEY` is set | **OpenRouter** (`OPENROUTER_MODEL`, default `openai/gpt-4o-mini`) |
+| otherwise | **local Ollama** (`OLLAMA_MODEL`, default `llama3.2`; `OLLAMA_URL`) |
+
+The chosen backend is printed on startup, e.g. `backend: ollama/llama3.2`.
+Registers as `llm`.
+
+### `05-tools.py` — give the agent a tool backed by a microservice
+
+The agent gains a `read_sensor` **tool**, and that tool is wired to a NATS
+microservice. This is the whole point in one file:
+
+> any microservice already on your NATS network can become an agent capability —
+> the agent need not embed the database, device, or credential that sits behind it.
+
+The agent holds only an LLM and a NATS connection; it can't read a sensor itself.
+When the model needs live data it calls the tool, the tool makes a single
+`nc.request(...)`, and a microservice answers. For a self-contained demo it's
+faked in the same file. It uses Ollama's `/api/chat` tool-calling in two
+round-trips. Needs a tool-capable model (`llama3.1:8b` by default):
+
+```sh
+ollama pull llama3.1:8b
+uv run python examples/05-tools.py --url nats://127.0.0.1:4222
+```
+
+Then ask it something that needs the sensor:
+
+```sh
+nats req agents.prompt.tools.<owner>.main \
+  "Is cold-storage room 3 within the safe range (below 4°C)?" \
+  --replies=0 --reply-timeout=45s --timeout=90s
+```
+
+Room 3 is deliberately too warm (`6.2°C`), so the agent has something to flag;
+rooms 1 and 2 are within range. While the agent runs, `nats micro ls` shows both
+the `agents` service (the agent) and the `sensors` service (its tool's backend).

--- a/agent-sdk/python/examples/_connect_cli.py
+++ b/agent-sdk/python/examples/_connect_cli.py
@@ -71,3 +71,61 @@ async def connect_from_cli(args: argparse.Namespace) -> NATSClient:
             file=sys.stderr,
         )
         sys.exit(2)
+
+
+def _env_owner_default() -> str:
+    return os.environ.get("NATS_AGENT_OWNER") or os.environ.get("USER") or "anon"
+
+
+def _env_session_default(fallback: str) -> str:
+    return os.environ.get("NATS_AGENT_NAME") or fallback
+
+
+def _env_heartbeat_default(fallback: int) -> int:
+    raw = os.environ.get("NATS_AGENT_HEARTBEAT_INTERVAL")
+    try:
+        value = int(raw) if raw else 0
+    except ValueError:
+        value = 0
+    # The SDK requires a positive interval; treat 0 / unset / invalid as the default.
+    return value if value > 0 else fallback
+
+
+def add_agent_identity_flags(
+    parser: argparse.ArgumentParser,
+    *,
+    session_fallback: str = "main",
+    heartbeat_fallback: int = 30,
+) -> None:
+    """Wire ``--owner`` / ``--session-name`` / ``--heartbeat-interval`` onto an agent example.
+
+    Each flag defaults to its ``NATS_AGENT_*`` environment variable, so the
+    examples are env-driven like the TS ladder (``NATS_AGENT_OWNER`` /
+    ``NATS_AGENT_NAME`` / ``NATS_AGENT_HEARTBEAT_INTERVAL``); an explicit flag
+    overrides the env. ``NATS_AGENT_HEARTBEAT_INTERVAL=0`` is treated as unset
+    and falls back to ``heartbeat_fallback`` (the SDK requires a positive
+    interval).
+    """
+    parser.add_argument(
+        "--owner",
+        default=_env_owner_default(),
+        help="4th subject token (default: $NATS_AGENT_OWNER, else $USER, else 'anon')",
+    )
+    parser.add_argument(
+        "--session-name",
+        default=_env_session_default(session_fallback),
+        help=(
+            "5th subject token / session this agent serves "
+            f"(default: $NATS_AGENT_NAME, else '{session_fallback}')"
+        ),
+    )
+    parser.add_argument(
+        "--heartbeat-interval",
+        type=int,
+        default=_env_heartbeat_default(heartbeat_fallback),
+        metavar="SECONDS",
+        help=(
+            "heartbeat cadence in seconds "
+            f"(default: $NATS_AGENT_HEARTBEAT_INTERVAL, else {heartbeat_fallback})"
+        ),
+    )

--- a/agent-sdk/python/examples/_reference_agent.py
+++ b/agent-sdk/python/examples/_reference_agent.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import os
 import signal
 import sys
 from collections import deque
@@ -45,7 +44,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from synadia_ai.agents import Envelope
 
-from examples._connect_cli import add_connection_flags, connect_from_cli
+from examples._connect_cli import (
+    add_agent_identity_flags,
+    add_connection_flags,
+    connect_from_cli,
+)
 from synadia_ai.agent_service import AgentService, PromptStream
 
 log = logging.getLogger("synadia_ai.agent_service.examples.reference")
@@ -83,26 +86,15 @@ def _parse_args() -> argparse.Namespace:
         help="§2 `agent` token (default: demo-agent)",
     )
     parser.add_argument(
-        "--owner",
-        default=os.environ.get("USER", "anon"),
-        help="§2 `owner` token (default: $USER)",
-    )
-    parser.add_argument(
-        "--session-name",
-        default="example",
-        help="§2 5th token / session this agent serves (default: example)",
-    )
-    parser.add_argument(
-        "--heartbeat-interval",
-        type=int,
-        default=5,
-        help="heartbeat interval in seconds (default: 5)",
-    )
-    parser.add_argument(
         "--description",
         default="python reference agent",
         help="§3 service description (default: 'python reference agent')",
     )
+    # --owner / --session-name / --heartbeat-interval, each defaulting to its
+    # NATS_AGENT_* env var (so the reference agent is env-driven like the
+    # numbered examples). The reference agent keeps its own fallbacks: session
+    # "example" and a snappy 5s heartbeat (vs. the ladder's "main" / 30s).
+    add_agent_identity_flags(parser, session_fallback="example", heartbeat_fallback=5)
     add_connection_flags(parser)
     return parser.parse_args()
 

--- a/agent-sdk/python/examples/_reference_agent.py
+++ b/agent-sdk/python/examples/_reference_agent.py
@@ -36,7 +36,6 @@ import signal
 import sys
 from collections import deque
 from pathlib import Path
-from types import FrameType
 
 # Make `examples._connect_cli` importable whether the script is launched as
 # `python examples/_reference_agent.py` or `python -m examples._reference_agent`.
@@ -166,13 +165,12 @@ async def main() -> None:
     print(f"reference agent listening on {agent.subject.prompt}")
     print("press Ctrl+C to stop")
 
+    # add_signal_handler is the asyncio-safe way to wake `await stop.wait()`
+    # (matches the numbered ladder examples).
+    loop = asyncio.get_running_loop()
     stop = asyncio.Event()
-
-    def _on_signal(_sig: int, _frame: FrameType | None) -> None:
-        stop.set()
-
-    signal.signal(signal.SIGINT, _on_signal)
-    signal.signal(signal.SIGTERM, _on_signal)
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(_sig, stop.set)
 
     try:
         await stop.wait()

--- a/agent-sdk/python/examples/llm.py
+++ b/agent-sdk/python/examples/llm.py
@@ -1,0 +1,92 @@
+# llm.py — a tiny streaming chat client that targets EITHER a local Ollama or
+# OpenRouter, chosen automatically from the environment. Python mirror of
+# agent-sdk/typescript/examples/llm.ts.
+#
+# This is the "reusable base" behind 04-combined.py: it reduces both backends to
+# one chat shape, so the agent — and any future tool-calling — looks the same
+# regardless of provider. Keep it small and dependency-light (just httpx).
+#
+#   OPENROUTER_API_KEY set?  → OpenRouter (OPENROUTER_MODEL, default openai/gpt-4o-mini)
+#   otherwise                → local Ollama (OLLAMA_MODEL, default llama3.2; OLLAMA_URL)
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncGenerator
+
+import httpx
+
+ChatMessage = dict[str, str]  # {"role": ..., "content": ...}
+
+
+class OllamaClient:
+    def __init__(self) -> None:
+        self.url = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+        self.model = os.environ.get("OLLAMA_MODEL", "llama3.2")
+        self.label = f"ollama/{self.model}"
+
+    async def chat_stream(self, messages: list[ChatMessage]) -> AsyncGenerator[str, None]:
+        # /api/chat returns newline-delimited JSON, each line `{message: {content}}`.
+        async with (
+            httpx.AsyncClient(timeout=None) as client,
+            client.stream(
+                "POST",
+                f"{self.url}/api/chat",
+                json={"model": self.model, "messages": messages, "stream": True},
+            ) as resp,
+        ):
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.strip():
+                    continue
+                # A rare malformed line shouldn't crash the stream — skip it.
+                try:
+                    token = (json.loads(line).get("message") or {}).get("content", "")
+                except json.JSONDecodeError:
+                    continue
+                if token:
+                    yield token
+
+
+class OpenRouterClient:
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.model = os.environ.get("OPENROUTER_MODEL", "openai/gpt-4o-mini")
+        self.label = f"openrouter/{self.model}"
+
+    async def chat_stream(self, messages: list[ChatMessage]) -> AsyncGenerator[str, None]:
+        # OpenAI SSE: `data: {json}` lines (+ keep-alive comments), then `data: [DONE]`.
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        async with (
+            httpx.AsyncClient(timeout=None) as client,
+            client.stream(
+                "POST",
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers=headers,
+                json={"model": self.model, "messages": messages, "stream": True},
+            ) as resp,
+        ):
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                line = raw.strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[len("data:") :].strip()
+                if data in ("", "[DONE]"):
+                    continue
+                try:
+                    token = json.loads(data)["choices"][0]["delta"].get("content")
+                except (json.JSONDecodeError, KeyError, IndexError):
+                    continue
+                if token:
+                    yield token
+
+
+LlmClient = OllamaClient | OpenRouterClient
+
+
+def create_llm_client() -> LlmClient:
+    """Pick a backend from the environment: OpenRouter if a key is present, else Ollama."""
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    return OpenRouterClient(api_key) if api_key else OllamaClient()

--- a/agent-sdk/python/pyproject.toml
+++ b/agent-sdk/python/pyproject.toml
@@ -26,6 +26,14 @@ dependencies = [
     "synadia-ai-agents>=0.7",
 ]
 
+[project.optional-dependencies]
+# Runtime deps for the LLM / tool example scripts only — httpx streams HTTP to
+# Ollama / OpenRouter. Not part of the published SDK surface; CI installs them
+# via `uv sync --all-extras` so ruff/mypy can check the examples.
+examples = [
+    "httpx>=0.27",
+]
+
 [project.urls]
 Homepage = "https://github.com/synadia-ai/synadia-agents/tree/main/agent-sdk/python"
 Repository = "https://github.com/synadia-ai/synadia-agents"

--- a/agent-sdk/python/uv.lock
+++ b/agent-sdk/python/uv.lock
@@ -16,12 +16,80 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -391,6 +459,11 @@ dependencies = [
     { name = "synadia-ai-agents" },
 ]
 
+[package.optional-dependencies]
+examples = [
+    { name = "httpx" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -401,10 +474,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", marker = "extra == 'examples'", specifier = ">=0.27" },
     { name = "nats-py", specifier = ">=2.7" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "synadia-ai-agents", editable = "../../client-sdk/python" },
 ]
+provides-extras = ["examples"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Brings the **Python** agent examples to parity with the TypeScript ladder. `agent-sdk/python/examples/` previously shipped only the reference agent; this adds the numbered ladder, mirroring `agent-sdk/typescript/examples/`, so the repo now has every agent example in **both** languages.

## What's added
- `01-echo.py`, `02-ollama.py`, `03-openrouter.py`, `04-combined.py` + the shared `llm.py` base — ported from `synadia-agents-labs/python/agent/` (the guarded versions).
- `05-tools.py` — **written from scratch** (no labs source): an Ollama `/api/chat` tool-calling agent whose `read_sensor` tool is backed by a NATS micro service. Python port of this repo's unique `05-tools.ts`.
- `agent-sdk/python/examples/README.md` documenting the ladder.

## Adapted to this repo's conventions (not a verbatim copy)
- **Connection** via the shared `_connect_cli.py` resolver (`--context`/`--url` + `$NATS_CONTEXT`/`$NATS_URL`), like every other Python example here.
- **Env-first identity + heartbeat**: `--owner` / `--session-name` / `--heartbeat-interval` each **default to** `NATS_AGENT_OWNER` / `NATS_AGENT_NAME` / `NATS_AGENT_HEARTBEAT_INTERVAL` (flags override). New shared `add_agent_identity_flags()` helper; `HEARTBEAT_INTERVAL=0` is treated as unset → default.
- `_reference_agent.py` flags now default to the same env vars too — **non-breaking** (its e2e test passes explicit flags, which still win).
- `httpx` added as an `examples` extra (CI runs `uv sync --all-extras`); only `02`–`05` need it.
- Backend config (`OLLAMA_*` / `OPENROUTER_*`) stays in env — the natural home for an API key.

## The strictness gotcha (Python analog of TS `exactOptionalPropertyTypes`)
Labs Python is only `py_compile` + `ruff E9,F` checked, but this repo runs **strict `mypy` over `examples/`**. The ports are typed to pass it (e.g. `json.loads(...)` results assigned through `dict[str, Any]` to avoid `warn_return_any`).

## Verification
`ruff check --no-cache`, `ruff format --check`, strict `mypy src tests examples`, and `pytest` (**42 passed** — incl. the retrofit-sensitive `_reference_agent` e2e) all clean. An echo round-trip smoke against a real `nats-server` confirms env-driven identity lands in the subject (`echo.<owner>.<session>`) and the `ack`→`response`→terminator wire shape.

Not included: client-side Python examples — they already exist here (`01-discover` … `06-chat`) and were untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)