### PR TITLE
feat(headless-examples): adopt SYNADIA_* identity env vars

### DIFF
--- a/examples/claude-code-headless/CHANGELOG.md
+++ b/examples/claude-code-headless/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Identity env vars adopt the `SYNADIA_*` convention** shared with
+  `agents/*`: `CLAUDE_CODE_HEADLESS_OWNER|NAME` resolve as CLI flag >
+  `SYNADIA_CLAUDE_CODE_HEADLESS_OWNER|NAME` (per-agent) > `SYNADIA_OWNER|NAME`
+  (fleet-wide) > `CLAUDE_CODE_HEADLESS_OWNER|NAME` (legacy, keeps working) > config /
+  derived fallback.
+
 ## [0.5.4] - 2026-05-11
 
 ### Changed

--- a/examples/claude-code-headless/README.md
+++ b/examples/claude-code-headless/README.md
@@ -102,8 +102,8 @@ Env overrides:
 
 | Variable | Overrides | Default |
 | --- | --- | --- |
-| `CLAUDE_CODE_HEADLESS_OWNER` | Owner subject token (3rd segment) | `$USER` |
-| `CLAUDE_CODE_HEADLESS_NAME` | Controller instance name (4th token) | `control` |
+| `SYNADIA_CLAUDE_CODE_HEADLESS_OWNER`, `SYNADIA_OWNER` | Owner subject token; per-agent var wins, then fleet-wide, then the legacy `CLAUDE_CODE_HEADLESS_OWNER` | `$USER` |
+| `SYNADIA_CLAUDE_CODE_HEADLESS_NAME`, `SYNADIA_NAME` | Controller instance name; same chain (legacy: `CLAUDE_CODE_HEADLESS_NAME`) | `control` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_MODEL` | Default Claude model id for spawns | `claude-sonnet-4-6` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_PERMISSION_MODE` | Default permission mode for spawns | `dontAsk` |
 | `CLAUDE_CODE_HEADLESS_DEFAULT_ALLOWED_TOOLS` | Default tool allowlist (comma-separated) | `Read,Glob,Grep` |

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -209,7 +209,7 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
   }
   if (name.length === 0 || sanitizeToken(name) !== name) {
     throw new Error(
-      `claude-code-headless: invalid name "${name}" — must match [a-z0-9_-]{1,63}. Override with --name or CLAUDE_CODE_HEADLESS_NAME.`,
+      `claude-code-headless: invalid name "${name}" — must match [a-z0-9_-]{1,63}. Override with --name, SYNADIA_CLAUDE_CODE_HEADLESS_NAME, or SYNADIA_NAME.`,
     );
   }
 

--- a/examples/claude-code-headless/src/config.ts
+++ b/examples/claude-code-headless/src/config.ts
@@ -148,14 +148,24 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
   const file = readConfigFile();
   const env = process.env;
 
+  // Identity chain per the SYNADIA_* convention shared across agents/*:
+  // CLI flag > per-agent var (hyphens → underscores) > fleet-wide var >
+  // legacy alias > config file > derived fallback.
   const owner =
     cli.owner ??
+    env["SYNADIA_CLAUDE_CODE_HEADLESS_OWNER"] ??
+    env["SYNADIA_OWNER"] ??
     env["CLAUDE_CODE_HEADLESS_OWNER"] ??
     env["USER"] ??
     userInfo().username ??
     "anon";
   const name =
-    cli.name ?? env["CLAUDE_CODE_HEADLESS_NAME"] ?? file.name ?? BUILT_IN_DEFAULTS.name;
+    cli.name ??
+    env["SYNADIA_CLAUDE_CODE_HEADLESS_NAME"] ??
+    env["SYNADIA_NAME"] ??
+    env["CLAUDE_CODE_HEADLESS_NAME"] ??
+    file.name ??
+    BUILT_IN_DEFAULTS.name;
   const context = cli.context ?? env["NATS_CONTEXT"] ?? file.context;
   const natsUrl = cli.natsUrl ?? env["NATS_URL"];
   const defaultModel =
@@ -194,7 +204,7 @@ export function loadConfig(cli: CliOverrides = {}): ClaudeCodeHeadlessConfig {
   // returns "" so the equality check alone wouldn't trip on it.
   if (owner.length === 0 || sanitizeToken(owner) !== owner) {
     throw new Error(
-      `claude-code-headless: invalid owner "${owner}" — must match [a-z0-9_-]{1,63}. Override with --owner or CLAUDE_CODE_HEADLESS_OWNER.`,
+      `claude-code-headless: invalid owner "${owner}" — must match [a-z0-9_-]{1,63}. Override with --owner, SYNADIA_CLAUDE_CODE_HEADLESS_OWNER, or SYNADIA_OWNER.`,
     );
   }
   if (name.length === 0 || sanitizeToken(name) !== name) {

--- a/examples/pi-headless/CHANGELOG.md
+++ b/examples/pi-headless/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Identity env vars adopt the `SYNADIA_*` convention** shared with
+  `agents/*`: `PI_HEADLESS_OWNER|NAME` resolve as CLI flag >
+  `SYNADIA_PI_HEADLESS_OWNER|NAME` (per-agent) > `SYNADIA_OWNER|NAME`
+  (fleet-wide) > `PI_HEADLESS_OWNER|NAME` (legacy, keeps working) > config /
+  derived fallback.
+
 ## [0.5.5] - 2026-05-12
 
 ### Changed

--- a/examples/pi-headless/README.md
+++ b/examples/pi-headless/README.md
@@ -93,8 +93,8 @@ Env overrides:
 
 | Variable | Overrides | Default |
 | --- | --- | --- |
-| `PI_HEADLESS_OWNER` | Owner subject token (3rd segment) | `$USER` |
-| `PI_HEADLESS_NAME` | Controller instance name (4th token) | `control` |
+| `SYNADIA_PI_HEADLESS_OWNER`, `SYNADIA_OWNER` | Owner subject token; per-agent var wins, then fleet-wide, then the legacy `PI_HEADLESS_OWNER` | `$USER` |
+| `SYNADIA_PI_HEADLESS_NAME`, `SYNADIA_NAME` | Controller instance name; same chain (legacy: `PI_HEADLESS_NAME`) | `control` |
 | `PI_HEADLESS_DEFAULT_MODEL` | Default model spec for spawns | (none — caller must set, or PI picks) |
 | `PI_HEADLESS_DEFAULT_THINKING_LEVEL` | Default thinking level for spawns | (none) |
 | `PI_HEADLESS_DEFAULT_MAX_LIFETIME` | Default session lifetime, in seconds | `1800` |

--- a/examples/pi-headless/src/config.ts
+++ b/examples/pi-headless/src/config.ts
@@ -107,9 +107,24 @@ export function loadConfig(cli: CliOverrides = {}): PiHeadlessConfig {
   const file = readConfigFile();
   const env = process.env;
 
+  // Identity chain per the SYNADIA_* convention shared across agents/*:
+  // CLI flag > per-agent var (hyphens → underscores) > fleet-wide var >
+  // legacy alias > config file > derived fallback.
   const owner =
-    cli.owner ?? env["PI_HEADLESS_OWNER"] ?? env["USER"] ?? userInfo().username ?? "anon";
-  const name = cli.name ?? env["PI_HEADLESS_NAME"] ?? file.name ?? BUILT_IN_DEFAULTS.name;
+    cli.owner ??
+    env["SYNADIA_PI_HEADLESS_OWNER"] ??
+    env["SYNADIA_OWNER"] ??
+    env["PI_HEADLESS_OWNER"] ??
+    env["USER"] ??
+    userInfo().username ??
+    "anon";
+  const name =
+    cli.name ??
+    env["SYNADIA_PI_HEADLESS_NAME"] ??
+    env["SYNADIA_NAME"] ??
+    env["PI_HEADLESS_NAME"] ??
+    file.name ??
+    BUILT_IN_DEFAULTS.name;
   const context = cli.context ?? env["NATS_CONTEXT"] ?? file.context;
   const natsUrl = cli.natsUrl ?? env["NATS_URL"];
   const defaultModel = env["PI_HEADLESS_DEFAULT_MODEL"] ?? file.defaultModel;


### PR DESCRIPTION
Seventh PR in the identity env var series — covers the two published headless controller examples, which register full 5-token identities (`agents.*.pi-headless/cc-headless.<owner>.<name>`) but used a bare per-example env prefix (a fifth naming family).

## What

```
owner: --owner > SYNADIA_PI_HEADLESS_OWNER > SYNADIA_OWNER > PI_HEADLESS_OWNER (legacy) > $USER > "anon"
name:  --name  > SYNADIA_PI_HEADLESS_NAME  > SYNADIA_NAME  > PI_HEADLESS_NAME  (legacy) > config "name" > "control"
```

claude-code-headless mirrors with `SYNADIA_CLAUDE_CODE_HEADLESS_*` / legacy `CLAUDE_CODE_HEADLESS_*` (hyphens → underscores per the convention settled in #154). **Purely additive** — legacy vars keep working. cc-headless's fail-fast invalid-owner error message now names the `SYNADIA_*` overrides. READMEs + CHANGELOGs updated.

Note: env plumbing only — no SDK surface involved, so per the release ladder this does not depend on any npm publish.

## Verification

- cc-headless `tsc --noEmit` clean; pi-headless shows the **same single pre-existing error** as unmodified main (type-only `@earendil-works/pi-ai` import in `pi-session-manager.ts`, module absent from the transitive install — untouched by this PR, worth its own look).
- Live smoke against an isolated nats-server: controllers register `agents.prompt.pi-headless.peragent.ctl1` and `agents.prompt.cc-headless.peragent.ctl2` — per-agent vars beating fleet-wide (`SYNADIA_OWNER=fleet`) and legacy (`PI_HEADLESS_OWNER=legacy`, `PI_HEADLESS_NAME=old`) exactly per the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)