### PR TITLE
Python: mirror the SYNADIA_* identity env-var convention

### DIFF
--- a/agent-sdk/python/CHANGELOG.md
+++ b/agent-sdk/python/CHANGELOG.md
@@ -15,11 +15,21 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
   `agent-sdk/typescript/examples/`: echo, Ollama, OpenRouter, a
   combined auto-selecting agent, and a tool-calling agent backed by a
   NATS microservice. Identity and heartbeat are flags that default to
-  the `NATS_AGENT_OWNER` / `NATS_AGENT_NAME` /
-  `NATS_AGENT_HEARTBEAT_INTERVAL` env vars (env-first, flag-overridable);
-  connection uses the shared `_connect_cli.py` resolver. The
-  `_reference_agent.py` flags now likewise default to those env vars
-  (non-breaking — explicit flags still win).
+  env vars (env-first, flag-overridable); connection uses the shared
+  `_connect_cli.py` resolver. Identity follows the same `SYNADIA_*`
+  ladder the TypeScript agents use, first non-empty wins:
+  `SYNADIA_<AGENT>_OWNER` (per-agent) > `SYNADIA_OWNER` (fleet-wide) >
+  `NATS_AGENT_OWNER` (legacy alias) > `$USER` > `anon`, and the `NAME`
+  analogue (`SYNADIA_<AGENT>_NAME` > `SYNADIA_NAME` > `NATS_AGENT_NAME`
+  > the `--session-name` fallback) for the 5th subject token.
+  `<AGENT>` is the example's registered subject token uppercased with
+  hyphens turned into underscores (e.g. `echo` → `SYNADIA_ECHO_OWNER`).
+  Heartbeat cadence stays config, not identity — it keeps its single
+  `NATS_AGENT_HEARTBEAT_INTERVAL` var. The `_reference_agent.py` flags
+  default through the fleet-wide + legacy + fallback rungs only (no
+  per-agent var — its `agent` token is a runtime CLI flag). Non-breaking
+  — explicit flags still win, and the legacy `NATS_AGENT_*` vars keep
+  working as lowest-priority aliases.
 - **`examples` extra** — `httpx`, used by the LLM/tool example scripts
   (`uv sync --extra examples`). Not part of the published SDK surface.
 

--- a/agent-sdk/python/examples/01-echo.py
+++ b/agent-sdk/python/examples/01-echo.py
@@ -6,10 +6,11 @@
 # agent-sdk/typescript/examples/01-echo.ts.
 #
 # Identity → subject agents.prompt.echo.<owner>.<session_name>. Owner and the
-# session name are overridable (--owner / --session-name, or $NATS_AGENT_OWNER /
-# $NATS_AGENT_NAME) so several people can run this against one server without
-# colliding. --heartbeat-interval / $NATS_AGENT_HEARTBEAT_INTERVAL tunes the
-# heartbeat cadence (default 30s).
+# session name are overridable: --owner / --session-name, else the SYNADIA_*
+# ladder ($SYNADIA_ECHO_OWNER > $SYNADIA_OWNER > legacy $NATS_AGENT_OWNER, and
+# the _NAME analogue) — so several people can run this against one server
+# without colliding. --heartbeat-interval / $NATS_AGENT_HEARTBEAT_INTERVAL tunes
+# the heartbeat cadence (default 30s).
 #
 # Connection: --context / --url, else $NATS_CONTEXT / $NATS_URL, else the
 # selected `nats` context. Run with -h for the full flag list.

--- a/agent-sdk/python/examples/01-echo.py
+++ b/agent-sdk/python/examples/01-echo.py
@@ -39,7 +39,7 @@ async def main() -> None:
         description="Echo agent — replies with the prompt prefixed by 'echo: '."
     )
     add_connection_flags(parser)
-    add_agent_identity_flags(parser)
+    add_agent_identity_flags(parser, agent="echo")
     args = parser.parse_args()
 
     nc = await connect_from_cli(args)

--- a/agent-sdk/python/examples/02-ollama.py
+++ b/agent-sdk/python/examples/02-ollama.py
@@ -73,7 +73,7 @@ async def main() -> None:
         description="LLM agent — streams replies from a local Ollama model."
     )
     add_connection_flags(parser)
-    add_agent_identity_flags(parser)
+    add_agent_identity_flags(parser, agent="ollama")
     args = parser.parse_args()
 
     nc = await connect_from_cli(args)

--- a/agent-sdk/python/examples/03-openrouter.py
+++ b/agent-sdk/python/examples/03-openrouter.py
@@ -79,7 +79,7 @@ async def main() -> None:
         description="LLM agent — streams replies from a hosted OpenRouter model."
     )
     add_connection_flags(parser)
-    add_agent_identity_flags(parser)
+    add_agent_identity_flags(parser, agent="openrouter")
     args = parser.parse_args()
 
     # Checked after parse_args so `--help` works without a key.

--- a/agent-sdk/python/examples/04-combined.py
+++ b/agent-sdk/python/examples/04-combined.py
@@ -37,7 +37,7 @@ async def main() -> None:
         description="LLM agent — answers prompts via Ollama or OpenRouter (auto-selected)."
     )
     add_connection_flags(parser)
-    add_agent_identity_flags(parser)
+    add_agent_identity_flags(parser, agent="llm")
     args = parser.parse_args()
 
     llm = create_llm_client()

--- a/agent-sdk/python/examples/04-combined.py
+++ b/agent-sdk/python/examples/04-combined.py
@@ -7,9 +7,11 @@
 #   OPENROUTER_API_KEY set  → OpenRouter (OPENROUTER_MODEL)
 #   otherwise               → local Ollama (OLLAMA_MODEL, OLLAMA_URL)
 #
-# Identity/heartbeat via --owner/--session-name/--heartbeat-interval or the
-# matching NATS_AGENT_* env vars. Connection: --context/--url, else
-# $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
+# Identity via --owner/--session-name, else the SYNADIA_* ladder
+# ($SYNADIA_LLM_OWNER > $SYNADIA_OWNER > legacy $NATS_AGENT_OWNER, and the _NAME
+# analogue — this example registers agent="llm"). --heartbeat-interval /
+# $NATS_AGENT_HEARTBEAT_INTERVAL tunes the cadence. Connection: --context/--url,
+# else $NATS_CONTEXT/$NATS_URL, else the selected `nats` context. Run -h for flags.
 
 from __future__ import annotations
 

--- a/agent-sdk/python/examples/05-tools.py
+++ b/agent-sdk/python/examples/05-tools.py
@@ -175,7 +175,7 @@ async def main() -> None:
         description="LLM agent with a read_sensor tool backed by a NATS microservice."
     )
     add_connection_flags(parser)
-    add_agent_identity_flags(parser)
+    add_agent_identity_flags(parser, agent="tools")
     args = parser.parse_args()
 
     nc = await connect_from_cli(args)

--- a/agent-sdk/python/examples/README.md
+++ b/agent-sdk/python/examples/README.md
@@ -35,17 +35,29 @@ uv sync --extra examples   # the `examples` extra pulls in httpx (used by 02–0
 
 None of these are required — the examples are configured entirely through flags
 and environment variables. Identity and heartbeat are flags that each default to
-a `NATS_AGENT_*` env var (so the examples are env-driven like the TS ladder; an
-explicit flag overrides the env). Connection is resolved by the shared
-`_connect_cli.py`; backend config is env-only.
+an env var (so the examples are env-driven like the TS agents; an explicit flag
+overrides the env). Connection is resolved by the shared `_connect_cli.py`;
+backend config is env-only.
+
+Identity (`owner` / `name`) resolves through a ladder, first non-empty wins:
+`SYNADIA_<AGENT>_OWNER` (per-agent override) > `SYNADIA_OWNER` (fleet-wide) >
+`NATS_AGENT_OWNER` (legacy alias) > `$USER` > `anon`; the `NAME` analogue is the
+same shape ending in the `--session-name` fallback. `<AGENT>` is the example's
+registered subject token, uppercased with hyphens turned into underscores — so
+`01-echo.py` (registers `echo`) reads `SYNADIA_ECHO_OWNER` / `SYNADIA_ECHO_NAME`,
+`04-combined.py` (registers `llm`) reads `SYNADIA_LLM_OWNER`, and so on.
 
 | Variable | Used by | Default | Purpose |
 | --- | --- | --- | --- |
 | `NATS_CONTEXT` | all | _(unset)_ | Connect via a named [`nats` CLI context](https://docs.nats.io/using-nats/nats-tools/nats_cli/nats_contexts). Same as `--context`. |
 | `NATS_URL` | all | _(unset)_ | Connect via a raw URL (credentials in the userinfo are honored). Same as `--url`. |
-| `NATS_AGENT_OWNER` | all | `$USER`, else `anon` | 4th subject token. Same as `--owner`. Set it so several people on one server don't collide. |
-| `NATS_AGENT_NAME` | all | `main` | 5th subject token / session this agent serves. Same as `--session-name`. |
-| `NATS_AGENT_HEARTBEAT_INTERVAL` | all | `30` | Heartbeat cadence in **seconds**. Same as `--heartbeat-interval`. Lower it (e.g. `2`) for a livelier `05-liveness` demo. `0` is treated as unset → the default. |
+| `SYNADIA_<AGENT>_OWNER` | all | _(unset)_ | 4th subject token, per-agent override (e.g. `SYNADIA_ECHO_OWNER`). Highest-priority owner source. Same as `--owner`. |
+| `SYNADIA_OWNER` | all | _(unset)_ | 4th subject token, fleet-wide. Used when the per-agent var is unset. Same as `--owner`. |
+| `NATS_AGENT_OWNER` | all | `$USER`, else `anon` | 4th subject token, **legacy alias** (lowest-priority owner source). Same as `--owner`. Set it so several people on one server don't collide. |
+| `SYNADIA_<AGENT>_NAME` | all | _(unset)_ | 5th subject token / session, per-agent override (e.g. `SYNADIA_ECHO_NAME`). Highest-priority name source. Same as `--session-name`. |
+| `SYNADIA_NAME` | all | _(unset)_ | 5th subject token / session, fleet-wide. Used when the per-agent var is unset. Same as `--session-name`. |
+| `NATS_AGENT_NAME` | all | `main` | 5th subject token / session, **legacy alias** (lowest-priority name source). Same as `--session-name`. |
+| `NATS_AGENT_HEARTBEAT_INTERVAL` | all | `30` | Heartbeat cadence in **seconds** (config, not identity — no `SYNADIA_*` form). Same as `--heartbeat-interval`. Lower it (e.g. `2`) for a livelier `05-liveness` demo. `0` is treated as unset → the default. |
 | `OLLAMA_URL` | `02`, `04`, `05` | `http://localhost:11434` | Where Ollama is listening. |
 | `OLLAMA_MODEL` | `02`, `04`, `05` | `llama3.2` (`05`: `llama3.1:8b`) | Which Ollama model to prompt. |
 | `OPENROUTER_API_KEY` | `03`, `04` | _(required for `03`)_ | Your [OpenRouter key](https://openrouter.ai/keys). |
@@ -58,9 +70,13 @@ silent localhost fallback — pass one of these (the examples below use `--url`)
 ## Run
 
 ```sh
-# localhost, env-driven identity:
+# localhost, env-driven identity (fleet-wide SYNADIA_* vars):
+SYNADIA_OWNER=alice SYNADIA_NAME=demo uv run python examples/01-echo.py --url nats://127.0.0.1:4222
+# per-agent override beats the fleet-wide var:
+SYNADIA_ECHO_OWNER=alice uv run python examples/01-echo.py --url nats://127.0.0.1:4222
+# the legacy NATS_AGENT_* vars still work (lowest priority):
 NATS_AGENT_OWNER=alice NATS_AGENT_NAME=demo uv run python examples/01-echo.py --url nats://127.0.0.1:4222
-# or pass identity as flags instead:
+# or pass identity as flags instead (flags win over every env var):
 uv run python examples/01-echo.py --url nats://127.0.0.1:4222 --owner alice --session-name demo
 # fast heartbeats, to make the liveness demo lively:
 uv run python examples/01-echo.py --url nats://127.0.0.1:4222 --heartbeat-interval 2

--- a/agent-sdk/python/examples/_connect_cli.py
+++ b/agent-sdk/python/examples/_connect_cli.py
@@ -73,12 +73,34 @@ async def connect_from_cli(args: argparse.Namespace) -> NATSClient:
         sys.exit(2)
 
 
-def _env_owner_default() -> str:
-    return os.environ.get("NATS_AGENT_OWNER") or os.environ.get("USER") or "anon"
+def _agent_env_token(agent: str) -> str:
+    """Map an agent's subject token to its per-agent env-var infix.
+
+    ``echo`` → ``ECHO``; ``my-agent`` → ``MY_AGENT`` — uppercased,
+    hyphens to underscores, so it composes into ``SYNADIA_<AGENT>_OWNER``.
+    """
+    return agent.upper().replace("-", "_")
 
 
-def _env_session_default(fallback: str) -> str:
-    return os.environ.get("NATS_AGENT_NAME") or fallback
+def _env_owner_default(agent: str | None) -> str:
+    per_agent = os.environ.get(f"SYNADIA_{_agent_env_token(agent)}_OWNER") if agent else None
+    return (
+        per_agent
+        or os.environ.get("SYNADIA_OWNER")
+        or os.environ.get("NATS_AGENT_OWNER")  # legacy alias
+        or os.environ.get("USER")
+        or "anon"
+    )
+
+
+def _env_session_default(agent: str | None, fallback: str) -> str:
+    per_agent = os.environ.get(f"SYNADIA_{_agent_env_token(agent)}_NAME") if agent else None
+    return (
+        per_agent
+        or os.environ.get("SYNADIA_NAME")
+        or os.environ.get("NATS_AGENT_NAME")  # legacy alias
+        or fallback
+    )
 
 
 def _env_heartbeat_default(fallback: int) -> int:
@@ -94,29 +116,48 @@ def _env_heartbeat_default(fallback: int) -> int:
 def add_agent_identity_flags(
     parser: argparse.ArgumentParser,
     *,
+    agent: str | None = None,
     session_fallback: str = "main",
     heartbeat_fallback: int = 30,
 ) -> None:
     """Wire ``--owner`` / ``--session-name`` / ``--heartbeat-interval`` onto an agent example.
 
-    Each flag defaults to its ``NATS_AGENT_*`` environment variable, so the
-    examples are env-driven like the TS ladder (``NATS_AGENT_OWNER`` /
-    ``NATS_AGENT_NAME`` / ``NATS_AGENT_HEARTBEAT_INTERVAL``); an explicit flag
-    overrides the env. ``NATS_AGENT_HEARTBEAT_INTERVAL=0`` is treated as unset
-    and falls back to ``heartbeat_fallback`` (the SDK requires a positive
-    interval).
+    Identity flags default through the ``SYNADIA_*`` ladder, so the examples
+    are env-driven like the TS agents. For ``--owner`` the order is
+    ``SYNADIA_<AGENT>_OWNER`` (per-agent, only when ``agent`` is given) >
+    ``SYNADIA_OWNER`` (fleet-wide) > ``NATS_AGENT_OWNER`` (legacy alias) >
+    ``$USER`` > ``"anon"``; ``--session-name`` mirrors it with the ``_NAME`` /
+    ``SYNADIA_NAME`` / ``NATS_AGENT_NAME`` vars and ``session_fallback``. An
+    explicit flag overrides the env. Pass ``agent`` (the example's registered
+    subject token) to enable the per-agent override; ``agent=None`` skips it
+    (the reference-agent path, whose token is a runtime CLI flag).
+
+    ``<AGENT>`` is the subject token uppercased with hyphens turned into
+    underscores (see :func:`_agent_env_token`). The heartbeat flag is config,
+    not identity, so it keeps its ``NATS_AGENT_HEARTBEAT_INTERVAL`` var;
+    ``NATS_AGENT_HEARTBEAT_INTERVAL=0`` is treated as unset and falls back to
+    ``heartbeat_fallback`` (the SDK requires a positive interval).
     """
+    if agent is not None:
+        owner_vars = f"$SYNADIA_{_agent_env_token(agent)}_OWNER, else $SYNADIA_OWNER"
+        name_vars = f"$SYNADIA_{_agent_env_token(agent)}_NAME, else $SYNADIA_NAME"
+    else:
+        owner_vars = "$SYNADIA_OWNER"
+        name_vars = "$SYNADIA_NAME"
     parser.add_argument(
         "--owner",
-        default=_env_owner_default(),
-        help="4th subject token (default: $NATS_AGENT_OWNER, else $USER, else 'anon')",
+        default=_env_owner_default(agent),
+        help=(
+            f"4th subject token (default: {owner_vars}, "
+            "else $NATS_AGENT_OWNER, else $USER, else 'anon')"
+        ),
     )
     parser.add_argument(
         "--session-name",
-        default=_env_session_default(session_fallback),
+        default=_env_session_default(agent, session_fallback),
         help=(
             "5th subject token / session this agent serves "
-            f"(default: $NATS_AGENT_NAME, else '{session_fallback}')"
+            f"(default: {name_vars}, else $NATS_AGENT_NAME, else '{session_fallback}')"
         ),
     )
     parser.add_argument(

--- a/agent-sdk/python/tests/test_connect_cli_identity.py
+++ b/agent-sdk/python/tests/test_connect_cli_identity.py
@@ -1,0 +1,156 @@
+"""Unit tests for the example identity resolver in ``examples/_connect_cli.py``.
+
+The examples are not an importable package (the e2e test path-references
+them), so we load the helper module straight off disk via
+:func:`importlib.util.spec_from_file_location` and assert the
+``SYNADIA_*`` precedence ladder that ``add_agent_identity_flags`` builds:
+
+    --flag > SYNADIA_<AGENT>_<TOKEN> > SYNADIA_<TOKEN> > NATS_AGENT_<TOKEN>
+            > ($USER for owner) > fallback
+
+This is a pure-resolution test — no NATS connection is opened.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONNECT_CLI_SCRIPT = REPO_ROOT / "examples" / "_connect_cli.py"
+
+# Every identity env var the resolver reads, cleared before each test so a
+# developer's shell env can't leak in.
+_IDENTITY_ENV_VARS = (
+    "SYNADIA_ECHO_OWNER",
+    "SYNADIA_OWNER",
+    "NATS_AGENT_OWNER",
+    "USER",
+    "SYNADIA_ECHO_NAME",
+    "SYNADIA_NAME",
+    "NATS_AGENT_NAME",
+)
+
+
+def _load_connect_cli() -> Any:
+    spec = importlib.util.spec_from_file_location("examples_connect_cli", CONNECT_CLI_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def connect_cli() -> Any:
+    return _load_connect_cli()
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity_env(monkeypatch: Any) -> Iterator[None]:
+    for name in _IDENTITY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def _resolve(
+    connect_cli: Any,
+    *,
+    agent: str | None,
+    argv: Sequence[str] = (),
+) -> argparse.Namespace:
+    """Build a parser via the helper and resolve identity defaults from env."""
+    parser = argparse.ArgumentParser()
+    connect_cli.add_agent_identity_flags(parser, agent=agent)
+    return parser.parse_args(list(argv))
+
+
+def test_owner_ladder_per_agent(connect_cli: Any, monkeypatch: Any) -> None:
+    monkeypatch.setenv("SYNADIA_ECHO_OWNER", "per-agent")
+    monkeypatch.setenv("SYNADIA_OWNER", "fleet")
+    monkeypatch.setenv("NATS_AGENT_OWNER", "legacy")
+    monkeypatch.setenv("USER", "shelluser")
+
+    # Per-agent var wins at the top of the ladder.
+    assert _resolve(connect_cli, agent="echo").owner == "per-agent"
+
+    # …then fleet-wide, then the legacy alias, then $USER, then "anon".
+    monkeypatch.delenv("SYNADIA_ECHO_OWNER")
+    assert _resolve(connect_cli, agent="echo").owner == "fleet"
+    monkeypatch.delenv("SYNADIA_OWNER")
+    assert _resolve(connect_cli, agent="echo").owner == "legacy"
+    monkeypatch.delenv("NATS_AGENT_OWNER")
+    assert _resolve(connect_cli, agent="echo").owner == "shelluser"
+    monkeypatch.delenv("USER")
+    assert _resolve(connect_cli, agent="echo").owner == "anon"
+
+
+def test_name_ladder_per_agent(connect_cli: Any, monkeypatch: Any) -> None:
+    monkeypatch.setenv("SYNADIA_ECHO_NAME", "per-agent")
+    monkeypatch.setenv("SYNADIA_NAME", "fleet")
+    monkeypatch.setenv("NATS_AGENT_NAME", "legacy")
+
+    assert _resolve(connect_cli, agent="echo").session_name == "per-agent"
+    monkeypatch.delenv("SYNADIA_ECHO_NAME")
+    assert _resolve(connect_cli, agent="echo").session_name == "fleet"
+    monkeypatch.delenv("SYNADIA_NAME")
+    assert _resolve(connect_cli, agent="echo").session_name == "legacy"
+    # Falls back to session_fallback ("main") once every env source is gone.
+    monkeypatch.delenv("NATS_AGENT_NAME")
+    assert _resolve(connect_cli, agent="echo").session_name == "main"
+
+
+def test_agent_none_skips_per_agent_var(connect_cli: Any, monkeypatch: Any) -> None:
+    """The reference-agent path (agent=None) ignores SYNADIA_<AGENT>_* vars."""
+    monkeypatch.setenv("SYNADIA_ECHO_OWNER", "per-agent")
+    monkeypatch.setenv("SYNADIA_OWNER", "fleet")
+    monkeypatch.setenv("SYNADIA_ECHO_NAME", "per-agent-name")
+    monkeypatch.setenv("SYNADIA_NAME", "fleet-name")
+
+    args = _resolve(connect_cli, agent=None)
+    assert args.owner == "fleet"
+    assert args.session_name == "fleet-name"
+
+    # Legacy aliases + fallback still honored on the agent=None path.
+    monkeypatch.delenv("SYNADIA_OWNER")
+    monkeypatch.delenv("SYNADIA_NAME")
+    monkeypatch.setenv("NATS_AGENT_OWNER", "legacy")
+    monkeypatch.setenv("NATS_AGENT_NAME", "legacy-name")
+    args = _resolve(connect_cli, agent=None)
+    assert args.owner == "legacy"
+    assert args.session_name == "legacy-name"
+
+    monkeypatch.delenv("NATS_AGENT_OWNER")
+    monkeypatch.delenv("NATS_AGENT_NAME")
+    monkeypatch.setenv("USER", "shelluser")
+    args = _resolve(connect_cli, agent=None)
+    assert args.owner == "shelluser"
+    assert args.session_name == "main"
+
+
+def test_explicit_flags_override_env(connect_cli: Any, monkeypatch: Any) -> None:
+    monkeypatch.setenv("SYNADIA_ECHO_OWNER", "per-agent")
+    monkeypatch.setenv("SYNADIA_ECHO_NAME", "per-agent-name")
+
+    args = _resolve(
+        connect_cli,
+        agent="echo",
+        argv=["--owner", "flag-owner", "--session-name", "flag-name"],
+    )
+    assert args.owner == "flag-owner"
+    assert args.session_name == "flag-name"
+
+
+def test_agent_env_token_maps_hyphens(connect_cli: Any, monkeypatch: Any) -> None:
+    """A hyphenated agent token resolves to SYNADIA_<UPPER_SNAKE>_*."""
+    assert connect_cli._agent_env_token("my-agent") == "MY_AGENT"
+    monkeypatch.setenv("SYNADIA_MY_AGENT_OWNER", "per-agent")
+    monkeypatch.setenv("SYNADIA_MY_AGENT_NAME", "per-agent-name")
+
+    args = _resolve(connect_cli, agent="my-agent")
+    assert args.owner == "per-agent"
+    assert args.session_name == "per-agent-name"

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -63,8 +63,10 @@ export NATS_CONTEXT=prod
 # — or —
 export NATS_URL=nats://127.0.0.1:4222
 
-export NATS_OWNER=acme
-export NATS_AGENT_NAME=research
+# Identity: SYNADIA_DEERFLOW_* (per-agent) > SYNADIA_* (fleet-wide) > legacy
+# NATS_OWNER / NATS_AGENT_NAME aliases. Use whichever fits your deployment.
+export SYNADIA_OWNER=acme
+export SYNADIA_NAME=research
 export DEERFLOW_URL=http://localhost:2026
 
 # Preferred for current DeerFlow Gateway auth: the wrapper logs in once,
@@ -155,10 +157,14 @@ TOML
 | --- | --- | --- |
 | `NATS_AGENT_TOKEN` | `agent` | Preferred env name for the protocol type token. |
 | `DEERFLOW_NATS_AGENT` | `agent` | DeerFlow-specific alias. Used only when `NATS_AGENT_TOKEN` is unset. |
-| `NATS_OWNER` | `owner` | Preferred owner env var. |
-| `DEERFLOW_NATS_OWNER` | `owner` | DeerFlow-specific alias. Used only when `NATS_OWNER` is unset. |
-| `NATS_AGENT_NAME` | `session` | Preferred session env var for sibling channel consistency. |
-| `NATS_SESSION` | `session` | Alias. Used only when `NATS_AGENT_NAME` is unset. |
+| `SYNADIA_DEERFLOW_OWNER` | `owner` | Per-agent override, highest priority. The `SYNADIA_<AGENT>_OWNER` form shared across all agents (here `<AGENT>` is `DEERFLOW`). |
+| `SYNADIA_OWNER` | `owner` | Fleet-wide owner env var. Used when `SYNADIA_DEERFLOW_OWNER` is unset. |
+| `NATS_OWNER` | `owner` | **Legacy alias.** Used only when neither `SYNADIA_*` owner var is set. |
+| `DEERFLOW_NATS_OWNER` | `owner` | **Legacy alias** (DeerFlow-specific). Used only when the above are unset. |
+| `SYNADIA_DEERFLOW_NAME` | `session` | Per-agent override for the 5th (session/name) token, highest priority. The `SYNADIA_<AGENT>_NAME` form shared across all agents. |
+| `SYNADIA_NAME` | `session` | Fleet-wide session/name env var. Used when `SYNADIA_DEERFLOW_NAME` is unset. |
+| `NATS_AGENT_NAME` | `session` | **Legacy alias.** Used only when neither `SYNADIA_*` name var is set. Note: despite the "agent" in its name it sets the 5th *session* token — the `SYNADIA_*` names fix that confusion. |
+| `NATS_SESSION` | `session` | **Legacy alias.** Used only when the above are unset. |
 | `DEERFLOW_URL` | `deerflow_url` | DeerFlow Gateway base URL. |
 | `DEERFLOW_USERNAME` | `deerflow_username` | DeerFlow local-login username/email for automatic Gateway session login. |
 | `DEERFLOW_PASSWORD` | `deerflow_password` | DeerFlow local-login password for automatic Gateway session login. Prefer env over config files. Redacted from `doctor` output. |
@@ -282,7 +288,7 @@ asyncio.run(main())
 
 ## Troubleshooting
 
-- **`owner is not configured; set NATS_OWNER or pass --owner`** — set `NATS_OWNER`, `DEERFLOW_NATS_OWNER`, `owner = "..."`, or `--owner`. The owner is required because it is part of the protocol subject.
+- **`owner is not configured; set NATS_OWNER or pass --owner`** — set `SYNADIA_DEERFLOW_OWNER`, `SYNADIA_OWNER`, a legacy `NATS_OWNER`/`DEERFLOW_NATS_OWNER` alias, `owner = "..."`, or `--owner`. The owner is required because it is part of the protocol subject.
 - **`set NATS_CONTEXT or NATS_URL before starting the channel`** — configure one NATS target. Prefer `NATS_CONTEXT` for authenticated deployments.
 - **`agent token must be lowercase alphanumeric plus hyphen`** — use a subject-safe token such as `df` or `deerflow`. Do not use spaces, dots, or uppercase.
 - **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.

--- a/agents/deerflow/README.md
+++ b/agents/deerflow/README.md
@@ -288,7 +288,7 @@ asyncio.run(main())
 
 ## Troubleshooting
 
-- **`owner is not configured; set NATS_OWNER or pass --owner`** — set `SYNADIA_DEERFLOW_OWNER`, `SYNADIA_OWNER`, a legacy `NATS_OWNER`/`DEERFLOW_NATS_OWNER` alias, `owner = "..."`, or `--owner`. The owner is required because it is part of the protocol subject.
+- **`owner is not configured; set SYNADIA_DEERFLOW_OWNER, SYNADIA_OWNER, a legacy NATS_OWNER/DEERFLOW_NATS_OWNER alias, or pass --owner`** — also settable via `owner = "..."` in the config file. The owner is required because it is part of the protocol subject.
 - **`set NATS_CONTEXT or NATS_URL before starting the channel`** — configure one NATS target. Prefer `NATS_CONTEXT` for authenticated deployments.
 - **`agent token must be lowercase alphanumeric plus hyphen`** — use a subject-safe token such as `df` or `deerflow`. Do not use spaces, dots, or uppercase.
 - **`DeerFlow Gateway is not reachable at .../health`** — start DeerFlow Gateway first, confirm the port, and run `curl <DEERFLOW_URL>/health` from the same host as the wrapper.

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/config.py
@@ -154,8 +154,16 @@ def _apply_env(config: ChannelConfig) -> ChannelConfig:
     return replace(
         config,
         agent=_env("NATS_AGENT_TOKEN") or _env("DEERFLOW_NATS_AGENT") or config.agent,
-        owner=_env("NATS_OWNER") or _env("DEERFLOW_NATS_OWNER") or config.owner,
-        session=_env("NATS_AGENT_NAME") or _env("NATS_SESSION") or config.session,
+        owner=_env("SYNADIA_DEERFLOW_OWNER")
+        or _env("SYNADIA_OWNER")
+        or _env("NATS_OWNER")  # legacy alias
+        or _env("DEERFLOW_NATS_OWNER")  # legacy alias
+        or config.owner,
+        session=_env("SYNADIA_DEERFLOW_NAME")
+        or _env("SYNADIA_NAME")
+        or _env("NATS_AGENT_NAME")  # legacy alias
+        or _env("NATS_SESSION")  # legacy alias
+        or config.session,
         deerflow_url=_env("DEERFLOW_URL") or config.deerflow_url,
         nats_context=_env("NATS_CONTEXT") or config.nats_context,
         nats_url=_env("NATS_URL") or config.nats_url,

--- a/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
+++ b/agents/deerflow/src/synadia_ai/nats_deerflow_channel/doctor.py
@@ -89,7 +89,10 @@ def run_doctor(
 
     checks["owner_configured"] = bool(config.owner)
     if not config.owner:
-        messages.append("owner is not configured; set NATS_OWNER or pass --owner")
+        messages.append(
+            "owner is not configured; set SYNADIA_DEERFLOW_OWNER, SYNADIA_OWNER, "
+            "a legacy NATS_OWNER/DEERFLOW_NATS_OWNER alias, or pass --owner"
+        )
 
     parsed = urlparse(config.deerflow_url)
     checks["deerflow_url_shape"] = parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from synadia_ai.nats_deerflow_channel.config import resolve_config
 
-# Every identity env var the resolver reads, so a developer's shell can't leak
-# into the default-state and precedence tests.
+# Every identity env var the resolver reads. Cleared before each test so a
+# developer's shell env can't leak in — the SYNADIA_* vars outrank the legacy
+# aliases, so a stray export would otherwise turn the precedence tests flaky.
 _IDENTITY_ENV_VARS = (
     "SYNADIA_DEERFLOW_OWNER",
     "SYNADIA_OWNER",
@@ -19,9 +23,14 @@ _IDENTITY_ENV_VARS = (
 )
 
 
-def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
+@pytest.fixture(autouse=True)
+def _clean_identity_env(monkeypatch: Any) -> Iterator[None]:
     for name in _IDENTITY_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
     monkeypatch.delenv("DEERFLOW_URL", raising=False)
 
     config = resolve_config(config_file=tmp_path / "missing.toml")

--- a/agents/deerflow/tests/test_config.py
+++ b/agents/deerflow/tests/test_config.py
@@ -5,10 +5,23 @@ from typing import Any
 
 from synadia_ai.nats_deerflow_channel.config import resolve_config
 
+# Every identity env var the resolver reads, so a developer's shell can't leak
+# into the default-state and precedence tests.
+_IDENTITY_ENV_VARS = (
+    "SYNADIA_DEERFLOW_OWNER",
+    "SYNADIA_OWNER",
+    "NATS_OWNER",
+    "DEERFLOW_NATS_OWNER",
+    "SYNADIA_DEERFLOW_NAME",
+    "SYNADIA_NAME",
+    "NATS_AGENT_NAME",
+    "NATS_SESSION",
+)
+
 
 def test_defaults_include_df_agent(tmp_path: Path, monkeypatch: Any) -> None:
-    monkeypatch.delenv("NATS_OWNER", raising=False)
-    monkeypatch.delenv("NATS_AGENT_NAME", raising=False)
+    for name in _IDENTITY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.delenv("DEERFLOW_URL", raising=False)
 
     config = resolve_config(config_file=tmp_path / "missing.toml")
@@ -80,6 +93,54 @@ def test_config_file_then_env_then_cli_precedence(tmp_path: Path, monkeypatch: A
     assert config.deerflow_password == "cli-password"
     assert config.redacted_dict()["deerflow_username"] == "cli@example.com"
     assert config.redacted_dict()["deerflow_password"] == "[REDACTED]"
+
+
+def test_synadia_identity_env_precedence(tmp_path: Path, monkeypatch: Any) -> None:
+    """SYNADIA_DEERFLOW_* > SYNADIA_* > legacy aliases > config, and CLI beats all."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        'owner = "file-owner"\nsession = "file-session"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SYNADIA_DEERFLOW_OWNER", "synadia-deerflow-owner")
+    monkeypatch.setenv("SYNADIA_OWNER", "synadia-owner")
+    monkeypatch.setenv("NATS_OWNER", "nats-owner")
+    monkeypatch.setenv("DEERFLOW_NATS_OWNER", "deerflow-nats-owner")
+    monkeypatch.setenv("SYNADIA_DEERFLOW_NAME", "synadia-deerflow-name")
+    monkeypatch.setenv("SYNADIA_NAME", "synadia-name")
+    monkeypatch.setenv("NATS_AGENT_NAME", "nats-agent-name")
+    monkeypatch.setenv("NATS_SESSION", "nats-session")
+
+    # Top of each ladder: the per-agent SYNADIA_DEERFLOW_* var wins.
+    config = resolve_config(config_file=config_file)
+    assert config.owner == "synadia-deerflow-owner"
+    assert config.session == "synadia-deerflow-name"
+
+    # A CLI flag still overrides the SYNADIA_* env vars.
+    config = resolve_config(config_file=config_file, owner="cli-owner", session="cli-session")
+    assert config.owner == "cli-owner"
+    assert config.session == "cli-session"
+
+    # Drop the per-agent vars: the fleet-wide SYNADIA_* vars win over legacy.
+    monkeypatch.delenv("SYNADIA_DEERFLOW_OWNER")
+    monkeypatch.delenv("SYNADIA_DEERFLOW_NAME")
+    config = resolve_config(config_file=config_file)
+    assert config.owner == "synadia-owner"
+    assert config.session == "synadia-name"
+
+    # Drop the fleet-wide vars too: the legacy aliases win over the config file.
+    monkeypatch.delenv("SYNADIA_OWNER")
+    monkeypatch.delenv("SYNADIA_NAME")
+    config = resolve_config(config_file=config_file)
+    assert config.owner == "nats-owner"
+    assert config.session == "nats-agent-name"
+
+    # Drop the preferred legacy aliases: the secondary aliases win, then config.
+    monkeypatch.delenv("NATS_OWNER")
+    monkeypatch.delenv("NATS_AGENT_NAME")
+    config = resolve_config(config_file=config_file)
+    assert config.owner == "deerflow-nats-owner"
+    assert config.session == "nats-session"
 
 
 def test_nats_url_env_is_used(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
Mirrors the TypeScript agents' `SYNADIA_*` identity env-var convention onto the two Python surfaces Rene maintains: the agent-sdk examples ladder and the deerflow channel. No other Python surface reads NATS identity.

## The convention

Identity (`owner` = 4th subject token, `name`/session = 5th token) resolves first-non-empty-wins:

```
CLI flag  >  SYNADIA_<AGENT>_<TOKEN>  >  SYNADIA_<TOKEN>  >  <legacy var>  >  config/derived default
            └ per-agent override ┘      └ fleet-wide ┘      └ kept as alias ┘
```

- `<AGENT>` = the agent's own subject token, uppercased, hyphens→underscores (e.g. `echo` → `SYNADIA_ECHO_OWNER`). It derives from the **registered** token, not the filename — `04-combined.py` registers `agent="llm"`, so its per-agent var is `SYNADIA_LLM_OWNER`.
- `<TOKEN>` = `OWNER` or `NAME` (the spec word for the 5th token, even where the code calls it `session`).
- Connection vars (`NATS_URL`, `NATS_CONTEXT`, `NATS_CREDENTIALS`) stay generic and untouched.
- The `agent` (3rd) token is **not** env-settable under this scheme. Deerflow keeps its existing `NATS_AGENT_TOKEN`/`DEERFLOW_NATS_AGENT` handling unchanged.

## Scope decision: precedence ladder ported, Python's `or`-chain idiom preserved

The TS side has a "first-present-wins, does-NOT-cascade-on-empty, loud-fail-on-invalid-token" semantic. **This PR does not port that semantic** — it ports the *precedence ladder* only. Rationale:

- The Python SDK's `AgentSubject.new` / `_sanitize` base64-encodes non-conforming tokens rather than failing loud — a different, already-shipped contract.
- Both Python surfaces already resolve identity with `or`-chaining (empty/whitespace cascades to the next source). We preserve that idiom and only **prepend the new `SYNADIA_*` sources** to the chain.

So a blank `SYNADIA_*` value cascades to the next rung rather than registering an empty owner — verified at runtime (see below).

## Change 1 — agent-sdk examples ladder

- `examples/_connect_cli.py`: `add_agent_identity_flags` gains a keyword-only `agent` param; `--owner`/`--session-name` defaults resolve through the ladder above (`agent=None` skips the per-agent rung — the reference-agent path, whose token is a runtime CLI flag). Help strings name the new vars.
- The five numbered examples pass their registered token (`echo`/`ollama`/`openrouter`/`llm`/`tools`). `_reference_agent.py` keeps `session_fallback="example"` and no per-agent var.
- `examples/README.md` env-var table + run snippets, and `CHANGELOG.md` `[Unreleased]`, updated.
- New `tests/test_connect_cli_identity.py` path-loads the helper and asserts the ladder, the `agent=None` path, flag-override, and hyphen→underscore mapping.

## Change 2 — deerflow channel

- `config.py` `_apply_env()`: prepends `SYNADIA_DEERFLOW_OWNER`/`SYNADIA_OWNER` and `SYNADIA_DEERFLOW_NAME`/`SYNADIA_NAME` to the owner/session chains; legacy `NATS_OWNER`/`DEERFLOW_NATS_OWNER`/`NATS_AGENT_NAME`/`NATS_SESSION` kept as lowest-priority aliases. `agent` token and connection vars untouched; CLI flags still win.
- `README.md` env-var table, quickstart exports, troubleshooting line updated. (Bonus readability note in the docs: `NATS_AGENT_NAME`, named "agent", actually sets the 5th *session* token — the `SYNADIA_*` names fix that confusion.)
- `tests/test_config.py`: new `test_synadia_identity_env_precedence` (full ladder + CLI override) and the default-state test now clears the new vars so a developer's shell can't leak in.

## Legacy aliases

All legacy aliases are kept everywhere as lowest-priority sources — zero behavior change for anyone already setting old vars.

## Verification

Lint/format/mypy/pytest green for both packages (deerflow: 47 passed; agent-sdk: 47 passed, synced `--all-extras` to match CI).

Beyond CI, `/verify` drove the two real CLI surfaces against a live `nats-server`:
- **deerflow `doctor`**: all five rungs + CLI override resolved to the expected `prompt_subject`; blank/whitespace `SYNADIA_*` correctly cascaded.
- **agent-sdk examples**: `01-echo` / `04-combined` / `_reference_agent` printed the expected `agents.prompt.<agent>.<owner>.<session>`. Confirmed `04-combined`'s per-agent var keys off the registered `llm` token (a filename-derived `SYNADIA_COMBINED_OWNER` was ignored), and the reference agent (`agent=None`) ignored a per-agent var while honoring `SYNADIA_OWNER` + the `example` fallback.

## Ripple-check

- TS SDK public surface: untouched (Python-only).
- Wire format / protocol behavior: unchanged — this is config resolution, not wire shape. No interop-test impact.
- READMEs (agent-sdk examples + deerflow) and agent-sdk CHANGELOG updated. Deerflow has no CHANGELOG (README is its doc surface).
- No release ladder needed — examples consume the local SDK; deerflow uses its own config module.

Reference TS template PRs: #150 (SDK examples), #153 (openclaw legacy-alias handling). The §5.3 `{"prompt":""}` decode-parity item is explicitly out of scope per the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)