### PR TITLE
docs(durable-agents): per-chapter READMEs as a guided tour

### DIFF
--- a/examples/durable-agents/README.md
+++ b/examples/durable-agents/README.md
@@ -17,9 +17,16 @@ durable function.
 | Path | What it shows | Infra |
 | --- | --- | --- |
 | [`src/minimal/`](./src/minimal) | **Durability in ~10 lines** — a plain agent loop made durable with nothing but two `yield* ctx.run(...)` wraps. Native Resonate SDK, no abstraction. | none |
+| [`src/core/`](./src/core) | The **shared engine-neutral core** the agents below run on — the effects loop, the Resonate driver, the LLM client, the front-door. Library code, nothing to run. | — |
 | [`src/sre/`](./src/sre) | A concrete **SRE agent** (metrics → restart-with-approval → notify) on a thin **durable-execution abstraction**, run as a real Synadia agent with human approval surfaced as an in-chat query. | NATS + resonate-on-nats |
 | [`src/coding/`](./src/coding) | A **coding agent** ("durable Claude Code") — the _same_ abstraction, a different tool-set: sandboxed read/list/grep/write + an approval-gated `run_bash`. Proves "one loop, many agents." | NATS + resonate-on-nats |
 | [`src/crash/`](./src/crash) | The **crash-replay proof** — kill a worker mid-task, restart it, and verify the pre-crash model turn + tool were replayed, not re-run. | NATS + resonate-on-nats |
+
+Each directory has its own README, and they read **in order** — a guided tour from the bare trick
+to the verified proof:
+[**1 · minimal**](./src/minimal/README.md) → [**2 · core**](./src/core/README.md) →
+[**3 · sre**](./src/sre/README.md) → [**4 · coding**](./src/coding/README.md) →
+[**5 · crash**](./src/crash/README.md)
 
 ## The one idea
 

--- a/examples/durable-agents/src/coding/README.md
+++ b/examples/durable-agents/src/coding/README.md
@@ -1,0 +1,89 @@
+# 4 · coding — "durable Claude Code"
+
+> **Durable-agents tour, chapter 4 of 5**
+> [overview](../../README.md) · [minimal](../minimal/README.md) · [core](../core/README.md) · [sre](../sre/README.md) · **coding** · [crash](../crash/README.md)
+
+The same [core](../core/README.md) — loop, driver, LLM client, front-door — with a different
+tool-set: a coding agent that works inside a sandboxed directory and needs human approval to run
+shell commands. Diff this chapter against [sre](../sre/README.md) and you'll find the entire
+difference is one persona file plus names: **one loop, many agents.**
+
+## The tool-set ([`agent.ts`](./agent.ts))
+
+| Tool | What it does | Durable shape |
+| --- | --- | --- |
+| `list_dir` | list a directory in the sandbox | plain step |
+| `read_file` | read a file in the sandbox | plain step |
+| `grep` | recursive search in the sandbox (output capped at 4 kB) | plain step |
+| `write_file` | create/overwrite a file (parent dirs auto-created) | plain step |
+| `run_bash` | run a shell command, sandbox as cwd, 15 s timeout, output capped at 4 kB | **`dangerous: true`** → human approval first |
+
+Safety is deliberate and small: every path goes through `safe()`, which resolves it inside the
+sandbox root and rejects traversal (`path escapes sandbox`); `grep` and `run_bash` execute with
+the sandbox as their working directory. A real deployment would also allow-list commands — the
+source says so out loud.
+
+## Why durability matters for a coding agent
+
+A coding agent is mid-task state *par excellence*: it has written three files and is about to run
+the build when the host dies. On restart in the same worker group, the run resumes from the
+journal — completed `write_file` and `run_bash` steps **never re-fire**, finished model turns are
+**never re-billed**, and the approval that let `run_bash` through is journaled like everything
+else. Restarting mid-refactor is safe by construction.
+
+## Run it
+
+Offline smoke — in-memory Resonate, deterministic stub, a throwaway temp-dir sandbox,
+auto-approval:
+
+```sh
+bun run coder:offline
+```
+
+```
+▶ coding agent (durable brain, offline; sandbox …/de-coder-XXXXXX):
+   · write_file  [key=tool-0-0]
+   · read_file  [key=tool-1-0]
+   🔔 approval requested: {"name":"run_bash","args":{"cmd":"wc -c greeting.txt"}} → approving
+   · run_bash  [key=tool-2-0]
+
+🧠 answer: Done: wrote greeting.txt, read it back, and measured it with wc.
+   tool executions: {"write_file":1,"read_file":1,"run_bash":1}
+✅ tools executed as scripted (write, read, approval-gated bash)
+```
+
+Live — with the [same infrastructure as chapter 3](../sre/README.md#live--a-real-synadia-agent-servets)
+(`nats-server -js` + `resonate-on-nats serve`):
+
+```sh
+bun run coder:serve                                           # agent type `durable-coder`
+AGENT=durable-coder bun run prompt "add hello.py and run it"  # in another terminal
+```
+
+(Set `AGENT` — the caller falls back to the *first* agent it discovers when the requested type
+isn't found, which may be your SRE agent from chapter 3.)
+
+The serve process uses `./coding-sandbox/` at the package root as its sandbox (override with
+`CODING_SANDBOX=/path`); the offline smoke always uses a fresh temp dir. For a real brain, pick a
+coding-capable local model:
+
+```sh
+LLM_BACKEND=ollama OLLAMA_MODEL=qwen3.6:35b-mlx bun run coder:serve
+```
+
+## Things to try
+
+- **Deny the bash step**: `APPROVE=no AGENT=durable-coder bun run prompt` — `run_bash` never
+  executes. (Same caveat as chapter 3: the stub's script doesn't react to the denial; a real
+  backend does.)
+- **Kill `coder:serve` mid-task and restart it** (same `RESONATE_GROUP`, default
+  `coder-workers`): the run resumes from the journal — a completed `write_file` or `run_bash`
+  never re-fires, exactly like the [crash-replay proof](../crash/README.md).
+- **Grow the persona**: add a `delete_file` tool to [`agent.ts`](./agent.ts) and decide whether
+  it's `dangerous`. One `Tool` entry is the entire cost of a new capability — the loop, journal,
+  and approval plumbing come for free.
+
+## Next
+
+**[5 · crash →](../crash/README.md)** — stop taking "resumes from the journal" on faith: kill a
+worker mid-task and *prove* the replay.

--- a/examples/durable-agents/src/core/README.md
+++ b/examples/durable-agents/src/core/README.md
@@ -1,0 +1,119 @@
+# 2 · core — the engine-neutral agent core
+
+> **Durable-agents tour, chapter 2 of 5**
+> [overview](../../README.md) · [minimal](../minimal/README.md) · **core** · [sre](../sre/README.md) · [coding](../coding/README.md) · [crash](../crash/README.md)
+
+Everything the remaining chapters run is assembled from the five files in this directory. The
+design has one goal: **the agent loop is written once and knows nothing about any
+durable-execution engine.** It yields plain effect descriptors; a small per-engine driver
+interprets them. Supporting another DE framework later means writing one more ~15-line driver —
+the agent itself never changes.
+
+| File | Role |
+| --- | --- |
+| [`effects.ts`](./effects.ts) | `agentLoop` — the engine-neutral loop; yields `step` / `signal` effects |
+| [`resonate.ts`](./resonate.ts) | `driveResonate` — the **only** Resonate-aware code in the suite |
+| [`llm.ts`](./llm.ts) | a one-turn, non-streaming LLM client: deterministic stub / OpenRouter / Ollama |
+| [`frontdoor.ts`](./frontdoor.ts) | `serveAgent` — the non-durable Synadia-agent front-door + approval bridge |
+| [`subjects.ts`](./subjects.ts) | the single shared NATS subject (approval announcements) |
+
+There is nothing to run in this chapter — every later chapter executes this code.
+
+## Two effects are the whole durable vocabulary
+
+```ts
+export type Effect =
+  | { t: "step";   name: string; run: (key: string) => Promise<unknown> }
+  | { t: "signal"; name: string; timeoutMs?: number; ask?: unknown };
+```
+
+- **`step`** — anything nondeterministic or side-effecting: a model turn, a tool call. The `name`
+  (`llm-0`, `tool-1-0`, …) is stable across replays and doubles as the step's **idempotency
+  key**: it's passed into the tool as `run(args, key)` so a real side effect can forward it to
+  at-least-once infrastructure (the SRE `restart_service` tool echoes it back to make that visible).
+- **`signal`** — wait for the outside world, i.e. a human approval. The loop parks until someone
+  resolves it with `{ approved: boolean }`.
+
+Why a generator and not an `async/await` interface? Resonate is generator-based (`yield*`), so
+the shared layer can't be `async` — and yielding inert descriptors is precisely what keeps the
+loop free of engine imports.
+
+## `effects.ts` — the loop
+
+[`agentLoop`](./effects.ts) holds the transcript (`system` + `user` to start) and runs up to
+`maxSteps` (default 8) turns:
+
+1. **REASON** — yield a `step` named `llm-<n>` that calls `llm.decide(messages, tools)`. If the
+   decision contains no tool calls, the loop returns `{ answer, steps }` — done.
+2. **ACT** — for each requested tool call:
+   - unknown tool → an error message goes back into the transcript (the model gets to react);
+   - a tool marked `dangerous: true` → first yield a `signal` named `approve-<step>-<i>`
+     carrying `{ name, args }`; a denial pushes `"✗ denied by human"` into the transcript and
+     the loop moves on — with a real backend, the model sees the denial and adapts;
+   - then yield a `step` named `tool-<step>-<i>` that runs the tool.
+
+The loop only ever advances on values fed back from durable ops, so on replay it re-yields the
+identical effect sequence. The one rule, verbatim from the source: *no raw nondeterminism
+(`Date.now` / `Math.random` / I/O) between yields.*
+
+## `resonate.ts` — the driver
+
+The only Resonate-aware code. It steps the generator and pattern-matches each effect:
+
+```ts
+if (eff.t === "step") {
+  fed = yield* ctx.run(() => eff.run(eff.name));          // journaled once, replayed thereafter
+  hooks?.afterStep?.(eff.name);                            // observability (the crash demo's trigger)
+} else {
+  const p = yield* ctx.promise<{ approved: boolean }>();   // a durable promise
+  yield* ctx.run(() => notify(eff.name, p.id, eff.ask));   // announce it — as a step, so a replay
+  fed = yield* p;                                          //   won't re-announce; then park
+}
+```
+
+`notify` is how a parked approval reaches the world: in serve mode it publishes
+`{ promiseId, ask }` on `de-agent.approval.<runId>` ([`subjects.ts`](./subjects.ts)), and anyone
+holding the id can settle it via `resonate.promises.resolve(...)`. Pointing the same agent at a
+different durable-execution framework means writing one more file shaped like this one.
+
+## `llm.ts` — one turn, no streaming
+
+The loop owns the agentic while-loop, so the client doesn't loop: it exposes a single awaitable
+turn, `decide(messages, tools) → { content, toolCalls }`. It is non-streaming **by design** — a
+durable step journals a *value*, and replay returns the recorded turn instead of re-calling (and
+re-billing) the model. Token streaming, when wanted, belongs in the non-durable front-door as a
+best-effort channel; it never rides the journal. `ChatMessage` is plain JSON for the same reason:
+every transcript entry must round-trip the journal.
+
+Backend selection is env-driven; the deterministic per-agent stub is the fallback so demos and
+the crash proof are reproducible:
+
+| Env | Effect |
+| --- | --- |
+| `OPENROUTER_API_KEY` | use OpenRouter (`OPENROUTER_MODEL`, default `openai/gpt-4o-mini`) |
+| `LLM_BACKEND` | force `openrouter` or `ollama`; unset → key ⇒ OpenRouter, else the stub |
+| `OLLAMA_URL` / `OLLAMA_MODEL` | Ollama endpoint + model (defaults `http://localhost:11434`, `llama3.1:8b`) |
+| `LLM_TIMEOUT_MS` | per-call abort (default 60 000) so a hung model can't stall a durable step forever |
+
+## `frontdoor.ts` — the non-durable face
+
+`serveAgent(cfg)` turns a registered durable workflow into a real Synadia agent using
+[`AgentService`](../../../../agent-sdk/typescript) (registration, heartbeats every 10 s). On each
+prompt it:
+
+1. mints a **dotless** run id `<agent>-<instanceId>-<seq>` (in Resonate a dot denotes
+   parent/child lineage, so a root id must not contain one) and dispatches `beginRun`;
+2. subscribes to that run's approval subject; each announcement becomes a §7 **query** — the
+   protocol's mid-stream question to the caller — `⏸ Approve \`tool(args)\`? (yes/no)`. An
+   affirmative reply (`y/yes/approve/allow/ok/true`) resolves the durable promise with
+   `{ approved: true }`; anything else, or no reply within `approvalTimeoutMs` (default 5 min),
+   denies;
+3. awaits `handle.result()` and sends the answer back down the stream.
+
+It is deliberately **not** durable: session and transport are ephemeral, the brain is journaled.
+The approval gate lives in the journal — the in-chat query is just its live face.
+
+## Next
+
+**[3 · sre →](../sre/README.md)** — the first real agent built on this core: an SRE persona on
+live NATS, with the approval surfacing in chat.

--- a/examples/durable-agents/src/crash/README.md
+++ b/examples/durable-agents/src/crash/README.md
@@ -1,0 +1,98 @@
+# 5 · crash — the crash-replay proof
+
+> **Durable-agents tour, chapter 5 of 5**
+> [overview](../../README.md) · [minimal](../minimal/README.md) · [core](../core/README.md) · [sre](../sre/README.md) · [coding](../coding/README.md) · **crash**
+
+The headline demo. Every earlier chapter *claims* that a durable agent survives a crash without
+re-calling the model or re-firing a side effect — this one **proves** it: it hard-kills a worker
+mid-task, restarts it, and verifies from an execution log that the pre-crash work was *replayed*
+from the journal, not re-run.
+
+Two files:
+
+- [`worker.ts`](./worker.ts) — a headless durable worker running the [SRE persona](../sre/agent.ts)
+  with an auto-approver (no human in this proof). In `PHASE=1` it crashes on cue; in `PHASE=2` it
+  rejoins the same group and finishes the run.
+- [`demo.ts`](./demo.ts) — spawns phase 1, then phase 2, then reads the log and prints a verdict.
+
+## The choreography
+
+| Durable step | Phase 1 | Phase 2 |
+| --- | --- | --- |
+| `llm-0` — decide | **executed** + journaled | replayed |
+| `tool-0-0` — `get_metrics` | **executed** + journaled, then 💥 `process.exit(137)` | replayed |
+| `llm-1` — decide | — | **executed** |
+| `approve-1-0` — restart approval | — | auto-approved |
+| `tool-1-0` — `restart_service` | — | **executed** |
+| `llm-2` — decide | — | **executed** |
+| `tool-2-0` — `send_notification` | — | **executed** |
+| `llm-3` — final answer | — | **executed** |
+
+Phase 1 dispatches the run and dies the instant `get_metrics` is journaled — the crash trigger is
+the driver's `afterStep` hook ([`core/resonate.ts`](../core/resonate.ts)) firing on the step name
+`tool-0-0` (the name [`core/effects.ts`](../core/effects.ts) gives the first tool call). Exit code
+137 is the classic SIGKILL code: a worker death, not a graceful shutdown.
+
+Phase 2 starts a fresh worker in the **same group** (`sre-crash`) with the **same run id** —
+`beginRun` with an existing id attaches to the run instead of starting a new one. The worker was
+created with a short dispatch lease (`ttl: 5000`, instead of the default of about a minute) so the
+server notices the orphaned run within seconds and re-dispatches it. The generator then restarts
+from the top: the journaled `llm-0` and `tool-0-0` fast-forward — their recorded results return
+without the functions being invoked — and live execution resumes at `llm-1`.
+
+## How "real vs replayed" is measured
+
+Every **real** execution appends a line to a JSONL log (`$TMPDIR/de-crash-exec.jsonl`): the LLM
+client is wrapped to log each actual `decide`, and the tools log via their `onCall` hook. A
+replayed step returns its journaled value **without invoking the function**, so it leaves no
+trace in the log — absence of a phase-2 `get_metrics` line *is* the proof. The stub brain keeps
+the whole thing deterministic: same crash point, same counts, every run.
+
+## Run it
+
+Needs the [chapter-3 infrastructure](../sre/README.md#live--a-real-synadia-agent-servets) —
+`nats-server -js` and `resonate-on-nats serve` (the journal that survives the crash lives in
+JetStream). Then:
+
+```sh
+bun run crash
+```
+
+```
+phase 1 executed:  decide, get_metrics
+phase 2 executed:  decide, restart_service, decide, send_notification, decide
+real LLM calls: 4  ·  get_metrics: 1  ·  restart_service: 1  ·  send_notification: 1
+
+✅ REPLAY PROVEN
+   • the pre-crash model turn + get_metrics were REPLAYED from the journal in phase 2, not re-run
+   • the model was billed 4× total across the crash (not 5×+); get_metrics fired exactly once
+   • restart_service and send_notification each fired exactly once — no double side effects
+```
+
+The verdict asserts exactly: 4 real LLM calls total, each tool fired exactly once, and no
+`get_metrics` in phase 2. The process exits non-zero if any of that fails.
+
+**Why 4 and not 5+?** Without a journal, restarting means starting over: `llm-0` and
+`get_metrics` run again — at least 5 model calls, and every already-fired side effect fires
+twice. With tools like `restart_service` or `send_notification`, that's not just a billing bug —
+it's a second production restart and a duplicate page.
+
+## Details worth stealing
+
+- **Dotless run ids** — in Resonate a dot denotes parent/child lineage, so root ids are minted
+  dot-free (`sre-crash-<timestamp>`).
+- **Short leases for fast failover** — `ttl: 5000` makes orphan re-dispatch a seconds-scale
+  event; the default is tuned for production patience, not demos.
+- **Observability without touching the loop** — both the execution log and the crash trigger
+  hang off hooks (`onCall`, `afterStep`); the agent code is byte-identical to chapter 3's.
+
+## That's the tour
+
+1. [minimal](../minimal/README.md) — durability is two `ctx.run` wraps.
+2. [core](../core/README.md) — the loop written once, engine-neutrally; a tiny driver per engine.
+3. [sre](../sre/README.md) — a real Synadia agent with approval-as-chat-query.
+4. [coding](../coding/README.md) — same loop, new tools: "one loop, many agents."
+5. **crash** — the replay, proven.
+
+Back to the [overview](../../README.md) — and re-read
+[`minimal/index.ts`](../minimal/index.ts): after this tour it should read as obvious.

--- a/examples/durable-agents/src/minimal/README.md
+++ b/examples/durable-agents/src/minimal/README.md
@@ -1,0 +1,70 @@
+# 1 · minimal — durability in ~10 lines
+
+> **Durable-agents tour, chapter 1 of 5**
+> [overview](../../README.md) · **minimal** · [core](../core/README.md) · [sre](../sre/README.md) · [coding](../coding/README.md) · [crash](../crash/README.md)
+
+The smallest possible durable agent. [`index.ts`](./index.ts) is an ordinary tool-calling loop —
+*ask the model, run the tools it asked for, repeat* — and the **only** thing that makes it durable
+is that the model call and the tool call are each wrapped in `yield* ctx.run(...)`, a
+[Resonate](https://resonatehq.io) **durable step**. No abstraction, no framework glue, no
+infrastructure.
+
+## The two wraps
+
+```ts
+// (1) REASON — journaled once; after a crash it REPLAYS (never re-called, never re-billed)
+const decision = yield* ctx.run(() => callModel(messages));
+
+// (2) ACT — journaled once; the side effect fires once, never twice on replay
+const result = yield* ctx.run(() => tool(call.args));
+```
+
+That's the entire durability story. Everything else in the file is a plain agent: a deterministic
+stub "model" that asks for the weather once and then answers, one `get_weather` tool, and a
+message transcript.
+
+## The mental model: journal + replay
+
+A durable step means: *run the function once, record its result in a journal, and on any
+re-execution return the recorded result instead of running the function again.*
+
+When the process dies and the run is picked up again, the generator restarts **from the top** —
+but every step that already completed returns instantly from the journal. Execution fast-forwards
+through the recorded history and resumes at the first step that never finished. Two consequences:
+
+- a completed **model turn** is never re-called → a crash never re-bills you;
+- a completed **tool call** never re-fires its side effect → no double restart, no double email.
+
+The price is one rule: **code between steps must be deterministic** — no `Date.now()`,
+`Math.random()`, or raw I/O outside a step — so the replayed generator takes the same path and
+yields the same steps in the same order.
+
+## Run it
+
+```sh
+bun install        # once, in examples/durable-agents/
+bun run minimal
+```
+
+```
+🧠 agent answer: Here you go — Berlin: 21°C, clear.
+```
+
+`new Resonate()` with no URL runs an **in-memory** Resonate server inside the process — ideal for
+reading the mechanics, but the journal dies with the process. The wraps don't change at all when
+you point Resonate at a real server over NATS; that is exactly what the [sre](../sre/README.md)
+and [crash](../crash/README.md) chapters do, and where crash-resume becomes real.
+
+## Things to try
+
+- Swap `callModel` for a real backend (OpenAI-compatible, Ollama, …) — it changes nothing about
+  the durability story; the loop and the wraps stay identical.
+- Add a second tool and have the stub "model" call both — each call becomes its own journaled step.
+- Break the rule on purpose: branch on `Math.random()` between steps and reason about why a
+  replay could then diverge from the recorded history.
+
+## Next
+
+**[2 · core →](../core/README.md)** — here the wraps were written directly against Resonate. The
+rest of the suite factors them out: the agent loop is written once, engine-neutrally, and a
+~15-line driver supplies the durability.

--- a/examples/durable-agents/src/sre/README.md
+++ b/examples/durable-agents/src/sre/README.md
@@ -1,0 +1,123 @@
+# 3 · sre — a durable SRE agent on NATS
+
+> **Durable-agents tour, chapter 3 of 5**
+> [overview](../../README.md) · [minimal](../minimal/README.md) · [core](../core/README.md) · **sre** · [coding](../coding/README.md) · [crash](../crash/README.md)
+
+The first real agent built on the [core](../core/README.md): a Synadia agent you can discover and
+prompt over NATS, whose brain is a durable workflow. The scenario is an SRE incident: investigate
+a slow service with read-only tools, restart it **only after a human approves**, then notify
+on-call and summarize.
+
+## The persona ([`agent.ts`](./agent.ts))
+
+One file defines everything agent-specific — system prompt, tools, and a deterministic offline
+script. The other two files are just entry points.
+
+| Tool | What it does | Durable shape |
+| --- | --- | --- |
+| `get_metrics` | returns (canned) unhealthy p99 / error-rate / saturation for a service | plain step |
+| `restart_service` | "restarts" the service — disruptive | **`dangerous: true`** → parks on an approval signal first; echoes its idempotency `key` back so exactly-once is visible in the output |
+| `send_notification` | posts to the on-call channel | plain step |
+
+The stub brain ([`sreStub`](./agent.ts)) is a fixed playbook — *pull metrics → restart (needs
+approval) → notify → final summary* — computed purely from how many tool results are in the
+transcript. Being a pure function of the transcript makes it deterministic and replay-safe, which
+is what lets the [crash chapter](../crash/README.md) assert exact call counts. Tools accept an
+`onCall` hook so a harness can count real executions — the exactly-once proof in miniature.
+
+## Offline smoke — no infrastructure
+
+```sh
+bun run sre:offline
+```
+
+Runs the durable brain on Resonate's in-memory server with the stub and an auto-approver:
+
+```
+▶ SRE agent (durable brain, offline in-memory Resonate):
+   · get_metrics  [key=tool-0-0]
+   🔔 approval requested: {"name":"restart_service","args":{"service":"checkout"}} → approving
+   · restart_service  [key=tool-1-0]
+   · send_notification  [key=tool-2-0]
+
+🧠 answer: Done: checkout was unhealthy, I restarted it (with approval) and metrics are recovering.
+   tool executions: {"get_metrics":1,"restart_service":1,"send_notification":1}
+✅ every tool executed exactly once
+```
+
+It exits non-zero if any tool ran more or less than once, so it doubles as a fast test of the
+whole loop + approval gate.
+
+## Live — a real Synadia agent ([`serve.ts`](./serve.ts))
+
+```
+caller ──prompt──▶ AgentService front-door ──beginRun──▶ Resonate worker (same process)
+                         │                                    │
+                         │  approval as §7 query              │  durable steps journaled to
+                         ▼                                    ▼  resonate-on-nats over NATS
+                    the human answers                    JetStream (survives a crash)
+```
+
+Infrastructure first (also needed by the [coding](../coding/README.md) and
+[crash](../crash/README.md) chapters):
+
+```sh
+# 1) a NATS server with JetStream (≥ 2.14 — Resonate's durable timers ride native message scheduling)
+nats-server -js -sd /tmp/de-nats
+
+# 2) the Resonate server on that NATS (built from the resonate-on-nats repo)
+go build -o resonate-on-nats . && ./resonate-on-nats serve --nats-url nats://localhost:4222
+```
+
+Then, in two terminals:
+
+```sh
+bun run sre:serve       # the agent: durable worker + front-door in one process
+bun run prompt          # a caller: discovers, prompts, and auto-answers the approval
+```
+
+The caller ([`../caller.ts`](../caller.ts)) prints the whole §7 conversation:
+
+```
+prompting durable-sre/<owner>/sre:
+  "checkout is slow — investigate and fix."
+
+  [status] ack
+  [status] ▶ durable run `durable-sre-<instance>-1`
+  [query]  ⏸ Approve `restart_service({"service":"checkout"})`? (yes/no)
+           → replying "yes"
+  [status] ✅ approved
+  [answer] Done: checkout was unhealthy, I restarted it (with approval) and metrics are recovering.
+
+✅ prompt complete
+```
+
+Once `sre:serve` is up, the agent also appears in [`agent-web-ui`](../../../agent-web-ui) with
+zero config — prompt it there and the approval renders as an in-chat allow/deny query.
+
+Knobs (all env):
+
+| Env | Default | Meaning |
+| --- | --- | --- |
+| `NATS_URL` | `nats://127.0.0.1:4222` | NATS to connect to (agent and caller) |
+| `RESONATE_GROUP` | `sre-workers` | Resonate worker group — restart into the **same** group to resume runs |
+| `APPROVE` | `yes` | caller's scripted answer to the approval query (`APPROVE=no` denies) |
+| `AGENT` | `durable-sre` | which agent type the caller prompts (`durable-coder` for chapter 4) |
+| `LLM_BACKEND` … | *(stub)* | real brain, e.g. `LLM_BACKEND=ollama OLLAMA_MODEL=gpt-oss:latest bun run sre:serve` — see [core → `llm.ts`](../core/README.md) |
+
+## Things to try
+
+- **Deny the restart**: `APPROVE=no bun run prompt`. The tool never fires and the transcript gets
+  `✗ denied by human`. (Caveat: the deterministic stub follows its script regardless of the
+  denial — swap in a real backend to watch the model actually adapt.)
+- **Watch the approval side-channel**: `nats sub 'de-agent.approval.>'` while prompting — that's
+  the parked promise being announced ([`core/subjects.ts`](../core/subjects.ts)).
+- **Kill `sre:serve` mid-run and restart it** (same `RESONATE_GROUP`): the *run* resumes from the
+  journal and completes — but the caller's live stream is gone, because the front-door is
+  deliberately ephemeral. That asymmetry — durable brain, disposable face — is the architecture
+  working as intended; the [crash chapter](../crash/README.md) turns it into a verified proof.
+
+## Next
+
+**[4 · coding →](../coding/README.md)** — the same loop, driver, and front-door with a different
+tool-set: "one loop, many agents."


### PR DESCRIPTION
## What

Adds the missing per-example READMEs under `examples/durable-agents/src/*` and links them into a 5-chapter guided tour:

**[1 · minimal](../blob/docs/durable-agents-chapter-readmes/examples/durable-agents/src/minimal/README.md) → 2 · core → 3 · sre → 4 · coding → 5 · crash**

Every chapter has the same structure so the whole thing reads like a short course:

- a breadcrumb trail (`overview · minimal · core · sre · coding · crash`) with a bolded you-are-here marker,
- a code walkthrough grounded in the actual source (step names like `tool-0-0`, the real env knobs, the real log lines as expected output),
- run instructions + things to try,
- a **Next** teaser handing off to the following chapter; chapter 5 closes with a recap of the arc.

`src/core/` gets a chapter too (not just the four runnable examples) since the engine-neutral effects loop + driver is the pedagogical heart the other chapters keep pointing into. The durable-execution layer stays framed as pluggable — the Resonate driver is described as "one more ~15-line file" per future framework.

The package `README.md` gains a `src/core/` row in the What's-here table and a one-line reading-order chain below it.

## Notes for review

- Docs only — no code changes. All relative links across the six files were script-checked to resolve; the two cross-file section anchors follow GitHub's slugger rules (em dash → `--`).
- Sample outputs are transcribed from the actual `console.log` strings in the sources, not invented.
- Two honest caveats are documented on purpose: killing a serve process mid-run resumes the *run* but not the ephemeral chat stream (brain durable, face ephemeral), and `caller.ts` falls back to the first discovered agent when `AGENT` doesn't match — worth knowing when both agents are up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)