### PR TITLE
chore: gitignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@ htmlcov/
 # Per-test evidence (client-sdk/python)
 client-sdk/python/tests/_evidence/
 
+# Secrets / local env — API keys (NVIDIA, Tavily, Exa, …) live here.
+# Examples source these (e.g. dspy-research-agent/scripts/run.sh reads ../../.env).
+# Keep templates trackable so the convention stays discoverable.
+.env
+.env.*
+!.env.example
+!.env.sample
+
 # Editor / OS
 .DS_Store
 .idea/


### PR DESCRIPTION
Examples source API keys from a repo-root `.env` — e.g. `examples/dspy-research-agent/scripts/run.sh` does `source ../../.env` for `NVIDIA_API_KEY` / `TAVILY_API_KEY` / `EXA_API_KEY` — but the root `.gitignore` had no rule covering it. A stray `git add -A` from the repo root would commit live secrets.

This ignores `.env` and `.env.*` (root and nested), while keeping `.env.example` / `.env.sample` templates trackable so the convention stays discoverable.

No currently-tracked files are affected (`git ls-files | grep .env` is empty) — purely preventive.

Verified:
- `git check-ignore .env` → ignored
- `git check-ignore examples/foo/.env` → ignored (nested)
- `git check-ignore .env.example` → NOT ignored (templates still trackable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)