### PR TITLE
feat(claude-code): make owner settable; adopt SYNADIA_* identity env vars

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -58,6 +58,8 @@ and permissions. All state lives in `~/.claude/channels/nats/config.json`.
 | `/nats-channel:configure <context-name>` | Select a NATS CLI context to connect to |
 | `/nats-channel:configure session <name>` | Override the session name (5th token in `agents.prompt.cc.<owner>.<name>`) |
 | `/nats-channel:configure session clear` | Remove session name override, revert to CWD basename |
+| `/nats-channel:configure owner <name>` | Override the owner (4th token in `agents.prompt.cc.<owner>.<name>`) |
+| `/nats-channel:configure owner clear` | Remove owner override, revert to sanitized `$USER` |
 | `/nats-channel:configure permissions terminal` | Prompt for permissions in the terminal (default) |
 | `/nats-channel:configure permissions query` | Relay permission prompts as protocol query chunks |
 | `/nats-channel:configure permissions clear` | Reset permissions to default |
@@ -143,7 +145,12 @@ canonical counterpart.
 The micro service prompt subject is `agents.prompt.cc.<owner>.<name>` (v0.3 verb-first §2). Heartbeats go to `agents.hb.cc.<owner>.<name>` and the status endpoint replies on `agents.status.cc.<owner>.<name>`.
 
 - **Default:** sanitized basename of the working directory (e.g., `my-project`)
-- **Override:** set `NATS_SESSION_NAME` env var, or use `/nats-channel:configure session <name>`
+- **Override:** set `SYNADIA_CLAUDE_CODE_NAME` (or the fleet-wide
+  `SYNADIA_NAME`, or the legacy `NATS_SESSION_NAME`) env var, or use
+  `/nats-channel:configure session <name>`
+- **Owner:** the 4th token defaults to the sanitized `$USER`; override
+  with `SYNADIA_CLAUDE_CODE_OWNER` (or the fleet-wide `SYNADIA_OWNER`),
+  or `/nats-channel:configure owner <name>`
 - **Multiple sessions:** if the default name is already taken by another
   claude-code instance owned by the same user, the plugin auto-appends
   `-2`, `-3`, etc.
@@ -262,6 +269,7 @@ NATS CLI contexts live in `~/.config/nats/context/<name>.json`.
 ```json
 {
   "context": "my-context",
+  "owner": "my-team",
   "sessionName": "my-session",
   "permissions": {
     "mode": "query"
@@ -272,12 +280,22 @@ NATS CLI contexts live in `~/.config/nats/context/<name>.json`.
 | Field | Default | Description |
 | --- | --- | --- |
 | `context` | *(none - uses demo.nats.io)* | NATS CLI context name |
+| `owner` | sanitized `$USER` | Override the owner (4th subject token) |
 | `sessionName` | CWD basename | Override the session name |
 | `permissions.mode` | `terminal` | `terminal` or `query` (`nats` accepted as legacy alias for `query`) |
 
 ### Environment variables
 
+Identity vars follow the `SYNADIA_*` convention shared across the agent
+plugins: per-agent var > fleet-wide var > legacy alias / config file >
+derived fallback.
+
 | Variable | Overrides | Default |
 | --- | --- | --- |
-| `NATS_SESSION_NAME` | Session name (5th token in `agents.prompt.cc.<owner>.<name>`) | sanitized basename of `$CLAUDE_CWD` |
+| `SYNADIA_CLAUDE_CODE_OWNER`, `SYNADIA_OWNER` | Owner (4th token in `agents.prompt.cc.<owner>.<name>`); per-agent var wins, then fleet-wide, then config `owner` | sanitized `$USER` |
+| `SYNADIA_CLAUDE_CODE_NAME`, `SYNADIA_NAME` | Session name (5th token); per-agent var wins, then fleet-wide, then the legacy `NATS_SESSION_NAME`, then config `sessionName` | sanitized basename of `$CLAUDE_CWD` |
+| `NATS_SESSION_NAME` | Session name — legacy alias, still honored below the `SYNADIA_*` vars | — |
+| `NATS_CONTEXT` | NATS CLI context to connect with (wins over config `context`) | — |
+| `NATS_URL` | Raw NATS URL; used when no context is set via env or config | `demo.nats.io` |
 | `NATS_STATE_DIR` | State directory location | `~/.claude/channels/nats` |
+| `CLAUDE_CWD` | Working directory whose basename seeds the default session name | — |

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -294,7 +294,7 @@ derived fallback.
 | --- | --- | --- |
 | `SYNADIA_CLAUDE_CODE_OWNER`, `SYNADIA_OWNER` | Owner (4th token in `agents.prompt.cc.<owner>.<name>`); per-agent var wins, then fleet-wide, then config `owner` | sanitized `$USER` |
 | `SYNADIA_CLAUDE_CODE_NAME`, `SYNADIA_NAME` | Session name (5th token); per-agent var wins, then fleet-wide, then the legacy `NATS_SESSION_NAME`, then config `sessionName` | sanitized basename of `$CLAUDE_CWD` |
-| `NATS_SESSION_NAME` | Session name — legacy alias, still honored below the `SYNADIA_*` vars | — |
+| `NATS_SESSION_NAME` | Session name — legacy alias, still honored below the `SYNADIA_*` vars | *(unset — falls through to config `sessionName`, then the `$CLAUDE_CWD` basename)* |
 | `NATS_CONTEXT` | NATS CLI context to connect with (wins over config `context`) | — |
 | `NATS_URL` | Raw NATS URL; used when no context is set via env or config | `demo.nats.io` |
 | `NATS_STATE_DIR` | State directory location | `~/.claude/channels/nats` |

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -105,6 +105,7 @@ type PermissionMode = 'terminal' | 'query'
 
 type NatsChannelConfig = {
   context?: string
+  owner?: string
   sessionName?: string
   permissions?: {
     // 'nats' is accepted as a backward-compatible alias for 'query'.
@@ -366,8 +367,19 @@ process.stderr.write(`nats channel: connected (max_payload=${MAX_PAYLOAD_STR})\n
 
 // ── Resolve session name and register micro service ────────────────────
 
-const owner = sanitizeSessionName(process.env.USER ?? 'unknown') || 'unknown'
-const rawSessionName = (process.env.NATS_SESSION_NAME
+// Owner and name follow the SYNADIA_* identity convention shared across
+// agents/*: per-agent var > fleet-wide var > legacy alias / config file >
+// derived fallback. Explicit values flow through unsanitized — the SDK's
+// `AgentSubject.new` rejects invalid tokens with a clear error — while
+// derived ones ($USER, CWD basename) are sanitized into subject-safe form.
+const owner = (process.env.SYNADIA_CLAUDE_CODE_OWNER
+  ?? process.env.SYNADIA_OWNER
+  ?? config.owner
+  ?? sanitizeSessionName(process.env.USER ?? 'unknown'))
+  || 'unknown'
+const rawSessionName = (process.env.SYNADIA_CLAUDE_CODE_NAME
+  ?? process.env.SYNADIA_NAME
+  ?? process.env.NATS_SESSION_NAME
   ?? config.sessionName
   ?? sanitizeSessionName(basename(process.env.CLAUDE_CWD ?? '')))
   || 'default'

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -388,9 +388,21 @@ const sessionName = await resolveSessionName(nc, rawSessionName, owner)
 // `metadata.agent` carries the canonical "claude-code"; the wire subject's
 // 3rd token is the conventional abbreviation `cc` (Appendix C).
 // `AgentSubject.new(...)`'s `subjectToken` option owns this split.
-const agentSubject = AgentSubject.new(AGENT_ID, owner, sessionName, {
-  subjectToken: AGENT_SUBJECT_TOKEN,
-})
+const agentSubject = (() => {
+  try {
+    return AgentSubject.new(AGENT_ID, owner, sessionName, {
+      subjectToken: AGENT_SUBJECT_TOKEN,
+    })
+  } catch (err) {
+    process.stderr.write(
+      `nats channel: invalid identity token (owner=${JSON.stringify(owner)}, name=${JSON.stringify(sessionName)}) — ` +
+      `check SYNADIA_CLAUDE_CODE_OWNER / SYNADIA_OWNER / config "owner" and ` +
+      `SYNADIA_CLAUDE_CODE_NAME / SYNADIA_NAME / NATS_SESSION_NAME / config "sessionName": ` +
+      `${(err as Error).message}\n`,
+    )
+    process.exit(1)
+  }
+})()
 const subject = agentSubject.prompt
 const heartbeatSubject = agentSubject.heartbeat
 const statusSubject = agentSubject.status

--- a/agents/claude-code/skills/configure/SKILL.md
+++ b/agents/claude-code/skills/configure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configure
-description: Configure NATS channel - select context, set session name, configure permissions. Use when user asks to set up NATS, connect to NATS, change context, or configure permissions.
+description: Configure NATS channel - select context, set owner and session name, configure permissions. Use when user asks to set up NATS, connect to NATS, change context, or configure permissions.
 user-invocable: true
 allowed-tools:
   - Read
@@ -30,6 +30,7 @@ Read state and give the user a complete picture, then ask:
 
 1. **Current config** - read `~/.claude/channels/nats/config.json`. Show:
    - Selected context name (or "none - using demo.nats.io")
+   - Owner override (if set)
    - Session name override (if set)
    - Connection URL and description from the context file
    - Permission mode (`terminal` or `query`) and whether permission prompts
@@ -81,6 +82,22 @@ Two separate steps - do NOT combine into one Bash call:
 
 Remove the `sessionName` field from `config.json` so the default
 (CWD basename) is used.
+
+### `owner <name>` - set owner override
+
+1. The owner is the 4th token in the v0.3 verb-first subject
+   `agents.prompt.cc.<owner>.<name>`. It defaults to the sanitized
+   `$USER`. This command overrides it — useful for service accounts or
+   deployment-scoped owners.
+2. Read existing `config.json` (or start fresh). Set the `owner` field.
+   Write back.
+3. Confirm the override. Note: the `SYNADIA_CLAUDE_CODE_OWNER` and
+   `SYNADIA_OWNER` env vars take precedence over this config field.
+
+### `owner clear` - remove owner override
+
+Remove the `owner` field from `config.json` so the default (sanitized
+`$USER`) is used.
 
 ### `permissions terminal` - use terminal for permission prompts
 

--- a/agents/claude-code/skills/configure/SKILL.md
+++ b/agents/claude-code/skills/configure/SKILL.md
@@ -72,7 +72,7 @@ Two separate steps - do NOT combine into one Bash call:
 ### `session <name>` - set session name override
 
 1. The session name is the 5th token in the v0.3 verb-first subject
-   `agents.prompt.cc.<user>.<name>`. It defaults to the working directory
+   `agents.prompt.cc.<owner>.<name>`. It defaults to the working directory
    basename. This command overrides it.
 2. Read existing `config.json` (or start fresh). Set `sessionName` field.
    Write back.


### PR DESCRIPTION
Second PR in the identity env var series (follows #150, the examples migration).

## What

The owner (4th subject token) in `agents.prompt.cc.<owner>.<name>` was hard-wired to sanitized `$USER` — claude-code was the only agent plugin where it could not be configured at all. It now resolves through the `SYNADIA_*` identity convention:

```
owner: SYNADIA_CLAUDE_CODE_OWNER > SYNADIA_OWNER > config "owner" > sanitized $USER > "unknown"
name:  SYNADIA_CLAUDE_CODE_NAME  > SYNADIA_NAME  > NATS_SESSION_NAME (legacy) > config "sessionName" > sanitized basename($CLAUDE_CWD) > "default"
```

- **Zero behavior change when no new vars are set** — the default path produces byte-identical subjects.
- **`NATS_SESSION_NAME` keeps working** as a legacy alias, one notch below the `SYNADIA_*` vars.
- Sanitization philosophy preserved: explicit values flow raw to `AgentSubject.new` (which rejects invalid tokens loudly via `assertValidToken`); derived values (`$USER`, CWD basename) stay sanitized.

## Also in this PR

- `/nats-channel:configure` learns `owner <name>` / `owner clear` subcommands and shows the owner override in the status view (the skill is the documented writer of `config.json`, so the new config field gets a writer too).
- README: documents the new identity vars **and** the previously undocumented `NATS_CONTEXT`, `NATS_URL`, and `CLAUDE_CWD` (README-drift found during the env var analysis).

## Verification

5-case smoke matrix against an isolated local nats-server, asserting the registered subject from server stderr:

| Case | Env / config | Registered subject |
| --- | --- | --- |
| per-agent wins over fleet + legacy | `SYNADIA_CLAUDE_CODE_OWNER=peragent` `SYNADIA_OWNER=fleet` `SYNADIA_CLAUDE_CODE_NAME=t1` `SYNADIA_NAME=x` `NATS_SESSION_NAME=y` | `agents.prompt.cc.peragent.t1` |
| fleet owner, legacy name | `SYNADIA_OWNER=fleet` `NATS_SESSION_NAME=t2` | `agents.prompt.cc.fleet.t2` |
| config owner honored | config `{"owner":"cfgowner"}` | `agents.prompt.cc.cfgowner.t3` |
| env beats config | config `{"owner":"cfgowner"}` + `SYNADIA_OWNER=fleet` | `agents.prompt.cc.fleet.t4` |
| defaults unchanged | none | `agents.prompt.cc.m64.cwd-base` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)