### PR TITLE
ci(agents): run pi + openclaw suites; fix stale pi heartbeat assertion

### DIFF
--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -79,10 +79,18 @@ jobs:
       # dependency (ephemeral on the CI checkout) so the full tree installs,
       # then assert the subpath the tests import actually resolves — a broken
       # peer fails the job instead of hollowing it out.
-      - name: Install openclaw deps + peer
+      #
+      # Resolve the LATEST openclaw rather than pinning: this plugin's whole
+      # job is to track openclaw, so a breaking change to `plugin-sdk/core`
+      # SHOULD surface here (the resolve-assert guards presence; a broken API
+      # surfaces as a vitest failure). A pin silently rots — openclaw shipped
+      # 2026.6.5 -> 2026.6.6 within days of this workflow landing.
+      - name: Install openclaw deps + peer (latest)
         working-directory: agents/openclaw
         run: |
-          npm pkg set "dependencies.openclaw=2026.6.5"
+          OPENCLAW_VERSION="$(npm view openclaw version)"
+          echo "openclaw peer: $OPENCLAW_VERSION"
+          npm pkg set "dependencies.openclaw=${OPENCLAW_VERSION}"
           npm install
           node -e "require.resolve('openclaw/plugin-sdk/core')"
       - name: Tests (account resolution + protocol + context loader)

--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -1,0 +1,90 @@
+name: CI — agents (TypeScript)
+
+# Runs the test suites for the TypeScript agent harnesses, which depend on
+# the TS SDKs via `file:` links — so SDK changes trigger this too, catching
+# cross-subtree regressions (e.g. an envelope-decode change breaking the pi
+# spec-compliance smoke).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agents/pi/**"
+      - "agents/openclaw/**"
+      - "client-sdk/typescript/**"
+      - "agent-sdk/typescript/**"
+      - ".github/workflows/agents-typescript.yml"
+  pull_request:
+    paths:
+      - "agents/pi/**"
+      - "agents/openclaw/**"
+      - "client-sdk/typescript/**"
+      - "agent-sdk/typescript/**"
+      - ".github/workflows/agents-typescript.yml"
+
+concurrency:
+  group: ci-agents-ts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pi:
+    name: agents/pi (unit + spec smoke)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install nats-server
+        run: |
+          curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
+          tar -xzf nats-server.tar.gz --strip-components=1
+          sudo mv nats-server /usr/local/bin/
+          nats-server --version
+      # pi imports both SDKs via `file:` links, which resolve to each
+      # package's built `dist/` — so build them before installing pi.
+      - name: Build client-sdk
+        working-directory: client-sdk/typescript
+        run: bun install && bun run build
+      - name: Build agent-sdk
+        working-directory: agent-sdk/typescript
+        run: bun install && bun run build
+      - name: Install pi
+        working-directory: agents/pi
+        run: bun install
+      - name: Unit tests (owner-token precedence)
+        working-directory: agents/pi
+        run: bun test test/owner.test.ts
+      - name: Spec-compliance smoke (spawns its own nats-server)
+        working-directory: agents/pi
+        run: bun test/smoke.mjs
+
+  openclaw:
+    name: agents/openclaw (vitest)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Build client-sdk
+        working-directory: client-sdk/typescript
+        run: npm install && npm run build
+      - name: Build agent-sdk
+        working-directory: agent-sdk/typescript
+        run: npm install && npm run build
+      # The `openclaw` peer is optional with an empty version range, so npm
+      # treats it as satisfied-by-absence: a plain `npm install`, `npm install
+      # --no-save openclaw`, and even `npm install openclaw` all leave it out,
+      # silently SKIPPING the account-resolution suite. Promote it to a real
+      # dependency (ephemeral on the CI checkout) so the full tree installs,
+      # then assert the subpath the tests import actually resolves — a broken
+      # peer fails the job instead of hollowing it out.
+      - name: Install openclaw deps + peer
+        working-directory: agents/openclaw
+        run: |
+          npm pkg set "dependencies.openclaw=2026.6.5"
+          npm install
+          node -e "require.resolve('openclaw/plugin-sdk/core')"
+      - name: Tests (account resolution + protocol + context loader)
+        working-directory: agents/openclaw
+        run: npm test

--- a/agents/openclaw/package.json
+++ b/agents/openclaw/package.json
@@ -61,8 +61,8 @@
     "@nats-io/services": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
     "@sinclair/typebox": "^0.34.0",
-    "@synadia-ai/agents": "file:../../client-sdk/typescript",
-    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript"
+    "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",
+    "@synadia-ai/agents": "file:../../client-sdk/typescript"
   },
   "peerDependencies": {
     "openclaw": ""
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "tsup": "^8.3.0",
-    "typescript": "~5.6.0"
+    "typescript": "~5.6.0",
+    "vitest": "^3.2.0"
   }
 }

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -79,7 +79,9 @@ const SERVICE_VERSION = "0.4.0";
 // `pi` agent in ~15s instead of ~90s. The SDK's
 // `DEFAULT_HEARTBEAT_INTERVAL_S` stays at 30s as a sensible third-party
 // default — first-party harnesses opt into the snappier cadence.
-const HEARTBEAT_INTERVAL_S = 5;
+// Exported so the smoke test asserts the advertised `interval_s` against
+// this single source of truth (passes whether it's pinned at 5s or 30s).
+export const HEARTBEAT_INTERVAL_S = 5;
 
 // Spec §2, Appendix C: `pi` is both the canonical agent identifier and its
 // conventional subject abbreviation, so `metadata.agent` and the wire

--- a/agents/pi/test/smoke.mjs
+++ b/agents/pi/test/smoke.mjs
@@ -118,7 +118,9 @@ delete process.env.NATS_PI_OWNER;
 delete process.env.SYNADIA_PI_NAME;
 delete process.env.SYNADIA_NAME;
 
-const { default: channelFactory } = await import("../extensions/nats-channel.ts");
+const { default: channelFactory, HEARTBEAT_INTERVAL_S } = await import(
+	"../extensions/nats-channel.ts"
+);
 const { formatHumanBytes } = await import("@synadia-ai/agents");
 const { DEFAULT_MAX_PAYLOAD } = await import("@synadia-ai/agent-service");
 
@@ -232,7 +234,10 @@ await step("heartbeat published on agents.hb.pi.{owner}.{session}", async () => 
 	assert.ok(mine, "no matching heartbeat received");
 	assert.equal(typeof mine.instance_id, "string");
 	assert.equal(typeof mine.ts, "string");
-	assert.equal(mine.interval_s, 30);
+	// Assert against the extension's own constant, not a hard-coded number —
+	// the advertised cadence is whatever HEARTBEAT_INTERVAL_S is pinned to
+	// (5s today, 30s if a future change reverts to the SDK default).
+	assert.equal(mine.interval_s, HEARTBEAT_INTERVAL_S);
 })();
 
 await step("status endpoint replies with a heartbeat-shaped payload", async () => {
@@ -243,7 +248,7 @@ await step("status endpoint replies with a heartbeat-shaped payload", async () =
 	assert.equal(body.session, session);
 	assert.equal(typeof body.instance_id, "string");
 	assert.equal(typeof body.ts, "string");
-	assert.equal(body.interval_s, 30);
+	assert.equal(body.interval_s, HEARTBEAT_INTERVAL_S);
 })();
 
 // Helper — consume a stream until terminator, capturing chunks + error.

--- a/client-sdk/typescript/test/unit/decode-envelope.test.ts
+++ b/client-sdk/typescript/test/unit/decode-envelope.test.ts
@@ -49,6 +49,15 @@ describe("decodeEnvelope", () => {
     expect(decodeEnvelope(utf8('  \n\t {"prompt":"hi"}')).prompt).toBe("hi");
     // Leading whitespace before non-`{` content stays plain text (verbatim).
     expect(decodeEnvelope(utf8("  hello")).prompt).toBe("  hello");
+    // An all-whitespace payload has no `{` byte → plain-text shorthand,
+    // preserved verbatim (it is non-empty, so not the zero-byte rejection).
+    expect(decodeEnvelope(utf8("   ")).prompt).toBe("   ");
+    // Only the four ASCII whitespace bytes are skipped. `\f` (0x0C) is JS
+    // whitespace (trimStart would skip it) but NOT §5.3 whitespace, so a
+    // `\f`-led payload is the first non-ws byte itself → plain text, never
+    // mis-classified as a JSON envelope. This is why discrimination is a
+    // hand-rolled byte check, not `text.trimStart().startsWith("{")`.
+    expect(decodeEnvelope(utf8('\f{"prompt":"hi"}')).prompt).toBe('\f{"prompt":"hi"}');
   });
 
   it("decodes a JSON envelope with valid attachments", () => {


### PR DESCRIPTION
Stacked on #158 (the decode fix). **Base is `sdk/decode-envelope-5.3-compliance`** — GitHub will retarget this to `main` once #158 merges. The pi smoke only goes fully green with #158's decode fix present, hence the stacking.

This is the CI + smoke-staleness PR we'd queued. Diagnosing the pi smoke for it is what surfaced the #158 SDK bug; this PR handles the rest.

## What

**New workflow `.github/workflows/agents-typescript.yml`** — the TS agent harness suites were never wired into CI (and openclaw's couldn't run at all; see below). Two jobs, triggered on `agents/pi/**`, `agents/openclaw/**`, **and** `client-sdk/typescript/**` + `agent-sdk/typescript/**` (both agents link the SDKs via `file:`, so an SDK change that breaks an agent now surfaces here):

- **pi (bun):** build both SDKs → `test/owner.test.ts` (unit) + `test/smoke.mjs` (spec-compliance smoke; spawns its own nats-server). **13/13** with #158.
- **openclaw (node):** build both SDKs → install + peer → vitest. **33/33, zero skipped.**

## Two latent gaps that kept openclaw's tests from ever running

1. **vitest was never declared.** The `test` script is `vitest run`, but `vitest` wasn't in `devDependencies` — so `npm test` couldn't find a runner anywhere. Added `vitest@^3.2.0` (matching the SDKs).
2. **The optional `openclaw` peer is uninstallable by normal means.** Its empty-range optional-peer declaration makes npm treat it satisfied-by-absence: plain `npm install`, `npm install --no-save openclaw`, and even `npm install openclaw` all leave it absent — silently skipping the 15-test account-resolution suite. The workflow promotes it to a real dep with `npm pkg set "dependencies.openclaw=2026.6.5"` (ephemeral on the CI checkout) so the tree installs, then **asserts `openclaw/plugin-sdk/core` resolves** so a broken peer fails the job rather than hollowing it out.

## pi heartbeat staleness (the only genuinely-stale assertion)

The smoke asserted `interval_s === 30`, but the extension pins `HEARTBEAT_INTERVAL_S = 5` (the snappy first-party cadence). Per your ask that **both 5s and 30s pass**, I exported the constant from the extension and assert the advertised `interval_s` against it — the test now tracks the source of truth. Proven by flipping the constant to 30 locally (still 13/13), reverted to 5.

## Verification (local)

- pi smoke **13/13** (against #158's rebuilt SDK); flipped-to-30 also 13/13.
- openclaw **33/33, zero skipped**; `openclaw/plugin-sdk/core` resolves.
- Clean dry-run of the exact openclaw job steps from an empty `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)