### PR TITLE
Context-loader follow-ups: consistent errors, agent TLS ports, examples CI

### DIFF
--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Install pi
         working-directory: agents/pi
         run: bun install
-      - name: Unit tests (owner-token precedence)
+      - name: Unit tests (owner-token precedence + context TLS)
         working-directory: agents/pi
-        run: bun test test/owner.test.ts
+        run: bun test test/owner.test.ts test/context.test.ts
       - name: Spec-compliance smoke (spawns its own nats-server)
         working-directory: agents/pi
         run: bun test/smoke.mjs

--- a/.github/workflows/examples-typescript.yml
+++ b/.github/workflows/examples-typescript.yml
@@ -5,6 +5,12 @@ name: CI — examples (TypeScript)
 # here instead of after a release. Typecheck-only by design: the
 # examples talk to live NATS servers / LLM backends, so their runtime
 # behavior is exercised manually (see each example's README).
+#
+# Installs use npm, not bun: bun 1.3.14's resolver is nondeterministic
+# on the client-sdk ⇄ agent-sdk `file:` cycle — it can hang forever or
+# die with SIGILL ("Illegal instruction") after ~7 minutes, on macOS
+# and Linux alike. npm symlinks `file:` deps and is unaffected. Revisit
+# once a bun release fixes cyclic file: resolution.
 
 on:
   push:
@@ -42,17 +48,17 @@ jobs:
           - pi-headless
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
         with:
-          bun-version: latest
+          node-version: 22
       # The examples import the SDKs via `file:` links, which resolve to
       # each package's built `dist/` — build both before installing.
       - name: Build client-sdk
         working-directory: client-sdk/typescript
-        run: bun install && bun run build
+        run: npm install --no-audit --no-fund && npm run build
       - name: Build agent-sdk
         working-directory: agent-sdk/typescript
-        run: bun install && bun run build
+        run: npm install --no-audit --no-fund && npm run build
       - name: Typecheck
         working-directory: examples/${{ matrix.example }}
-        run: bun install && bun run typecheck
+        run: npm install --no-audit --no-fund && npm run typecheck

--- a/.github/workflows/examples-typescript.yml
+++ b/.github/workflows/examples-typescript.yml
@@ -1,0 +1,58 @@
+name: CI — examples (TypeScript)
+
+# Typecheck smoke for the runnable examples. They all `file:`-link the
+# local SDKs, so an SDK surface change that breaks an example shows up
+# here instead of after a release. Typecheck-only by design: the
+# examples talk to live NATS servers / LLM backends, so their runtime
+# behavior is exercised manually (see each example's README).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "client-sdk/typescript/**"
+      - "agent-sdk/typescript/**"
+      - ".github/workflows/examples-typescript.yml"
+  pull_request:
+    paths:
+      - "examples/**"
+      - "client-sdk/typescript/**"
+      - "agent-sdk/typescript/**"
+      - ".github/workflows/examples-typescript.yml"
+
+concurrency:
+  group: ci-examples-ts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: examples/${{ matrix.example }} (typecheck)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - agent-web-ui
+          - claude-code-headless
+          - dspy
+          - dspy-research-agent
+          - durable-agents
+          - open-agent-vercel
+          - pi-headless
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      # The examples import the SDKs via `file:` links, which resolve to
+      # each package's built `dist/` — build both before installing.
+      - name: Build client-sdk
+        working-directory: client-sdk/typescript
+        run: bun install && bun run build
+      - name: Build agent-sdk
+        working-directory: agent-sdk/typescript
+        run: bun install && bun run build
+      - name: Typecheck
+        working-directory: examples/${{ matrix.example }}
+        run: bun install && bun run typecheck

--- a/.github/workflows/examples-typescript.yml
+++ b/.github/workflows/examples-typescript.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Build agent-sdk
         working-directory: agent-sdk/typescript
         run: npm install --no-audit --no-fund && npm run build
+      # open-agent-vercel file:-links agents/open-agent and path-aliases
+      # into its vendored sources, whose `ai`/`zod` imports resolve from
+      # that agent's own node_modules — install it first.
+      - name: Install agents/open-agent deps
+        if: matrix.example == 'open-agent-vercel'
+        working-directory: agents/open-agent
+        run: npm install --no-audit --no-fund
       - name: Typecheck
         working-directory: examples/${{ matrix.example }}
         run: npm install --no-audit --no-fund && npm run typecheck

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -231,7 +231,7 @@ function readTlsFile(field: string, path: string): string {
   try {
     return readFileSync(path, 'utf8')
   } catch (err) {
-    throw new Error(`failed to read TLS ${field} file ${path} (${(err as Error).message})`)
+    throw new Error(`failed to read TLS ${field} file ${path}`, { cause: err })
   }
 }
 

--- a/agents/claude-code/server.ts
+++ b/agents/claude-code/server.ts
@@ -206,13 +206,18 @@ function contextToConnectOpts(ctx: NatsContext): NodeConnectionOptions {
     opts.authenticator = usernamePasswordAuthenticator(urlOpts.user, urlOpts.pass ?? '')
   }
 
-  if (ctx.cert || ctx.key || ctx.ca) {
-    opts.tls = {
-      certFile: ctx.cert || undefined,
-      keyFile: ctx.key || undefined,
-      caFile: ctx.ca || undefined,
-      handshakeFirst: ctx.tls_first || undefined,
-    }
+  // TLS triple: the context stores file *paths*; load their contents into
+  // the standard `tls.cert`/`key`/`ca` options rather than passing the
+  // Node-only `certFile`/`keyFile`/`caFile` helper fields, so mTLS
+  // contexts work on runtimes whose transports don't expand the helper
+  // fields (e.g. Bun). Mirrors the SDK's `loadContextOptions`.
+  if (ctx.cert || ctx.key || ctx.ca || ctx.tls_first) {
+    const tls: NonNullable<NodeConnectionOptions['tls']> = {}
+    if (ctx.cert) tls.cert = readTlsFile('cert', ctx.cert)
+    if (ctx.key) tls.key = readTlsFile('key', ctx.key)
+    if (ctx.ca) tls.ca = readTlsFile('ca', ctx.ca)
+    if (ctx.tls_first) tls.handshakeFirst = true
+    opts.tls = tls
   }
 
   if (ctx.inbox_prefix) {
@@ -220,6 +225,14 @@ function contextToConnectOpts(ctx: NatsContext): NodeConnectionOptions {
   }
 
   return opts
+}
+
+function readTlsFile(field: string, path: string): string {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (err) {
+    throw new Error(`failed to read TLS ${field} file ${path} (${(err as Error).message})`)
+  }
 }
 
 // ── Session name resolution ────────────────────────────────────────────

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -244,7 +244,7 @@ function readTlsFile(field: string, path: string): string {
 	try {
 		return readFileSync(path, "utf8");
 	} catch (err) {
-		throw new Error(`failed to read TLS ${field} file ${path} (${(err as Error).message})`);
+		throw new Error(`failed to read TLS ${field} file ${path}`, { cause: err });
 	}
 }
 

--- a/agents/pi/extensions/nats-channel.ts
+++ b/agents/pi/extensions/nats-channel.ts
@@ -122,7 +122,8 @@ type PiNatsConfig = {
 };
 
 // Matches NATS CLI context files at ~/.config/nats/context/<name>.json.
-type NatsContext = {
+// Exported for unit tests (test/context.test.ts).
+export type NatsContext = {
 	description?: string;
 	url?: string;
 	token?: string;
@@ -188,7 +189,8 @@ function loadNatsContext(name: string): NatsContext {
 	}
 }
 
-function contextToConnectOpts(ctx: NatsContext): NodeConnectionOptions {
+// Exported for unit tests (test/context.test.ts).
+export function contextToConnectOpts(ctx: NatsContext): NodeConnectionOptions {
 	const opts: NodeConnectionOptions = { name: "pi-nats-channel" };
 
 	// Parse the URL once; extracted userinfo serves as a fallback only when
@@ -219,18 +221,31 @@ function contextToConnectOpts(ctx: NatsContext): NodeConnectionOptions {
 		opts.authenticator = usernamePasswordAuthenticator(urlOpts.user, urlOpts.pass ?? "");
 	}
 
-	if (ctx.cert || ctx.key || ctx.ca) {
-		opts.tls = {
-			certFile: ctx.cert || undefined,
-			keyFile: ctx.key || undefined,
-			caFile: ctx.ca || undefined,
-			handshakeFirst: ctx.tls_first || undefined,
-		};
+	// TLS triple: the context stores file *paths*; load their contents into
+	// the standard `tls.cert`/`key`/`ca` options rather than passing the
+	// Node-only `certFile`/`keyFile`/`caFile` helper fields, so mTLS
+	// contexts work on runtimes whose transports don't expand the helper
+	// fields (e.g. Bun). Mirrors the SDK's `loadContextOptions`.
+	if (ctx.cert || ctx.key || ctx.ca || ctx.tls_first) {
+		const tls: NonNullable<NodeConnectionOptions["tls"]> = {};
+		if (ctx.cert) tls.cert = readTlsFile("cert", ctx.cert);
+		if (ctx.key) tls.key = readTlsFile("key", ctx.key);
+		if (ctx.ca) tls.ca = readTlsFile("ca", ctx.ca);
+		if (ctx.tls_first) tls.handshakeFirst = true;
+		opts.tls = tls;
 	}
 
 	if (ctx.inbox_prefix) opts.inboxPrefix = ctx.inbox_prefix;
 
 	return opts;
+}
+
+function readTlsFile(field: string, path: string): string {
+	try {
+		return readFileSync(path, "utf8");
+	} catch (err) {
+		throw new Error(`failed to read TLS ${field} file ${path} (${(err as Error).message})`);
+	}
 }
 
 function loadConfig(): PiNatsConfig {

--- a/agents/pi/test/context.test.ts
+++ b/agents/pi/test/context.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for contextToConnectOpts TLS handling.
+//
+// NATS CLI contexts store cert/key/ca as file *paths*; the loader must
+// read their contents into the standard `tls.cert`/`key`/`ca` options
+// (portable across runtimes — Bun's transport never consumed the
+// Node-only `certFile`/`keyFile`/`caFile` helper fields) rather than
+// passing the paths through. Mirrors the SDK's `loadContextOptions`
+// semantics, including `tls_first` alone producing `handshakeFirst`
+// with no file reads.
+//
+// Run with: bun test test/context.test.ts
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { contextToConnectOpts } from "../extensions/nats-channel.ts";
+
+let baseDir: string;
+
+beforeAll(() => {
+	baseDir = mkdtempSync(join(tmpdir(), "pi-nats-ctx-"));
+});
+
+afterAll(() => {
+	rmSync(baseDir, { recursive: true, force: true });
+});
+
+test("loads TLS file contents into standard tls options", () => {
+	const certPath = join(baseDir, "client.pem");
+	const keyPath = join(baseDir, "client.key");
+	const caPath = join(baseDir, "ca.pem");
+	writeFileSync(certPath, "client-cert");
+	writeFileSync(keyPath, "client-key");
+	writeFileSync(caPath, "ca-cert");
+	const opts = contextToConnectOpts({
+		url: "tls://nats.example.com:4222",
+		cert: certPath,
+		key: keyPath,
+		ca: caPath,
+		tls_first: true,
+	});
+	expect(opts.tls).toEqual({
+		cert: "client-cert",
+		key: "client-key",
+		ca: "ca-cert",
+		handshakeFirst: true,
+	});
+});
+
+test("loads a partial TLS triple (ca only)", () => {
+	const caPath = join(baseDir, "ca-only.pem");
+	writeFileSync(caPath, "ca-only-cert");
+	const opts = contextToConnectOpts({
+		url: "tls://nats.example.com:4222",
+		ca: caPath,
+	});
+	expect(opts.tls).toEqual({ ca: "ca-only-cert" });
+});
+
+test("sets handshakeFirst alone when only tls_first is set", () => {
+	const opts = contextToConnectOpts({
+		url: "tls://nats.example.com:4222",
+		tls_first: true,
+	});
+	expect(opts.tls).toEqual({ handshakeFirst: true });
+});
+
+test("throws a clear error when a TLS file is missing", () => {
+	const certPath = join(baseDir, "missing-client.pem");
+	expect(() =>
+		contextToConnectOpts({
+			url: "tls://nats.example.com:4222",
+			cert: certPath,
+		}),
+	).toThrow(`failed to read TLS cert file ${certPath}`);
+});
+
+test("leaves tls undefined when no TLS fields are set", () => {
+	const opts = contextToConnectOpts({ url: "nats://localhost:4222" });
+	expect(opts.tls).toBeUndefined();
+});

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -13,6 +13,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Missing or unreadable `creds` / `nkey` files now throw a
+  `NatsContextError`** (with the original filesystem error as `cause`)
+  from `loadContextOptions()`, matching the TLS triple's error handling
+  below, instead of letting the raw `ENOENT` escape. Code that matched
+  `err.code === "ENOENT"` on the thrown error should inspect
+  `err.cause` instead.
+- Documented in `src/context.ts` that file-path context fields
+  (`creds`, `nkey`, `cert` / `key` / `ca`) expand a leading `~/` and
+  otherwise resolve relative to the process working directory (as the
+  `nats` CLI does), not the context file's directory. Behavior is
+  unchanged — it was just never written down.
+
 ### Fixed
 
 - **`decodeEnvelope` now follows the §5.3 discrimination algorithm

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -30,6 +30,11 @@
 // `tls_first`.
 // Skipped: `nsc` integration.
 //
+// File-path fields (`creds`, `nkey`, and the TLS triple) expand a leading
+// `~/` to the home directory; any other relative path resolves against the
+// process working directory (as the `nats` CLI does), not the context
+// file's directory.
+//
 // Precedence inside a context: `creds` > `nkey` > `user_jwt` (+`user_seed`
 // when present) > `user`/`password` > `token`.
 //
@@ -89,7 +94,7 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
   const userJwt = str(parsed["user_jwt"]);
   const userSeed = str(parsed["user_seed"]);
   if (creds) {
-    const bytes = await readFile(expandHome(creds));
+    const bytes = await readAuthFile("creds", expandHome(creds));
     opts.authenticator = credsAuthenticator(
       new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
     );
@@ -97,7 +102,7 @@ export async function loadContextOptions(selector: string): Promise<NodeConnecti
     // `nats context add` writes `nkey` as a path to a file containing the
     // raw seed. Read it once and pass through `nkeyAuthenticator`, which
     // signs the server nonce on each CONNECT.
-    const bytes = await readFile(expandHome(nkey));
+    const bytes = await readAuthFile("nkey", expandHome(nkey));
     opts.authenticator = nkeyAuthenticator(
       new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
     );
@@ -150,6 +155,16 @@ async function readTlsFile(field: string, path: string): Promise<string> {
     return await readFile(path, "utf8");
   } catch (error) {
     throw new NatsContextError(`failed to read TLS ${field} file ${path}`, {
+      cause: error,
+    });
+  }
+}
+
+async function readAuthFile(field: string, path: string): Promise<Buffer> {
+  try {
+    return await readFile(path);
+  } catch (error) {
+    throw new NatsContextError(`failed to read ${field} file ${path}`, {
       cause: error,
     });
   }

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -148,6 +148,30 @@ describe("loadContextOptions", () => {
     expect(opts.token).toBeUndefined();
   });
 
+  it("wraps creds file read failures", async () => {
+    const credsPath = join(baseDir, "missing.creds");
+    await writeContext("missing-creds", {
+      url: "nats://localhost:4222",
+      creds: credsPath,
+    });
+    await expect(loadContextOptions("missing-creds")).rejects.toThrow(NatsContextError);
+    await expect(loadContextOptions("missing-creds")).rejects.toThrow(
+      `failed to read creds file ${credsPath}`,
+    );
+  });
+
+  it("wraps nkey file read failures", async () => {
+    const nkeyPath = join(baseDir, "missing.nk");
+    await writeContext("missing-nkey", {
+      url: "nats://localhost:4222",
+      nkey: nkeyPath,
+    });
+    await expect(loadContextOptions("missing-nkey")).rejects.toThrow(NatsContextError);
+    await expect(loadContextOptions("missing-nkey")).rejects.toThrow(
+      `failed to read nkey file ${nkeyPath}`,
+    );
+  });
+
   it("uses inline user_jwt + user_seed when both are present", async () => {
     await writeContext("with-jwt-seed", {
       url: "nats://localhost:4222",

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -44,6 +44,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
+    "@earendil-works/pi-ai": "^0.79.1",
     "@earendil-works/pi-coding-agent": "latest",
     "@nats-io/services": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",


### PR DESCRIPTION
## Summary

Sweeps the follow-up list from the #164/#167 investigation. Independent pieces, one commit each:

### 1. `client-sdk`: consistent context-load failures (`a2be41b`)
- `creds`/`nkey` read failures now throw `NatsContextError` with the filesystem error as `cause`, matching the TLS triple from #167 — previously raw `ENOENT` escaped `loadContextOptions()`. Callers matching `err.code === "ENOENT"` should inspect `err.cause` (CHANGELOG'd under `[Unreleased] > Changed`).
- Documented the path-resolution rules in the module header (leading `~/` expands; other relative paths resolve against process CWD, as the `nats` CLI does — the footgun the #167 review flagged). Behavior unchanged, now written down.

### 2. `agents/pi` + `agents/claude-code`: TLS contents port (`6db6355`, `378db05`)
The two hand-rolled context loaders still passed `certFile`/`keyFile`/`caFile` — Node-only helper fields Bun's transport never consumed — so mTLS contexts failed there even after #167 fixed the SDK. Both now read PEM contents into standard `tls.cert`/`key`/`ca` (forwarding the original read error as `cause`, per review), and both fix a shared latent gap: `tls_first` **alone** previously never produced `handshakeFirst` (the guard ignored it without cert/key/ca).

PI's loader is now exported and covered by a new 5-case `test/context.test.ts`, wired into the CI unit-test step. claude-code has no test infra; its port is line-for-line the SDK's typechecked pattern and passes a parse check.

Not in scope (tracked in the follow-up issue): migrating these loaders to the SDK's `loadContextOptions`, their `user_jwt`-without-seed gap, and their missing `~/` expansion. The other five agents already use the SDK loader and get the fix via the next SDK release + bump.

### 3. CI for `examples/*` (`6d0a844`, `340867a`, `901d931`)
`examples/*` had zero CI. New `examples-typescript.yml` builds both `file:`-linked SDKs and typechecks each of the seven examples, on changes to `examples/**` or either SDK. This PR itself proves the gap: **`pi-headless` was silently broken on main** — it imports `@earendil-works/pi-ai` without declaring it (worked only via transitive hoisting that clean installs no longer provide). Declared aligned with `pi-coding-agent`'s own range (`^0.79.1`). The `open-agent-vercel` job additionally installs `agents/open-agent`'s deps, since that example's tsconfig path-aliases into the agent's vendored sources.

**The workflow installs with npm, not bun** — and this PR's own first CI run is the evidence: `bun install` in the agent-sdk step stalled ~7 minutes and died with `Illegal instruction (core dumped)` (exit 132) in 4 of 7 identical concurrent jobs ([the run](https://github.com/synadia-ai/synadia-agents/actions/runs/29242174408)), while the same step passed elsewhere. Combined with the local macOS behavior below, bun 1.3.14's resolver is **nondeterministic on the client-sdk ⇄ agent-sdk `file:` cycle — cross-platform**: it can succeed, hang forever, or crash. npm symlinks `file:` deps and resolves the same graph in seconds.

## Verification

- client-sdk: format/typecheck/lint clean, **258/258 unit**, **41 integration** against a real nats-server; agent-sdk suite clean (fires on client-sdk src changes).
- agents/pi: **14/14 unit** (owner + new context tests), **13/13 spec smoke**.
- All **seven examples typecheck** (pi-headless after the dep fix); the workflow validates itself on this PR.

## Heads-up for anyone installing locally

The bun bug above bites dev machines too: on macOS, `bun install` **hangs forever** (~100% CPU, threads parked in `kevent64`) in any package needing fresh resolution of the SDK `file:` cycle — which since the #166 prettier pin staled every dependent lockfile means effectively all of them (agents/pi, examples/*). Latest bun (1.3.14) is affected; there is no newer release. Working fallback: `rm -rf node_modules && npm install`, keep bun as the runtime; don't commit the resulting `package-lock.json`, and note npm runs postinstall scripts bun blocks (the Ax packages drop `.claude/skills/` dirs into `examples/dspy*` — delete them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)