### PR TITLE
Load NATS context TLS files and honor agent web UI host binding

### DIFF
--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -26,7 +26,7 @@
 //
 // Supported context fields: `url`, `creds` (path), `nkey` (path),
 // `user_jwt` (+ optional `user_seed` for nonce signing), `user`+`password`,
-// `token`, `inbox_prefix`, plus the TLS triple `cert`/`key`/`ca` and
+// `token`, `inbox_prefix`, plus the TLS file triple `cert`/`key`/`ca` and
 // `tls_first`.
 // Skipped: `nsc` integration.
 //
@@ -120,16 +120,16 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   }
 
   // Optional TLS triple. `nats context add --tlscert/--tlskey/--tlsca`
-  // writes file paths; `--tlsfirst` toggles handshake-first.
+  // writes file paths; load them into standard node:tls options.
   const cert = str(parsed["cert"]);
   const key = str(parsed["key"]);
   const ca = str(parsed["ca"]);
   const tlsFirst = parsed["tls_first"];
   if (cert || key || ca || tlsFirst === true) {
     const tls: NonNullable<NodeConnectionOptions["tls"]> = {};
-    if (cert) tls.certFile = expandHome(cert);
-    if (key) tls.keyFile = expandHome(key);
-    if (ca) tls.caFile = expandHome(ca);
+    if (cert) tls.cert = await readTlsFile("cert", expandHome(cert));
+    if (key) tls.key = await readTlsFile("key", expandHome(key));
+    if (ca) tls.ca = await readTlsFile("ca", expandHome(ca));
     if (tlsFirst === true) tls.handshakeFirst = true;
     opts.tls = tls;
   }
@@ -143,6 +143,16 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
 /** Expand a leading `~/` to `$HOME/`. */
 function expandHome(path: string): string {
   return path.startsWith("~/") ? join(homedir(), path.slice(2)) : path;
+}
+
+async function readTlsFile(field: string, path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    throw new NatsContextError(`failed to read TLS ${field} file ${path}`, {
+      cause: error,
+    });
+  }
 }
 
 /**

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -189,21 +189,41 @@ describe("loadContextOptions", () => {
     expect(opts.token).toBeUndefined();
   });
 
-  it("populates the TLS triple when cert/key/ca/tls_first are present", async () => {
+  it("loads the TLS triple when cert/key/ca/tls_first are present", async () => {
+    const certPath = join(baseDir, "client.pem");
+    const keyPath = join(baseDir, "client.key");
+    const caPath = join(baseDir, "ca.pem");
+    await writeFile(certPath, "client-cert");
+    await writeFile(keyPath, "client-key");
+    await writeFile(caPath, "ca-cert");
     await writeContext("with-tls", {
       url: "tls://nats.example.com:4222",
-      cert: "/etc/ssl/client.pem",
-      key: "/etc/ssl/client.key",
-      ca: "/etc/ssl/ca.pem",
+      cert: certPath,
+      key: keyPath,
+      ca: caPath,
       tls_first: true,
     });
     const opts = await loadContextOptions("with-tls");
     expect(opts.tls).toEqual({
-      certFile: "/etc/ssl/client.pem",
-      keyFile: "/etc/ssl/client.key",
-      caFile: "/etc/ssl/ca.pem",
+      cert: "client-cert",
+      key: "client-key",
+      ca: "ca-cert",
       handshakeFirst: true,
     });
+  });
+
+  it("wraps TLS file read failures", async () => {
+    const certPath = join(baseDir, "missing-client.pem");
+    await writeContext("missing-tls", {
+      url: "tls://nats.example.com:4222",
+      cert: certPath,
+    });
+    await expect(loadContextOptions("missing-tls")).rejects.toThrow(
+      NatsContextError,
+    );
+    await expect(loadContextOptions("missing-tls")).rejects.toThrow(
+      `failed to read TLS cert file ${certPath}`,
+    );
   });
 
   it("leaves TLS undefined when none of cert/key/ca/tls_first are set", async () => {

--- a/examples/agent-web-ui/server/config.ts
+++ b/examples/agent-web-ui/server/config.ts
@@ -1,9 +1,10 @@
 // CLI + env parser. Flags beat env beats defaults.
 //
-//   bun run server/index.ts [--port 3300] [--context current]
-//                           [--servers nats://...] [--dev]
+//   bun run server/index.ts [--host 127.0.0.1] [--port 3300]
+//                           [--context current] [--servers nats://...] [--dev]
 
 export type ServerConfig = {
+  host?: string;
   port: number;
   context?: string;
   servers?: string;
@@ -25,6 +26,8 @@ export function parseConfig(argv: string[]): ServerConfig {
   };
   const hasFlag = (name: string): boolean => args.includes(name);
 
+  const host = pickFlag("--host") ?? process.env["AGENT_WEB_UI_HOST"];
+
   const portRaw = pickFlag("--port") ?? process.env["PORT"];
   const port = portRaw ? Number.parseInt(portRaw, 10) : 3300;
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
@@ -42,5 +45,5 @@ export function parseConfig(argv: string[]): ServerConfig {
     ? undefined
     : (contextFlag ?? process.env["NATS_CONTEXT"] ?? "current");
 
-  return { port, context, servers, dev };
+  return { host, port, context, servers, dev };
 }

--- a/examples/agent-web-ui/server/index.ts
+++ b/examples/agent-web-ui/server/index.ts
@@ -52,6 +52,7 @@ const distDir = join(import.meta.dir, "..", "dist");
 const sdkVersionString = formatSdkProtocolVersion(SDK_PROTOCOL_VERSION);
 
 const server = Bun.serve<BridgeWsData>({
+  ...(config.host ? { hostname: config.host } : {}),
   port: config.port,
   async fetch(req, srv) {
     const url = new URL(req.url);
@@ -106,7 +107,9 @@ const server = Bun.serve<BridgeWsData>({
   },
 });
 
-console.log(`[testui] listening on http://localhost:${server.port} (sdk protocol ${sdkVersionString})`);
+console.log(
+  `[testui] listening on http://${config.host ?? "localhost"}:${server.port} (sdk protocol ${sdkVersionString})`,
+);
 if (config.dev) {
   console.log(`[testui] dev mode — open http://localhost:5173 (Vite)`);
 } else if (!existsSync(distDir)) {


### PR DESCRIPTION
## Summary

This makes two small compatibility fixes for Bun/Node clients that use NATS CLI contexts and the agent web UI:

- Load NATS context TLS file paths into standard TLS option contents.
- Add an explicit host bind option for `examples/agent-web-ui`.

## Why

### NATS context
NATS contexts created with:

```bash
nats context add --tlscert ... --tlskey ... --tlsca ...
```

store cert, key, and ca as file paths. The SDK previously passed those through as certFile, keyFile, and caFile. Some runtimes/transports do not consume those helper fields and instead expect the standard TLS options:

tls.cert
tls.key
tls.ca

This caused Bun-based clients using a valid NATS context with client mTLS to fail even though the same context worked with the NATS CLI.

This PR reads the configured TLS files during context loading and passes their contents through standard TLS options. File read failures are wrapped in NatsContextError so context resolution still fails with an SDK-specific error.

### --host acceptance
The agent web UI also documented/accepted --host, but the value was not passed to Bun.serve(). This meant commands like:
NATS_CONTEXT=prod bun run start --host 10.0.1.9

did not actually bind to the requested interface. This PR passes hostname only when explicitly configured, preserving Bun’s default binding behavior otherwise. The app-specific AGENT_WEB_UI_HOST environment variable is also supported.

## Compatibility
This PR keeps the diff intentionally narrow:

- Does not change the NATS context file format.
- Does not disable TLS hostname verification.
- Does not pass hostname to Bun.serve() unless --host / AGENT_WEB_UI_HOST is set.
- Avoids the generic HOST environment variable to prevent platform/CI/container collisions.
- Preserves the existing default server binding behavior.

The main behavior change is that missing or unreadable TLS files now fail during loadContextOptions() instead of later during connect(). Those failures are wrapped as NatsContextError.

## Verification
```bash
bun test client-sdk/typescript/test/unit/context.test.ts

33 pass
0 fail

cd client-sdk/typescript
bun run typecheck
bun run build

cd examples/agent-web-ui
bun run typecheck
bun run build
```

Live smoke checks:
```bash
❯ NATS_CONTEXT=homelab-audit-webui bun run start --host 10.0.1.9
$ bun run server/index.ts --host "10.0.1.9"
[testui] NATS client connected (context=homelab-audit-webui)
[testui] listening on http://10.0.1.9:3300 (sdk protocol 0.3)
```