### PR TITLE
release(deerflow): bump to 0.2.0

### DIFF
--- a/agents/deerflow/examples/env.example
+++ b/agents/deerflow/examples/env.example
@@ -5,13 +5,17 @@
 NATS_CONTEXT=prod
 # NATS_URL=nats://127.0.0.1:4222
 
-# Required protocol identity.
-NATS_OWNER=acme
+# Required protocol identity — 4th subject token. Resolution order, first
+# non-empty wins: SYNADIA_DEERFLOW_OWNER (per-agent override) > SYNADIA_OWNER
+# (fleet-wide) > legacy NATS_OWNER / DEERFLOW_NATS_OWNER aliases.
+SYNADIA_OWNER=acme
 
-# Stable DeerFlow session/thread and fifth protocol subject token.
-NATS_AGENT_NAME=research
+# Stable DeerFlow session/thread and 5th subject token. Same ladder:
+# SYNADIA_DEERFLOW_NAME > SYNADIA_NAME > legacy NATS_AGENT_NAME / NATS_SESSION.
+SYNADIA_NAME=research
 
-# Optional protocol type token. Defaults to df.
+# Optional protocol type token (3rd subject token). Defaults to df. Not
+# part of the SYNADIA_* scheme — set via NATS_AGENT_TOKEN or DEERFLOW_NATS_AGENT.
 NATS_AGENT_TOKEN=df
 
 # DeerFlow Gateway base URL.

--- a/agents/deerflow/pyproject.toml
+++ b/agents/deerflow/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synadia-ai-nats-deerflow-channel"
-version = "0.1.0"
+version = "0.2.0"
 description = "DeerFlow channel wrapper for the Synadia Agent Protocol for NATS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/agents/deerflow/uv.lock
+++ b/agents/deerflow/uv.lock
@@ -502,10 +502,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", marker = "extra == 'examples'", specifier = ">=0.27" },
     { name = "nats-py", specifier = ">=2.7" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "synadia-ai-agents", editable = "../../client-sdk/python" },
 ]
+provides-extras = ["examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -543,7 +545,7 @@ dev = [
 
 [[package]]
 name = "synadia-ai-nats-deerflow-channel"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release-prep version bump for `synadia-ai-nats-deerflow-channel`, following the `SYNADIA_*` identity env-var change merged in #160.

## What & why

`0.1.0` → **`0.2.0`** (minor). The deerflow channel's `owner`/`session` resolution now honors `SYNADIA_DEERFLOW_OWNER`/`_NAME` (per-agent) and `SYNADIA_OWNER`/`SYNADIA_NAME` (fleet-wide) ahead of the legacy `NATS_*` aliases. That's a **backward-compatible feature addition** — all legacy aliases stay as lowest-priority sources, so no existing user breaks — hence a minor bump, matching how the other Python packages here version features.

This is the only package with a shipped-code change from #160: the agent-sdk side was examples-only (not in the published wheel), and the client-sdk was untouched. So this is the lone release needed for that work.

## Files

- `pyproject.toml` — `version = "0.2.0"`.
- `uv.lock` — the self-version line, plus the already-pending `examples`/httpx extra metadata on the agent-sdk editable dep so `uv lock --check` is clean. The lockfile is dev-only (not in the published wheel), so this has no effect on the artifact.

## Verified locally (the exact release `verify` gate, caches bypassed)

```
uv sync --all-extras        → installs 0.2.0
uv lock --check             → consistent
uv run ruff check .         → All checks passed!
uv run ruff format --check  → 12 files already formatted
uv run mypy src tests       → no issues
uv run pytest               → 47 passed
uv build                    → synadia_ai_nats_deerflow_channel-0.2.0{.whl,.tar.gz}
```

## Release process (after merge — user-gated)

1. Merge this PR.
2. Tag `python-deerflow-v0.2.0` and push it.
3. `release-python-deerflow.yml` runs the `verify` matrix (ruff / format / mypy / pytest on py3.11–3.13), then — only if green — builds and publishes to PyPI via trusted publishing, and attaches artifacts to a GitHub release. The workflow also asserts the tag matches the pyproject version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)