### PR TITLE
examples(agent-sdk/typescript): guard runTool JSON.parse in 05-tools

### DIFF
--- a/agent-sdk/typescript/examples/05-tools.ts
+++ b/agent-sdk/typescript/examples/05-tools.ts
@@ -93,9 +93,18 @@ async function runTool(
   args: Record<string, unknown> | string,
 ): Promise<string> {
   if (name !== "read_sensor") return `error: unknown tool '${name}'`;
-  // Most models hand back parsed arguments; some return a JSON string instead.
-  const parsed: Record<string, unknown> =
-    typeof args === "string" ? (JSON.parse(args) as Record<string, unknown>) : args;
+  // Most models hand back parsed arguments; some return a JSON string instead —
+  // tolerate a malformed string rather than throwing out of the prompt handler.
+  let parsed: Record<string, unknown> = {};
+  if (typeof args === "string") {
+    try {
+      parsed = JSON.parse(args) as Record<string, unknown>;
+    } catch {
+      parsed = {};
+    }
+  } else {
+    parsed = args;
+  }
   const location = typeof parsed["location"] === "string" ? parsed["location"] : "";
   const reply = await nc.request(SENSOR_SUBJECT, location, { timeout: 5000 });
   const value = reply.string();


### PR DESCRIPTION
Small cross-language parity follow-up to #140.

`runTool` in `agent-sdk/typescript/examples/05-tools.ts` parsed a tool-call argument string with `JSON.parse(args)` and no guard — a model returning malformed JSON for the arguments would throw out of the prompt handler and abort the stream. Wrapped it in `try/catch`, falling back to `{}` (→ empty location → `"no sensor at ''"`), so a misbehaving model degrades gracefully.

This is the TS counterpart to the same fix made in `05-tools.py` during the #140 review — bringing both languages in line.

## Verification
`bun run typecheck`, `lint`, and `format:check` all pass. No behavior change for well-formed tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)