### PR TITLE
feat(open-agent): adopt SYNADIA_* identity env vars; honor NATS_CONTEXT

### DIFF
--- a/agents/open-agent/CHANGELOG.md
+++ b/agents/open-agent/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to `@synadia-ai/open-agent` will be documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Identity env vars adopt the `SYNADIA_*` convention** shared across
+  `agents/*`. Owner: `--owner` > `SYNADIA_OPEN_AGENT_OWNER` >
+  `SYNADIA_OWNER` > `OPEN_AGENT_OWNER` (legacy) > `$USER` > `anon`.
+  Session: `--session` > `SYNADIA_OPEN_AGENT_NAME` > `SYNADIA_NAME` >
+  `OPEN_AGENT_SESSION` (legacy) > `default`. Hyphens in the agent name
+  map to underscores in the env prefix. Legacy vars keep working.
+- `$NATS_CONTEXT` env var is honored (previously context selection was
+  CLI-only via `--nats-context`).
+
+### Changed
+
+- **Connection precedence: a selected NATS context now wins over
+  `$NATS_URL`** (`--nats-context` flag > `$NATS_CONTEXT` > `$NATS_URL`
+  > localhost), matching every other agent plugin. Previously
+  `$NATS_URL` silently overrode `--nats-context`. Only setups passing
+  `--nats-context` *while also* exporting `NATS_URL` are affected.
+
+## [0.0.1] and earlier
+
+Changelog started 2026-06-12 (at package version 0.0.1); see the git
+history of `agents/open-agent/` for earlier changes.

--- a/agents/open-agent/README.md
+++ b/agents/open-agent/README.md
@@ -115,21 +115,26 @@ Programmatic users can pass any `(modelId: string) => LanguageModel` to
 
 ## CLI flags / env
 
+Identity vars follow the `SYNADIA_*` convention shared across the agent
+plugins: CLI flag > per-agent var (`SYNADIA_OPEN_AGENT_*` — hyphens in the
+agent name become underscores) > fleet-wide var (`SYNADIA_*`) > legacy alias
+(`OPEN_AGENT_*`) > derived fallback. Legacy vars keep working.
+
 | Flag | Env | Default |
 | --- | --- | --- |
-| `--owner` | `OPEN_AGENT_OWNER` | `$USER` |
-| `--session` | `OPEN_AGENT_SESSION` | `default` |
+| `--owner` | `SYNADIA_OPEN_AGENT_OWNER`, `SYNADIA_OWNER`, `OPEN_AGENT_OWNER` (legacy) | `$USER` |
+| `--session` | `SYNADIA_OPEN_AGENT_NAME`, `SYNADIA_NAME`, `OPEN_AGENT_SESSION` (legacy) | `default` |
 | `--workdir` | `OPEN_AGENT_WORKDIR` | `${TMPDIR}/open-agent/<session>/` |
-| `--nats-context` | — | (unset) |
+| `--nats-context` | `NATS_CONTEXT` | (unset) |
 | `--provider` | `OPEN_AGENT_PROVIDER` | `gateway` (or `openrouter` if only `OPENROUTER_API_KEY` is set) |
 | — | `NATS_URL` | `nats://127.0.0.1:4222` |
 | — | `OPEN_AGENT_MODEL` | `anthropic/claude-opus-4.6` on Gateway; **required** on OpenRouter |
 | — | `AI_GATEWAY_API_KEY` | required when provider=gateway |
 | — | `OPENROUTER_API_KEY` | required when provider=openrouter |
 
-`--nats-context <name>` resolves a saved `nats` CLI context via
-`@synadia-ai/agents`'s `loadContextOptions`. `NATS_URL` overrides the
-context.
+`--nats-context <name>` (or `$NATS_CONTEXT`) resolves a saved `nats` CLI
+context via `@synadia-ai/agents`'s `loadContextOptions`. A selected context
+wins over `NATS_URL` — same precedence as the other agent plugins.
 
 ## Wire format for tool calls
 

--- a/agents/open-agent/src/cli.ts
+++ b/agents/open-agent/src/cli.ts
@@ -63,15 +63,33 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
     }
   }
 
+  // Identity tokens follow the SYNADIA_* convention shared across agents/*:
+  // CLI flag > per-agent env var (SYNADIA_OPEN_AGENT_*; hyphens in the agent
+  // name become underscores) > fleet-wide env var (SYNADIA_*) > legacy alias
+  // (OPEN_AGENT_*) > derived fallback. Legacy vars keep working indefinitely.
   const owner =
-    out["owner"] ?? process.env["OPEN_AGENT_OWNER"] ?? process.env["USER"] ?? "anon";
-  const session = out["session"] ?? process.env["OPEN_AGENT_SESSION"] ?? "default";
+    out["owner"] ??
+    process.env["SYNADIA_OPEN_AGENT_OWNER"] ??
+    process.env["SYNADIA_OWNER"] ??
+    process.env["OPEN_AGENT_OWNER"] ??
+    process.env["USER"] ??
+    "anon";
+  const session =
+    out["session"] ??
+    process.env["SYNADIA_OPEN_AGENT_NAME"] ??
+    process.env["SYNADIA_NAME"] ??
+    process.env["OPEN_AGENT_SESSION"] ??
+    "default";
   const workdir =
     out["workdir"] ??
     process.env["OPEN_AGENT_WORKDIR"] ??
     join(tmpdir(), "open-agent", session);
-  const natsContext = out["nats-context"];
-  const natsUrl = process.env["NATS_URL"];
+  // Connection precedence: --nats-context flag > $NATS_CONTEXT > $NATS_URL >
+  // localhost default. Context-over-URL matches the rest of agents/*;
+  // resolveConnectionOptions itself prefers natsUrl, so only forward the
+  // URL when no context is selected anywhere.
+  const natsContext = out["nats-context"] ?? process.env["NATS_CONTEXT"];
+  const natsUrl = natsContext === undefined ? process.env["NATS_URL"] : undefined;
 
   const providerEnv = (out["provider"] ?? process.env["OPEN_AGENT_PROVIDER"])?.toLowerCase();
   const provider: ProviderName =

--- a/agents/open-agent/src/nats-context.ts
+++ b/agents/open-agent/src/nats-context.ts
@@ -9,7 +9,11 @@ import type { NatsConnection } from "@nats-io/nats-core";
 export interface ResolveNatsOptions {
   /** Saved `nats` CLI context name; `"current"` resolves the selected one. */
   readonly natsContext?: string;
-  /** Direct URL — overrides the context if set. */
+  /**
+   * Direct URL. Within this resolver it wins over `natsContext`, but the
+   * CLI forwards it only when no context is selected — so user-facing
+   * precedence is context over URL (matching the other agent plugins).
+   */
   readonly natsUrl?: string;
 }
 


### PR DESCRIPTION
Fifth PR in the identity env var series (#150 examples, #151 claude-code, #152 pi, #153 openclaw).

## What

Identity tokens follow the `SYNADIA_*` convention (CLI flag stays highest):

```
owner:   --owner   > SYNADIA_OPEN_AGENT_OWNER > SYNADIA_OWNER > OPEN_AGENT_OWNER (legacy) > $USER > "anon"
session: --session > SYNADIA_OPEN_AGENT_NAME  > SYNADIA_NAME  > OPEN_AGENT_SESSION (legacy) > "default"
```

Hyphens in the agent name map to underscores in the env prefix (`open-agent` → `SYNADIA_OPEN_AGENT_*`) — settling the hyphenated-name convention question raised in the #150 review.

## Also: two connection fixes from the env var analysis

1. **`$NATS_CONTEXT` env var is honored** — previously context selection was CLI-only (`--nats-context`), the exact CLI-flags-only pattern this series removes.
2. **A selected context now wins over `$NATS_URL`**, matching every other agent plugin (pi, claude-code, openclaw, flue, opencode all treat the context as the single source of truth). Previously `NATS_URL` silently overrode `--nats-context`. Implemented in the CLI plumbing so the exported `resolveConnectionOptions` API is untouched. Behavior change only for setups passing `--nats-context` *while also* exporting `NATS_URL` — called out in the new `CHANGELOG.md`.

## Verification

- `tsc --noEmit` clean; `bun test test/` **71/71**.
- Live smoke against an isolated nats-server with a presence-only fake gateway key: `SYNADIA_OPEN_AGENT_OWNER=peragent SYNADIA_OWNER=fleet OPEN_AGENT_OWNER=legacy SYNADIA_NAME=t9 OPEN_AGENT_SESSION=legacy-sess` registers **`agents.prompt.open-agent.peragent.t9`** — per-agent owner beats fleet and legacy; `SYNADIA_NAME` beats the legacy session var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)