### PR TITLE
feat(openclaw): adopt SYNADIA_* identity env vars; accept NATS_CREDS alias

### DIFF
--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name: `SYNADIA_OPENCLAW_NAME` > `SYNADIA_NAME` > `NATS_AGENT_NAME`
   (legacy) > account config. Purely additive — the legacy vars keep
   working with identical behavior; the new vars only sit above them.
-- `NATS_CREDS` is accepted as an alias for `NATS_CREDENTIALS` (used
-  only when `NATS_CREDENTIALS` is unset), matching flue and opencode.
+- `NATS_CREDS` is accepted as an alias for `NATS_CREDENTIALS` — the
+  spelling flue and opencode also accept. Tie-break differs
+  deliberately: here the incumbent `NATS_CREDENTIALS` wins when both
+  are set (zero change for existing deployments), whereas flue/opencode
+  check `NATS_CREDS` first.
 - The env-override log line now names the variable that actually
   supplied the value (e.g. `SYNADIA_OWNER`), not just the legacy name.
 

--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `@synadia-ai/nats-channel` (the OpenClaw plugin)
+will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Identity env vars adopt the `SYNADIA_*` convention** shared across
+  `agents/*`. Owner: `SYNADIA_OPENCLAW_OWNER` > `SYNADIA_OWNER` >
+  `NATS_OWNER` (legacy) > `NATS_ORG` (legacy) > account config. Agent
+  name: `SYNADIA_OPENCLAW_NAME` > `SYNADIA_NAME` > `NATS_AGENT_NAME`
+  (legacy) > account config. Purely additive — the legacy vars keep
+  working with identical behavior; the new vars only sit above them.
+- `NATS_CREDS` is accepted as an alias for `NATS_CREDENTIALS` (used
+  only when `NATS_CREDENTIALS` is unset), matching flue and opencode.
+- The env-override log line now names the variable that actually
+  supplied the value (e.g. `SYNADIA_OWNER`), not just the legacy name.
+
+## [0.5.6] and earlier
+
+Changelog started 2026-06-12 (at package version 0.5.6); see the git
+history of `agents/openclaw/` for earlier changes.

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -113,15 +113,24 @@ Restart with `openclaw gateway restart`.
 
 Each field has a matching env var. Useful for containers and any setup where you don't want secrets baked into a config file.
 
+Identity vars (`owner`, `agentName`) follow the `SYNADIA_*` convention shared
+across the agent plugins: per-agent var > fleet-wide var > legacy alias >
+account config. The legacy vars keep working indefinitely.
+
 | Variable | Sets | Notes |
 |----------|------|-------|
 | `NATS_CONTEXT` | `context` | Highest precedence — see below. |
 | `NATS_URL` | `url` | |
-| `NATS_AGENT_NAME` | `agentName` | |
+| `SYNADIA_OPENCLAW_NAME` | `agentName` | Per-agent override — highest name precedence. |
+| `SYNADIA_NAME` | `agentName` | Fleet-wide override — below the per-agent var. |
+| `NATS_AGENT_NAME` | `agentName` | Legacy alias, still honored below the `SYNADIA_*` vars. |
 | `NATS_DESCRIPTION` | `description` | |
-| `NATS_OWNER` | `owner` | |
-| `NATS_ORG` | `owner` | Legacy alias. |
+| `SYNADIA_OPENCLAW_OWNER` | `owner` | Per-agent override — highest owner precedence. |
+| `SYNADIA_OWNER` | `owner` | Fleet-wide override — below the per-agent var. |
+| `NATS_OWNER` | `owner` | Legacy alias, still honored below the `SYNADIA_*` vars. |
+| `NATS_ORG` | `owner` | Legacy alias (pre-0.3). |
 | `NATS_CREDENTIALS` | `credentials` | |
+| `NATS_CREDS` | `credentials` | Alias — used only when `NATS_CREDENTIALS` is unset. |
 
 ### Resolution order
 

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -21,8 +21,8 @@ export NATS_CONTEXT=ngs                       # a NATS CLI context (recommended 
 export NATS_URL=nats://demo.nats.io            # raw URL
 export NATS_CREDENTIALS=/path/to/your.creds   # optional, for NKEY/JWT auth
 
-export NATS_AGENT_NAME=my-agent               # required: agent identity (5th subject token)
-export NATS_OWNER=my-org                      # optional: 4th subject token (defaults to "default")
+export NATS_AGENT_NAME=my-agent               # required: agent identity (5th subject token; or SYNADIA_OPENCLAW_NAME)
+export NATS_OWNER=my-org                      # optional: 4th subject token (defaults to "default"; or SYNADIA_OPENCLAW_OWNER)
 
 openclaw gateway
 ```
@@ -121,10 +121,10 @@ account config. The legacy vars keep working indefinitely.
 |----------|------|-------|
 | `NATS_CONTEXT` | `context` | Highest precedence — see below. |
 | `NATS_URL` | `url` | |
+| `NATS_DESCRIPTION` | `description` | |
 | `SYNADIA_OPENCLAW_NAME` | `agentName` | Per-agent override — highest name precedence. |
 | `SYNADIA_NAME` | `agentName` | Fleet-wide override — below the per-agent var. |
 | `NATS_AGENT_NAME` | `agentName` | Legacy alias, still honored below the `SYNADIA_*` vars. |
-| `NATS_DESCRIPTION` | `description` | |
 | `SYNADIA_OPENCLAW_OWNER` | `owner` | Per-agent override — highest owner precedence. |
 | `SYNADIA_OWNER` | `owner` | Fleet-wide override — below the per-agent var. |
 | `NATS_OWNER` | `owner` | Legacy alias, still honored below the `SYNADIA_*` vars. |

--- a/agents/openclaw/src/accounts.test.ts
+++ b/agents/openclaw/src/accounts.test.ts
@@ -19,7 +19,46 @@ try {
   skip = true;
 }
 
+// Identity env vars that influence resolveNatsAccount. Cleared per-test so
+// values leaking in from the invoking shell can't skew expectations, and
+// restored afterwards.
+const IDENTITY_ENV_VARS = [
+  "SYNADIA_OPENCLAW_OWNER",
+  "SYNADIA_OWNER",
+  "NATS_OWNER",
+  "NATS_ORG",
+  "SYNADIA_OPENCLAW_NAME",
+  "SYNADIA_NAME",
+  "NATS_AGENT_NAME",
+  "NATS_CREDENTIALS",
+  "NATS_CREDS",
+] as const;
+
+function snapshotIdentityEnv(): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const v of IDENTITY_ENV_VARS) {
+    saved[v] = process.env[v];
+    delete process.env[v];
+  }
+  return saved;
+}
+
+function restoreIdentityEnv(saved: Record<string, string | undefined>): void {
+  for (const v of IDENTITY_ENV_VARS) {
+    if (saved[v] === undefined) delete process.env[v];
+    else process.env[v] = saved[v];
+  }
+}
+
 describe.skipIf(skip)("account resolution", () => {
+  let savedIdentity: Record<string, string | undefined>;
+  beforeEach(() => {
+    savedIdentity = snapshotIdentityEnv();
+  });
+  afterEach(() => {
+    restoreIdentityEnv(savedIdentity);
+  });
+
   it("returns sensible defaults for empty config (owner falls back to \"default\")", () => {
     const account = resolveNatsAccount({});
     expect(account.url).toBe("");
@@ -71,23 +110,90 @@ describe.skipIf(skip)("account resolution", () => {
   });
 });
 
+describe.skipIf(skip)("identity env overrides (SYNADIA_* convention)", () => {
+  let savedIdentity: Record<string, string | undefined>;
+  beforeEach(() => {
+    savedIdentity = snapshotIdentityEnv();
+  });
+  afterEach(() => {
+    restoreIdentityEnv(savedIdentity);
+  });
+
+  const cfg = {
+    channels: {
+      nats: {
+        accounts: {
+          default: {
+            agentName: "cfg-name",
+            owner: "cfg-owner",
+            credentials: "/cfg.creds",
+          },
+        },
+      },
+    },
+  };
+
+  it("SYNADIA_OPENCLAW_OWNER (per-agent) wins over fleet-wide, legacy, and config", () => {
+    process.env.SYNADIA_OPENCLAW_OWNER = "per-agent";
+    process.env.SYNADIA_OWNER = "fleet";
+    process.env.NATS_OWNER = "legacy";
+    expect(resolveNatsAccount(cfg, "default").owner).toBe("per-agent");
+  });
+
+  it("SYNADIA_OWNER (fleet-wide) wins over the legacy vars and config", () => {
+    process.env.SYNADIA_OWNER = "fleet";
+    process.env.NATS_OWNER = "legacy";
+    process.env.NATS_ORG = "older";
+    expect(resolveNatsAccount(cfg, "default").owner).toBe("fleet");
+  });
+
+  it("legacy NATS_OWNER and NATS_ORG keep working below the SYNADIA_* vars", () => {
+    process.env.NATS_OWNER = "legacy";
+    expect(resolveNatsAccount(cfg, "default").owner).toBe("legacy");
+    delete process.env.NATS_OWNER;
+    process.env.NATS_ORG = "older";
+    expect(resolveNatsAccount(cfg, "default").owner).toBe("older");
+  });
+
+  it("agentName: SYNADIA_OPENCLAW_NAME > SYNADIA_NAME > NATS_AGENT_NAME > config", () => {
+    expect(resolveNatsAccount(cfg, "default").agentName).toBe("cfg-name");
+    process.env.NATS_AGENT_NAME = "legacy-name";
+    expect(resolveNatsAccount(cfg, "default").agentName).toBe("legacy-name");
+    process.env.SYNADIA_NAME = "fleet-name";
+    expect(resolveNatsAccount(cfg, "default").agentName).toBe("fleet-name");
+    process.env.SYNADIA_OPENCLAW_NAME = "per-agent-name";
+    expect(resolveNatsAccount(cfg, "default").agentName).toBe("per-agent-name");
+  });
+
+  it("NATS_CREDS is accepted as an alias when NATS_CREDENTIALS is unset", () => {
+    process.env.NATS_CREDS = "/alias.creds";
+    expect(resolveNatsAccount(cfg, "default").credentials).toBe("/alias.creds");
+  });
+
+  it("NATS_CREDENTIALS (incumbent) wins when both creds vars are set", () => {
+    process.env.NATS_CREDENTIALS = "/incumbent.creds";
+    process.env.NATS_CREDS = "/alias.creds";
+    expect(resolveNatsAccount(cfg, "default").credentials).toBe("/incumbent.creds");
+  });
+});
+
 describe.skipIf(skip)("config.context resolution", () => {
   let baseHome: string;
   let savedHome: string | undefined;
   let savedEnvUrl: string | undefined;
-  let savedEnvCreds: string | undefined;
   let savedEnvCtx: string | undefined;
+  let savedIdentity: Record<string, string | undefined>;
 
   beforeEach(() => {
     baseHome = mkdtempSync(join(tmpdir(), "openclaw-cfgctx-"));
     mkdirSync(join(baseHome, ".config", "nats", "context"), { recursive: true });
     savedHome = process.env.HOME;
     savedEnvUrl = process.env.NATS_URL;
-    savedEnvCreds = process.env.NATS_CREDENTIALS;
     savedEnvCtx = process.env.NATS_CONTEXT;
+    // Also clears NATS_CREDENTIALS / NATS_CREDS, which these tests assert on.
+    savedIdentity = snapshotIdentityEnv();
     process.env.HOME = baseHome;
     delete process.env.NATS_URL;
-    delete process.env.NATS_CREDENTIALS;
     delete process.env.NATS_CONTEXT;
   });
 
@@ -96,10 +202,9 @@ describe.skipIf(skip)("config.context resolution", () => {
     else process.env.HOME = savedHome;
     if (savedEnvUrl === undefined) delete process.env.NATS_URL;
     else process.env.NATS_URL = savedEnvUrl;
-    if (savedEnvCreds === undefined) delete process.env.NATS_CREDENTIALS;
-    else process.env.NATS_CREDENTIALS = savedEnvCreds;
     if (savedEnvCtx === undefined) delete process.env.NATS_CONTEXT;
     else process.env.NATS_CONTEXT = savedEnvCtx;
+    restoreIdentityEnv(savedIdentity);
   });
 
   function writeContext(name: string, body: Record<string, unknown>): void {

--- a/agents/openclaw/src/accounts.ts
+++ b/agents/openclaw/src/accounts.ts
@@ -19,7 +19,9 @@ function getAccounts(cfg: OpenClawConfig): Record<string, NatsAccountConfig> {
 
 // Dedup env-override log lines so the many `currentValue` callbacks in the
 // setup wizard don't flood the console — one line per (accountId, envVar) pair
-// per process is enough to make the override visible.
+// per process is enough to make the override visible. The dedup affects
+// LOGGING ONLY: `applyEnvOverride` always assigns `resolved[field]` before
+// the dedup check, so a missing log line never means a missing override.
 const loggedEnvOverrides = new Set<string>();
 
 function applyEnvOverride(
@@ -155,6 +157,10 @@ export function resolveNatsAccount(
   if (ownerEnv) {
     applyEnvOverride(resolved, "owner", raw.owner ?? raw.org, ownerEnv.value, id, ownerEnv.name);
   }
+  // NATS_CREDENTIALS deliberately wins over the NATS_CREDS alias here —
+  // it's openclaw's incumbent var, so existing deployments see zero change
+  // when both are set. (flue/opencode check NATS_CREDS first; only the
+  // accepted spelling is shared, not the tie-break order.)
   const credsEnv = firstDefinedEnv("NATS_CREDENTIALS", "NATS_CREDS");
   if (credsEnv) {
     applyEnvOverride(resolved, "credentials", resolved.credentials, credsEnv.value, id, credsEnv.name, true);

--- a/agents/openclaw/src/accounts.ts
+++ b/agents/openclaw/src/accounts.ts
@@ -45,12 +45,27 @@ function applyEnvOverride(
   console.warn(`[nats] env override ${envName} (account=${accountId}): ${suffix}`);
 }
 
+// First defined entry from an ordered list of env var names. Identity vars
+// follow the SYNADIA_* convention shared across agents/*: per-agent var >
+// fleet-wide var > legacy alias. Returns the winning name alongside the
+// value so the override log can attribute it to the var that supplied it.
+function firstDefinedEnv(
+  ...names: string[]
+): { name: string; value: string } | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value !== undefined) return { name, value };
+  }
+  return undefined;
+}
+
 export function listNatsAccountIds(cfg: OpenClawConfig): string[] {
   const ids = Object.keys(getAccounts(cfg));
   const result = ids.length > 0 ? ids : [DEFAULT_ACCOUNT_ID];
+  const nameEnv = firstDefinedEnv("SYNADIA_OPENCLAW_NAME", "SYNADIA_NAME", "NATS_AGENT_NAME");
   console.log(
-    `[nats] listAccountIds: ${JSON.stringify(result)} (config keys: ${ids.length}, NATS_AGENT_NAME: ${
-      process.env.NATS_AGENT_NAME ?? "unset"
+    `[nats] listAccountIds: ${JSON.stringify(result)} (config keys: ${ids.length}, name env: ${
+      nameEnv ? `${nameEnv.name}=${nameEnv.value}` : "unset"
     })`,
   );
   return result;
@@ -112,10 +127,16 @@ export function resolveNatsAccount(
   // Resolution order (matches pi-headless + agents/pi):
   //   1. $NATS_CONTEXT       — env-var NATS CLI context file (highest)
   //   2. $NATS_URL           — raw URL
-  //   3. $NATS_CREDENTIALS   — overrides config creds field
+  //   3. $NATS_CREDENTIALS   — overrides config creds field ($NATS_CREDS is
+  //                            accepted as an alias when it is unset)
   //   4. config.context      — wizard-selected NATS CLI context file
   //   5. account config (`url`, `credentials`)
   //   6. built-in default    — `demo.nats.io` (set in connection.ts)
+  //
+  // Identity tokens (owner / agentName) follow the SYNADIA_* convention
+  // shared across agents/*: per-agent var (SYNADIA_OPENCLAW_*) > fleet-wide
+  // var (SYNADIA_*) > legacy alias (NATS_OWNER / NATS_ORG / NATS_AGENT_NAME)
+  // > account config. The legacy vars keep working indefinitely.
   const env = process.env;
 
   // ── Per-field env overrides (lower precedence than $NATS_CONTEXT) ──────
@@ -125,14 +146,19 @@ export function resolveNatsAccount(
   // `raw.credentials` would read `<unset>` even when the prior value was
   // sourced from a context file, which misleads debugging.
   applyEnvOverride(resolved, "url", resolved.url, env.NATS_URL, id, "NATS_URL");
-  applyEnvOverride(resolved, "agentName", raw.agentName, env.NATS_AGENT_NAME, id, "NATS_AGENT_NAME");
-  applyEnvOverride(resolved, "description", raw.description, env.NATS_DESCRIPTION, id, "NATS_DESCRIPTION");
-  if (env.NATS_OWNER !== undefined) {
-    applyEnvOverride(resolved, "owner", raw.owner ?? raw.org, env.NATS_OWNER, id, "NATS_OWNER");
-  } else if (env.NATS_ORG !== undefined) {
-    applyEnvOverride(resolved, "owner", raw.owner ?? raw.org, env.NATS_ORG, id, "NATS_ORG");
+  const nameEnv = firstDefinedEnv("SYNADIA_OPENCLAW_NAME", "SYNADIA_NAME", "NATS_AGENT_NAME");
+  if (nameEnv) {
+    applyEnvOverride(resolved, "agentName", raw.agentName, nameEnv.value, id, nameEnv.name);
   }
-  applyEnvOverride(resolved, "credentials", resolved.credentials, env.NATS_CREDENTIALS, id, "NATS_CREDENTIALS", true);
+  applyEnvOverride(resolved, "description", raw.description, env.NATS_DESCRIPTION, id, "NATS_DESCRIPTION");
+  const ownerEnv = firstDefinedEnv("SYNADIA_OPENCLAW_OWNER", "SYNADIA_OWNER", "NATS_OWNER", "NATS_ORG");
+  if (ownerEnv) {
+    applyEnvOverride(resolved, "owner", raw.owner ?? raw.org, ownerEnv.value, id, ownerEnv.name);
+  }
+  const credsEnv = firstDefinedEnv("NATS_CREDENTIALS", "NATS_CREDS");
+  if (credsEnv) {
+    applyEnvOverride(resolved, "credentials", resolved.credentials, credsEnv.value, id, credsEnv.name, true);
+  }
 
   // ── $NATS_CONTEXT (highest precedence) ───────────────────────────────
   // Applied LAST so it wins over $NATS_URL and $NATS_CREDENTIALS — a


### PR DESCRIPTION
Fourth PR in the identity env var series (#150 examples, #151 claude-code, #152 pi).

## What

openclaw's identity env overrides follow the `SYNADIA_*` convention:

```
owner:     SYNADIA_OPENCLAW_OWNER > SYNADIA_OWNER > NATS_OWNER (legacy) > NATS_ORG (legacy) > account config
agentName: SYNADIA_OPENCLAW_NAME  > SYNADIA_NAME  > NATS_AGENT_NAME (legacy) > account config
```

**Purely additive — zero behavior change for existing setups.** The legacy vars keep identical semantics; the new vars only sit above them. Also: `NATS_CREDS` is now accepted as a credentials alias (used only when `NATS_CREDENTIALS` is unset — the incumbent wins when both are set), matching flue and opencode.

## Changes

- `src/accounts.ts`: new `firstDefinedEnv` helper returns the winning var's *name* alongside the value, so the existing env-override log line attributes the value to the var that actually supplied it. The `listAccountIds` debug line now reports the resolved name var instead of hardcoding `NATS_AGENT_NAME`.
- `src/accounts.test.ts`: new "identity env overrides" suite (6 tests covering both chains, both legacy owner aliases, and both creds-alias directions), plus hermetic snapshot/restore of identity env vars for the existing suites — a leaked `SYNADIA_OWNER` or `NATS_CREDS` in the invoking shell can no longer skew expectations.
- `README.md`: env table documents the new vars, the convention, and the alias semantics.
- `CHANGELOG.md`: new file (Keep a Changelog format).

## Verification

Full vitest suite: **33/33 pass, zero skipped** — with the `openclaw` peer dep made resolvable (scratch-dir install + symlink; note `npm i --no-save openclaw` is a silent no-op against the empty-string optional peer range). `tsc --noEmit` error count unchanged vs main (11 lines, all pre-existing SDK-type drift in `channel.ts`/`gateway.ts` plus vitest types; none in `accounts.ts`).

## Observability gap (for a follow-up, not this PR)

The accounts suite **auto-skips when the peer dep is absent**, and no CI workflow covers `agents/openclaw` (or any `agents/*`) — the same gap that let the pi smoke drift. A follow-up `agents/*` CI PR is planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)