### PR TITLE
Load NATS context TLS files and honor agent web UI host binding (supersedes #164)

### DIFF
--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -34,6 +34,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   missing / non-string / empty `prompt` and invalid attachments. The pi
   spec-compliance smoke (`agents/pi/test/smoke.mjs`) caught both gaps.
 
+- **`loadContextOptions` now loads the TLS triple's file contents**
+  (the `cert` / `key` / `ca` context fields) into the standard
+  `tls.cert` / `tls.key` / `tls.ca` connection options, instead of
+  passing paths through the Node-only `certFile` / `keyFile` / `caFile`
+  helper fields. Fixes client mTLS on runtimes whose transports don't
+  expand the helper fields (e.g. Bun) — a context created with
+  `nats context add --tlscert/--tlskey/--tlsca` now works everywhere
+  the standard options do. See
+  [#164](https://github.com/synadia-ai/synadia-agents/pull/164).
+
+  Behavior notes:
+
+  - Missing or unreadable TLS files now throw a `NatsContextError`
+    (with `cause`) from `loadContextOptions()` instead of failing
+    later inside `connect()`. This matches how `creds` / `nkey` files
+    are already read eagerly at context-load time, and it turns the
+    "stuck reconnecting on a bad cert path" failure mode (see the
+    0.5.2 behavior notes) into a fast, actionable error.
+  - TLS material is snapshotted at load time. Long-lived processes no
+    longer pick up rotated cert files on reconnect the way the
+    transport's per-attempt `certFile` reads did; call
+    `loadContextOptions()` again (and reconnect) to refresh.
+
 ## [0.5.2] - 2026-05-26
 
 ### Added

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -26,7 +26,7 @@
 //
 // Supported context fields: `url`, `creds` (path), `nkey` (path),
 // `user_jwt` (+ optional `user_seed` for nonce signing), `user`+`password`,
-// `token`, `inbox_prefix`, plus the TLS triple `cert`/`key`/`ca` and
+// `token`, `inbox_prefix`, plus the TLS file triple `cert`/`key`/`ca` and
 // `tls_first`.
 // Skipped: `nsc` integration.
 //
@@ -120,16 +120,16 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   }
 
   // Optional TLS triple. `nats context add --tlscert/--tlskey/--tlsca`
-  // writes file paths; `--tlsfirst` toggles handshake-first.
+  // writes file paths; load them into standard node:tls options.
   const cert = str(parsed["cert"]);
   const key = str(parsed["key"]);
   const ca = str(parsed["ca"]);
   const tlsFirst = parsed["tls_first"];
   if (cert || key || ca || tlsFirst === true) {
     const tls: NonNullable<NodeConnectionOptions["tls"]> = {};
-    if (cert) tls.certFile = expandHome(cert);
-    if (key) tls.keyFile = expandHome(key);
-    if (ca) tls.caFile = expandHome(ca);
+    if (cert) tls.cert = await readTlsFile("cert", expandHome(cert));
+    if (key) tls.key = await readTlsFile("key", expandHome(key));
+    if (ca) tls.ca = await readTlsFile("ca", expandHome(ca));
     if (tlsFirst === true) tls.handshakeFirst = true;
     opts.tls = tls;
   }
@@ -143,6 +143,16 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
 /** Expand a leading `~/` to `$HOME/`. */
 function expandHome(path: string): string {
   return path.startsWith("~/") ? join(homedir(), path.slice(2)) : path;
+}
+
+async function readTlsFile(field: string, path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    throw new NatsContextError(`failed to read TLS ${field} file ${path}`, {
+      cause: error,
+    });
+  }
 }
 
 /**

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -224,6 +224,26 @@ describe("loadContextOptions", () => {
     );
   });
 
+  it("sets handshakeFirst alone when only tls_first is set", async () => {
+    await writeContext("tls-first-only", {
+      url: "tls://nats.example.com:4222",
+      tls_first: true,
+    });
+    const opts = await loadContextOptions("tls-first-only");
+    expect(opts.tls).toEqual({ handshakeFirst: true });
+  });
+
+  it("loads a partial TLS triple (ca only)", async () => {
+    const caPath = join(baseDir, "ca-only.pem");
+    await writeFile(caPath, "ca-only-cert");
+    await writeContext("ca-only", {
+      url: "tls://nats.example.com:4222",
+      ca: caPath,
+    });
+    const opts = await loadContextOptions("ca-only");
+    expect(opts.tls).toEqual({ ca: "ca-only-cert" });
+  });
+
   it("leaves TLS undefined when none of cert/key/ca/tls_first are set", async () => {
     await writeContext("no-tls", { url: "nats://localhost:4222" });
     const opts = await loadContextOptions("no-tls");

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -189,21 +189,41 @@ describe("loadContextOptions", () => {
     expect(opts.token).toBeUndefined();
   });
 
-  it("populates the TLS triple when cert/key/ca/tls_first are present", async () => {
+  it("loads the TLS triple when cert/key/ca/tls_first are present", async () => {
+    const certPath = join(baseDir, "client.pem");
+    const keyPath = join(baseDir, "client.key");
+    const caPath = join(baseDir, "ca.pem");
+    await writeFile(certPath, "client-cert");
+    await writeFile(keyPath, "client-key");
+    await writeFile(caPath, "ca-cert");
     await writeContext("with-tls", {
       url: "tls://nats.example.com:4222",
-      cert: "/etc/ssl/client.pem",
-      key: "/etc/ssl/client.key",
-      ca: "/etc/ssl/ca.pem",
+      cert: certPath,
+      key: keyPath,
+      ca: caPath,
       tls_first: true,
     });
     const opts = await loadContextOptions("with-tls");
     expect(opts.tls).toEqual({
-      certFile: "/etc/ssl/client.pem",
-      keyFile: "/etc/ssl/client.key",
-      caFile: "/etc/ssl/ca.pem",
+      cert: "client-cert",
+      key: "client-key",
+      ca: "ca-cert",
       handshakeFirst: true,
     });
+  });
+
+  it("wraps TLS file read failures", async () => {
+    const certPath = join(baseDir, "missing-client.pem");
+    await writeContext("missing-tls", {
+      url: "tls://nats.example.com:4222",
+      cert: certPath,
+    });
+    await expect(loadContextOptions("missing-tls")).rejects.toThrow(
+      NatsContextError,
+    );
+    await expect(loadContextOptions("missing-tls")).rejects.toThrow(
+      `failed to read TLS cert file ${certPath}`,
+    );
   });
 
   it("leaves TLS undefined when none of cert/key/ca/tls_first are set", async () => {

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -218,9 +218,7 @@ describe("loadContextOptions", () => {
       url: "tls://nats.example.com:4222",
       cert: certPath,
     });
-    await expect(loadContextOptions("missing-tls")).rejects.toThrow(
-      NatsContextError,
-    );
+    await expect(loadContextOptions("missing-tls")).rejects.toThrow(NatsContextError);
     await expect(loadContextOptions("missing-tls")).rejects.toThrow(
       `failed to read TLS cert file ${certPath}`,
     );

--- a/examples/agent-web-ui/README.md
+++ b/examples/agent-web-ui/README.md
@@ -75,11 +75,12 @@ bun run start        # http://localhost:3300
 ## Flags & env
 
 ```
-bun run server/index.ts [--port 3300] [--context current] [--servers nats://...] [--dev]
+bun run server/index.ts [--host 127.0.0.1] [--port 3300] [--context current] [--servers nats://...] [--dev]
 ```
 
 | flag | env | default | meaning |
 |------|-----|---------|---------|
+| `--host <addr>` | `AGENT_WEB_UI_HOST` | Bun default (all interfaces) | Interface to bind the HTTP + WS server to |
 | `--port <n>` | `PORT` | `3300` | HTTP + WS port |
 | `--context <name>` | `NATS_CONTEXT` | `current` | NATS CLI context in `~/.config/nats/context/` |
 | `--servers <url>` | `NATS_URL` | - | Raw NATS URL (overrides context if given) |

--- a/examples/agent-web-ui/server/config.ts
+++ b/examples/agent-web-ui/server/config.ts
@@ -1,9 +1,10 @@
 // CLI + env parser. Flags beat env beats defaults.
 //
-//   bun run server/index.ts [--port 3300] [--context current]
-//                           [--servers nats://...] [--dev]
+//   bun run server/index.ts [--host 127.0.0.1] [--port 3300]
+//                           [--context current] [--servers nats://...] [--dev]
 
 export type ServerConfig = {
+  host?: string;
   port: number;
   context?: string;
   servers?: string;
@@ -25,6 +26,8 @@ export function parseConfig(argv: string[]): ServerConfig {
   };
   const hasFlag = (name: string): boolean => args.includes(name);
 
+  const host = pickFlag("--host") ?? process.env["AGENT_WEB_UI_HOST"];
+
   const portRaw = pickFlag("--port") ?? process.env["PORT"];
   const port = portRaw ? Number.parseInt(portRaw, 10) : 3300;
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
@@ -42,5 +45,5 @@ export function parseConfig(argv: string[]): ServerConfig {
     ? undefined
     : (contextFlag ?? process.env["NATS_CONTEXT"] ?? "current");
 
-  return { port, context, servers, dev };
+  return { host, port, context, servers, dev };
 }

--- a/examples/agent-web-ui/server/index.ts
+++ b/examples/agent-web-ui/server/index.ts
@@ -52,6 +52,7 @@ const distDir = join(import.meta.dir, "..", "dist");
 const sdkVersionString = formatSdkProtocolVersion(SDK_PROTOCOL_VERSION);
 
 const server = Bun.serve<BridgeWsData>({
+  ...(config.host ? { hostname: config.host } : {}),
   port: config.port,
   async fetch(req, srv) {
     const url = new URL(req.url);
@@ -106,7 +107,9 @@ const server = Bun.serve<BridgeWsData>({
   },
 });
 
-console.log(`[testui] listening on http://localhost:${server.port} (sdk protocol ${sdkVersionString})`);
+console.log(
+  `[testui] listening on http://${config.host ?? "localhost"}:${server.port} (sdk protocol ${sdkVersionString})`,
+);
 if (config.dev) {
   console.log(`[testui] dev mode — open http://localhost:5173 (Vite)`);
 } else if (!existsSync(distDir)) {


### PR DESCRIPTION
## Summary

Supersedes #164 — all credit to @escidmore, whose commit is cherry-picked here unchanged (authorship preserved). This PR adds only what was needed to land it on current `main`: a prettier-3.9.5 formatting pass on the new test (the branch predates the pin from #166), the `CHANGELOG.md` entry required for public-SDK-surface changes, and the web-ui README row for the new `--host` flag.

### The fix itself (from #164)

- `loadContextOptions` now reads the TLS triple's file contents (`cert`/`key`/`ca` context fields) into the standard `tls.cert`/`tls.key`/`tls.ca` options instead of passing paths via the Node-only `certFile`/`keyFile`/`caFile` helper fields. `@nats-io/transport-node`'s `loadClientCerts()` supports the contents form first-class, and it's portable to runtimes that never consumed the helper fields (e.g. Bun) — a context created with `nats context add --tlscert/--tlskey/--tlsca` now works everywhere.
- The agent web UI's documented `--host` flag is now actually passed to `Bun.serve()` (plus `AGENT_WEB_UI_HOST`); binding behavior is unchanged unless explicitly set.

### Behavior notes (also in the CHANGELOG)

- Missing/unreadable TLS files now throw `NatsContextError` (with `cause`) at `loadContextOptions()` instead of failing inside `connect()` — consistent with the existing eager reads of `creds`/`nkey` files, and it turns the "stuck reconnecting on a bad cert path" failure mode (0.5.2 behavior notes) into a fast, actionable error.
- TLS material is snapshotted at load time; long-lived processes no longer pick up rotated cert files on reconnect the way per-attempt `certFile` reads did. Re-run `loadContextOptions()` to refresh.
- Repo sweep found no consumers introspecting `tls.certFile`/`keyFile`/`caFile` from `loadContextOptions` output; `agents/pi` and `agents/claude-code` have their own context loaders and are unaffected (they still carry the Bun mTLS limitation — follow-up candidate). The Python SDK rejects TLS-triple contexts as unsupported, so no cross-SDK parity impact.

## Verification (on this branch, current main base)

- `client-sdk/typescript`: `format:check`, `typecheck`, `lint` clean; **254/254 unit** (Node + Bun) and **41 integration** tests pass against a real nats-server.
- `agent-sdk/typescript`: `format:check`, `typecheck`, `lint`, 20/20 unit tests.
- `examples/agent-web-ui`: `typecheck` + `build` clean against the freshly built `file:`-linked SDK (no CI covers this example — verified locally).
- Original live mTLS smoke through a real context: see #164's verification section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)