### PR TITLE
feat(examples): adopt SYNADIA_* identity env var scheme in agent-sdk TS examples

### DIFF
--- a/agent-sdk/typescript/CHANGELOG.md
+++ b/agent-sdk/typescript/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **Examples: identity env vars moved to the `SYNADIA_*` scheme.** The
+  numbered examples now resolve `owner`/`name` through the per-agent >
+  fleet-wide > legacy chain (`SYNADIA_<AGENT>_OWNER` > `SYNADIA_OWNER` >
+  `NATS_AGENT_OWNER`, same for `_NAME`), matching the env naming
+  convention being adopted across `agents/*`. The legacy
+  `NATS_AGENT_OWNER` / `NATS_AGENT_NAME` vars keep working as
+  lowest-priority aliases; no package API change.
 - `AgentService` now maps handler-raised `ProtocolError`s to
   `Nats-Service-Error-Code: 400` responses while preserving the existing
   `500` mapping for ordinary handler failures. This lets agent adapters reject

--- a/agent-sdk/typescript/examples/01-echo.ts
+++ b/agent-sdk/typescript/examples/01-echo.ts
@@ -22,16 +22,27 @@ async function main(): Promise<void> {
   const nc = await natsConnect(opts);
 
   // Identity → subject `agents.prompt.echo.<owner>.<name>`. Owner and name are
-  // overridable (NATS_AGENT_OWNER / NATS_AGENT_NAME) so several people can run
-  // this against one server without colliding; `agent` ("echo") is what this
-  // example *is*, so it stays fixed. NATS_AGENT_HEARTBEAT_INTERVAL (seconds)
-  // tunes the heartbeat cadence — unset falls back to the SDK default (30s).
+  // env-overridable so several people can run this against one server without
+  // colliding; `agent` ("echo") is what this example *is*, so it stays fixed.
+  // The lookup chain below is the convention agents should follow: per-agent
+  // var > fleet-wide var > legacy `NATS_AGENT_*` alias > derived fallback.
+  // NATS_AGENT_HEARTBEAT_INTERVAL (seconds) tunes the heartbeat cadence —
+  // unset falls back to the SDK default (30s).
   const heartbeatIntervalS = Number(process.env["NATS_AGENT_HEARTBEAT_INTERVAL"]) || undefined;
   const service = new AgentService({
     nc,
     agent: "echo",
-    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
-    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    owner:
+      process.env["SYNADIA_ECHO_OWNER"] ??
+      process.env["SYNADIA_OWNER"] ??
+      process.env["NATS_AGENT_OWNER"] ??
+      process.env["USER"] ??
+      "anon",
+    name:
+      process.env["SYNADIA_ECHO_NAME"] ??
+      process.env["SYNADIA_NAME"] ??
+      process.env["NATS_AGENT_NAME"] ??
+      "main",
     // Spread the key in only when set: exactOptionalPropertyTypes forbids passing
     // `heartbeatIntervalS: undefined` explicitly, and an absent key is exactly
     // what tells the SDK to apply its 30s default.

--- a/agent-sdk/typescript/examples/02-ollama.ts
+++ b/agent-sdk/typescript/examples/02-ollama.ts
@@ -70,8 +70,17 @@ async function main(): Promise<void> {
   const service = new AgentService({
     nc,
     agent: "ollama",
-    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
-    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    owner:
+      process.env["SYNADIA_OLLAMA_OWNER"] ??
+      process.env["SYNADIA_OWNER"] ??
+      process.env["NATS_AGENT_OWNER"] ??
+      process.env["USER"] ??
+      "anon",
+    name:
+      process.env["SYNADIA_OLLAMA_NAME"] ??
+      process.env["SYNADIA_NAME"] ??
+      process.env["NATS_AGENT_NAME"] ??
+      "main",
     ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: `LLM agent — answers prompts with the local Ollama '${MODEL}' model`,
   });

--- a/agent-sdk/typescript/examples/03-openrouter.ts
+++ b/agent-sdk/typescript/examples/03-openrouter.ts
@@ -87,8 +87,17 @@ async function main(): Promise<void> {
   const service = new AgentService({
     nc,
     agent: "openrouter",
-    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
-    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    owner:
+      process.env["SYNADIA_OPENROUTER_OWNER"] ??
+      process.env["SYNADIA_OWNER"] ??
+      process.env["NATS_AGENT_OWNER"] ??
+      process.env["USER"] ??
+      "anon",
+    name:
+      process.env["SYNADIA_OPENROUTER_NAME"] ??
+      process.env["SYNADIA_NAME"] ??
+      process.env["NATS_AGENT_NAME"] ??
+      "main",
     ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: `LLM agent — answers prompts with OpenRouter '${MODEL}'`,
   });

--- a/agent-sdk/typescript/examples/04-combined.ts
+++ b/agent-sdk/typescript/examples/04-combined.ts
@@ -35,8 +35,17 @@ async function main(): Promise<void> {
   const service = new AgentService({
     nc,
     agent: "llm",
-    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
-    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    owner:
+      process.env["SYNADIA_LLM_OWNER"] ??
+      process.env["SYNADIA_OWNER"] ??
+      process.env["NATS_AGENT_OWNER"] ??
+      process.env["USER"] ??
+      "anon",
+    name:
+      process.env["SYNADIA_LLM_NAME"] ??
+      process.env["SYNADIA_NAME"] ??
+      process.env["NATS_AGENT_NAME"] ??
+      "main",
     ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: `LLM agent — answers prompts via ${llm.label}`,
   });

--- a/agent-sdk/typescript/examples/05-tools.ts
+++ b/agent-sdk/typescript/examples/05-tools.ts
@@ -182,8 +182,17 @@ async function main(): Promise<void> {
   const service = new AgentService({
     nc,
     agent: "tools",
-    owner: process.env["NATS_AGENT_OWNER"] ?? process.env["USER"] ?? "anon",
-    name: process.env["NATS_AGENT_NAME"] ?? "main",
+    owner:
+      process.env["SYNADIA_TOOLS_OWNER"] ??
+      process.env["SYNADIA_OWNER"] ??
+      process.env["NATS_AGENT_OWNER"] ??
+      process.env["USER"] ??
+      "anon",
+    name:
+      process.env["SYNADIA_TOOLS_NAME"] ??
+      process.env["SYNADIA_NAME"] ??
+      process.env["NATS_AGENT_NAME"] ??
+      "main",
     ...(heartbeatIntervalS !== undefined ? { heartbeatIntervalS } : {}),
     description: "LLM agent with a read_sensor tool backed by a NATS microservice",
   });

--- a/agent-sdk/typescript/examples/README.md
+++ b/agent-sdk/typescript/examples/README.md
@@ -20,13 +20,17 @@ They form a ladder — each rung is the one before plus a little more:
 Every example resolves its NATS connection and identity the same way; none of
 these are required (the defaults connect to a local server as your `$USER`).
 
-| Variable                        | Default                    | Purpose                                                                                                                                                                                         |
-| ------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NATS_CONTEXT`                  | _(unset)_                  | Connect via a named [NATS CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Wins when set.                                                                       |
-| `NATS_URL`                      | _(unset)_                  | Connect via a raw URL; credentials in the userinfo are honored. When neither this nor `NATS_CONTEXT` is set, the examples fall back to `nats://127.0.0.1:4222`.                                 |
-| `NATS_AGENT_OWNER`              | your `$USER` (else `anon`) | The `owner` token in `agents.prompt.<agent>.<owner>.<name>`. Set it so several people running this against one server don't collide.                                                            |
-| `NATS_AGENT_NAME`               | `main`                     | The instance `name` token in the subject. Use different names to run several instances at once.                                                                                                 |
-| `NATS_AGENT_HEARTBEAT_INTERVAL` | `30`                       | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier [`05-liveness`](../../../client-sdk/typescript/examples/05-liveness.ts) demo. (`0` is treated as unset → the 30s default.) |
+| Variable                                 | Default                    | Purpose                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NATS_CONTEXT`                           | _(unset)_                  | Connect via a named [NATS CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Wins when set.                                                                                                                                                                                   |
+| `NATS_URL`                               | _(unset)_                  | Connect via a raw URL; credentials in the userinfo are honored. When neither this nor `NATS_CONTEXT` is set, the examples fall back to `nats://127.0.0.1:4222`.                                                                                                                                             |
+| `SYNADIA_<AGENT>_OWNER`, `SYNADIA_OWNER` | your `$USER` (else `anon`) | The `owner` token in `agents.prompt.<agent>.<owner>.<name>`. The per-example var (`SYNADIA_ECHO_OWNER`, `SYNADIA_OLLAMA_OWNER`, …) wins over the fleet-wide `SYNADIA_OWNER`; the legacy `NATS_AGENT_OWNER` is still honored below both. Set one so several people running against one server don't collide. |
+| `SYNADIA_<AGENT>_NAME`, `SYNADIA_NAME`   | `main`                     | The instance `name` token in the subject — same lookup chain (legacy: `NATS_AGENT_NAME`). Use different names to run several instances at once.                                                                                                                                                             |
+| `NATS_AGENT_HEARTBEAT_INTERVAL`          | `30`                       | Heartbeat cadence in **seconds**. Lower it (e.g. `2`) for a livelier [`05-liveness`](../../../client-sdk/typescript/examples/05-liveness.ts) demo. (`0` is treated as unset → the 30s default.)                                                                                                             |
+
+The identity lookup chain — per-agent var over fleet-wide var over legacy
+alias — is the env naming convention being adopted across the agent plugins
+(`agents/*`); copy it when writing your own agent.
 
 Per-backend variables (`OLLAMA_URL`, `OLLAMA_MODEL`, `OPENROUTER_API_KEY`,
 `OPENROUTER_MODEL`) are documented in the relevant sections below.
@@ -48,7 +52,7 @@ NATS_URL=tls://connect.ngs.global bun examples/01-echo.ts
 bun examples/01-echo.ts   # localhost fallback
 
 # run as a uniquely-named instance with fast heartbeats:
-NATS_AGENT_OWNER=alice NATS_AGENT_NAME=demo NATS_AGENT_HEARTBEAT_INTERVAL=2 bun examples/01-echo.ts
+SYNADIA_OWNER=alice SYNADIA_NAME=demo NATS_AGENT_HEARTBEAT_INTERVAL=2 bun examples/01-echo.ts
 ```
 
 You should see:
@@ -75,7 +79,8 @@ Output:
 (empty terminator)
 ```
 
-(The owner defaults to your `$USER` unless you set `NATS_AGENT_OWNER`.)
+(The owner defaults to your `$USER` unless you set `SYNADIA_OWNER` — or the
+per-example `SYNADIA_ECHO_OWNER`, or the legacy `NATS_AGENT_OWNER`.)
 
 ### `02-ollama.ts` — prompt a local LLM
 

--- a/client-sdk/typescript/examples/README.md
+++ b/client-sdk/typescript/examples/README.md
@@ -21,7 +21,8 @@ the TypeScript mirror of
 
 The demos resolve their NATS connection the same way; neither is required (the
 default connects to a local server). They discover and prompt agents — no agent
-identity to set, so the `NATS_AGENT_*` vars used by the
+identity to set, so the identity vars (`SYNADIA_OWNER` / `SYNADIA_NAME`, legacy
+`NATS_AGENT_*`) used by the
 [host-side examples](../../../agent-sdk/typescript/examples/) don't apply here.
 
 | Variable       | Default   | Purpose                                                                                                                   |


### PR DESCRIPTION
## What

Migrates the five numbered `agent-sdk/typescript/examples` to the canonical identity env var lookup chain being adopted across `agents/*`:

```
SYNADIA_<AGENT>_OWNER  >  SYNADIA_OWNER  >  NATS_AGENT_OWNER (legacy)  >  $USER  >  "anon"
SYNADIA_<AGENT>_NAME   >  SYNADIA_NAME   >  NATS_AGENT_NAME  (legacy)  >  "main"
```

`<AGENT>` is each example's agent token (`ECHO`, `OLLAMA`, `OPENROUTER`, `LLM`, `TOOLS`).

## Why

- The examples are what new agent authors copy-paste, so they should demonstrate the convention: a per-agent var (scopes an override to one agent on a shared host) above a fleet-wide var (set identity once for everything).
- The legacy `NATS_AGENT_OWNER` / `NATS_AGENT_NAME` vars **keep working** as lowest-priority aliases — `synadia-agents-labs` and the Python example ladder were built from these files and still document them. Nothing breaks.
- The `agent` (3rd) subject token stays fixed per example by design — no override mechanism is introduced (project decision, 2026-06-12).
- `NATS_AGENT_HEARTBEAT_INTERVAL` is deliberately untouched; heartbeat var naming is a separate, undecided question.

## Docs

- `examples/README.md`: env table rows for the new scheme (legacy noted as honored), run snippet uses `SYNADIA_OWNER`/`SYNADIA_NAME`, plus a note that the chain is the convention to copy.
- `client-sdk/typescript/examples/README.md`: cross-reference sentence updated.
- `agent-sdk/typescript/CHANGELOG.md`: entry under `[Unreleased]` (examples-only, no package API change).

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check` all green.
- Live precedence smoke test against a local nats-server: per-agent beats fleet-wide beats legacy, producing `agents.prompt.echo.peragent.t1`, `...fleet.t2`, `...legacy.t3` respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)