### PR TITLE
fix(client-sdk): decodeEnvelope follows §5.3 discrimination exactly

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`decodeEnvelope` now follows the §5.3 discrimination algorithm
+  exactly**, closing two wire-compatibility gaps with the spec and the
+  Python SDK:
+  - A **zero-byte request payload** is now rejected with a
+    `ProtocolError` (→ agent `400`). Previously it was silently accepted
+    as `{ prompt: "" }`. Spec §5.3: "A zero-byte request payload is
+    invalid and MUST be rejected with status `400`."
+  - A payload whose **first non-whitespace byte is `{` but which is not
+    well-formed JSON** (e.g. `{not json`) is now rejected as a malformed
+    envelope, instead of being mis-classified as a plain-text prompt
+    literally equal to the broken JSON. Discrimination now keys off the
+    leading `{` (matching the Python SDK's `looks_like_json`) rather than
+    "try `JSON.parse`, fall back to plain text on any failure".
+
+  Plain-text shorthand for payloads that don't lead with `{` (including
+  bare numbers, `[`, or quotes) is unchanged, as is rejection of
+  missing / non-string / empty `prompt` and invalid attachments. The pi
+  spec-compliance smoke (`agents/pi/test/smoke.mjs`) caught both gaps.
+
 ## [0.5.2] - 2026-05-26
 
 ### Added

--- a/client-sdk/typescript/src/prompt/envelope.ts
+++ b/client-sdk/typescript/src/prompt/envelope.ts
@@ -86,33 +86,53 @@ export function encodeBase64(bytes: Uint8Array): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Decode an inbound prompt envelope from raw NATS message bytes.
+ * Decode an inbound prompt envelope from raw NATS message bytes, following
+ * the §5.3 discrimination algorithm exactly:
  *
- * Tries JSON first; an envelope-shaped object (`{prompt: string, ...}`)
- * is decoded with §5.2 base64 + filename validation on attachments. A
- * non-object JSON value or a JSON parse failure falls back to the §5.3
- * plain-text shorthand: bytes are treated as the raw `prompt` text.
+ *  1. A zero-byte payload is invalid.
+ *  2. If the first non-whitespace byte is `{`, the payload is a JSON envelope
+ *     and MUST parse as one — a parse failure (or a missing `prompt` string
+ *     field) is a hard error, NOT a fall-through to plain text.
+ *  3. Otherwise it is the plain-text shorthand: the whole payload is the
+ *     `prompt`.
  *
- * Throws {@link ProtocolError} for: missing/non-string `prompt`, invalid
+ * An envelope-shaped object is decoded with §5.2 base64 + filename validation
+ * on attachments. This mirrors the Python SDK's `looks_like_json`
+ * discrimination so the two decoders agree on the wire (interop).
+ *
+ * Throws {@link ProtocolError} for: a zero-byte payload, a `{`-led payload
+ * that is not well-formed JSON, missing/non-string/empty `prompt`, invalid
  * `attachments` shape, non-strict base64 (URL-safe, unpadded, whitespace),
  * or unsafe filenames (path separators, `..`, NUL, absolute paths). Agent
  * services translate this into a `Nats-Service-Error-Code: 400` response.
  */
 export function decodeEnvelope(data: Uint8Array): RequestEnvelope {
+  // §5.3: a zero-byte request payload is invalid.
+  if (data.length === 0) {
+    throw new ProtocolError("zero-byte request payload (§5.3)");
+  }
+
   const text = new TextDecoder().decode(data);
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    // §5.3 plain-text shorthand: raw bytes are the prompt text.
+  // §5.3 discrimination: only a `{`-led payload is a JSON envelope. Anything
+  // else — including a leading digit, `[`, or quote — is the plain-text
+  // shorthand and the whole payload becomes the prompt verbatim.
+  if (!startsWithJsonObject(text)) {
     return { prompt: text };
   }
 
-  // A JSON value that isn't an envelope object falls back to plain text too,
-  // matching pi's prior behaviour and avoiding gotchas with quoted strings.
+  // §5.3 step 2: the payload committed to JSON by its leading `{`, so a parse
+  // failure is a malformed envelope (400), not plain text.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new ProtocolError(`malformed JSON envelope: ${(err as Error).message}`);
+  }
+
+  // A leading `{` can only parse to an object; this guard is defensive.
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return { prompt: text };
+    throw new ProtocolError("envelope must be a JSON object");
   }
 
   const obj = parsed as Record<string, unknown>;
@@ -139,6 +159,25 @@ export function decodeEnvelope(data: Uint8Array): RequestEnvelope {
     decodeAttachment(item, idx),
   );
   return attachments.length > 0 ? { prompt, attachments } : { prompt };
+}
+
+/**
+ * §5.3 discrimination predicate: `true` iff the first non-whitespace byte is
+ * `{`, marking the payload as a JSON envelope rather than the plain-text
+ * shorthand. Only ASCII whitespace (`0x09`, `0x0A`, `0x0D`, `0x20`) is
+ * skipped, per the spec. An empty or all-whitespace payload is not JSON
+ * (zero-byte is rejected separately by the caller).
+ *
+ * Mirrors the Python SDK's `looks_like_json` (`agents/envelope.py`) so both
+ * decoders classify the same bytes the same way.
+ */
+function startsWithJsonObject(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (c === 0x09 || c === 0x0a || c === 0x0d || c === 0x20) continue;
+    return c === 0x7b; // '{'
+  }
+  return false;
 }
 
 function decodeAttachment(item: unknown, idx: number): RequestAttachment {

--- a/client-sdk/typescript/test/unit/decode-envelope.test.ts
+++ b/client-sdk/typescript/test/unit/decode-envelope.test.ts
@@ -25,9 +25,30 @@ describe("decodeEnvelope", () => {
 
   it("treats a JSON value that isn't an envelope object as plain text", () => {
     // A bare string, number, or array on the wire is not an envelope per §5.1.
+    // None lead with `{`, so §5.3 classifies them as the plain-text shorthand.
     expect(decodeEnvelope(utf8('"just a string"')).prompt).toBe('"just a string"');
     expect(decodeEnvelope(utf8("[1, 2]")).prompt).toBe("[1, 2]");
     expect(decodeEnvelope(utf8("42")).prompt).toBe("42");
+  });
+
+  it("rejects a zero-byte payload (§5.3 — must be 400, not an empty prompt)", () => {
+    expect(() => decodeEnvelope(new Uint8Array(0))).toThrow(ProtocolError);
+    expect(() => decodeEnvelope(utf8(""))).toThrow(ProtocolError);
+  });
+
+  it("rejects a `{`-led payload that is not well-formed JSON (§5.3 step 2)", () => {
+    // Once the leading non-whitespace byte is `{`, the payload has committed to
+    // being a JSON envelope: a parse failure is a 400, NOT a plain-text prompt
+    // literally equal to "{not json". Matches the Python SDK's looks_like_json.
+    expect(() => decodeEnvelope(utf8("{not json"))).toThrow(ProtocolError);
+    expect(() => decodeEnvelope(utf8('{"prompt": "x"'))).toThrow(ProtocolError);
+  });
+
+  it("classifies a payload by its first non-whitespace byte (§5.3 step 1)", () => {
+    // Leading ASCII whitespace before `{` still parses as a JSON envelope.
+    expect(decodeEnvelope(utf8('  \n\t {"prompt":"hi"}')).prompt).toBe("hi");
+    // Leading whitespace before non-`{` content stays plain text (verbatim).
+    expect(decodeEnvelope(utf8("  hello")).prompt).toBe("  hello");
   });
 
   it("decodes a JSON envelope with valid attachments", () => {


### PR DESCRIPTION
While diagnosing the pi smoke failures (for the upcoming agents/* CI PR), the smoke turned out to be catching a **real spec-compliance bug** in the TS SDK decoder — not stale assertions. This PR fixes the bug; a follow-up PR handles the genuinely-stale heartbeat assertion + CI.

## The bug

`decodeEnvelope` discriminated JSON-vs-plain-text by "try `JSON.parse` the whole payload; on **any** failure, treat it as plain text." That violates spec **§5.3** in two ways:

| Input | Spec §5.3 | Old TS | Python SDK | New TS |
| --- | --- | --- | --- | --- |
| `""` (zero-byte) | **400** ("MUST be rejected") | accepted as `{prompt:""}` | 400 | **400** ✓ |
| `{not json` (leading `{`, bad JSON) | **400** (committed to JSON) | accepted as `{prompt:"{not json"}` | 400 | **400** ✓ |
| `Hello` / `5` / `[1,2]` / `"x"` | plain text | plain text | plain text | plain text ✓ |
| `{"prompt":"hi"}` | envelope | envelope | envelope | envelope ✓ |

Both gaps were also live **TS↔Python wire divergences** — the Python SDK already implements §5.3 correctly (`looks_like_json`), so this aligns TS *to* Python rather than the reverse. No Python change required.

## The fix

Discrimination now keys off the **first non-whitespace byte being `{`** (new `startsWithJsonObject` helper, mirroring Python's `looks_like_json`):
- first non-ws byte `{` → MUST parse as JSON; parse failure → `ProtocolError` (400).
- anything else → plain-text shorthand (whole payload is the prompt).
- zero-byte → rejected up front.

The decode **signature is unchanged**, so pi and claude-code (which route envelope decode through this SDK) inherit the fix with no edit. Everything else is unchanged: plain-text shorthand for non-`{` payloads, leading-whitespace tolerance, and rejection of missing/non-string/empty `prompt` + invalid attachments.

## Scope note (`{"prompt":""}`)

There is a third, **softer** TS↔Python divergence: a JSON envelope with an empty-string prompt. TS rejects it at decode; Python allows it and defers to §5.4/server. This PR **does not touch** that behavior (TS keeps rejecting). Reconciling it toward Python's "allow at decode" would require adding empty-prompt 400 checks in 4 host paths (`AgentService` + pi + claude-code + openclaw) to avoid silently regressing the 400 those agents return today — a distinct, broader change worth its own PR. Flagged for follow-up.

## Verification

- `client-sdk`: **294 pass / 2 skip**, typecheck + lint clean. New unit cases: zero-byte → throw, `{`-led-malformed → throw, leading-whitespace discrimination.
- `agent-sdk` (consumes `decodeEnvelope`): **40 pass** — the §5.3 plain-text routing test still passes.
- Against the rebuilt SDK, the pi smoke's 5 cascade failures clear (11/13; the 2 remaining are the stale `interval_s` 5-vs-30 assertion, fixed in the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)