### PR TITLE
feat(agents): generic ACP NATS channel + grok front door

### DIFF
--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -11,6 +11,7 @@ on:
       - "agents/openclaw/**"
       - "agents/opencode/**"
       - "agents/codex/**"
+      - "agents/acp/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -20,6 +21,7 @@ on:
       - "agents/openclaw/**"
       - "agents/opencode/**"
       - "agents/codex/**"
+      - "agents/acp/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -217,4 +219,58 @@ jobs:
         run: bun run smoke:codex-permission
       - name: Package contents
         working-directory: agents/codex
+        run: npm pack --dry-run --json
+
+  acp:
+    name: agents/acp (typecheck + package-safe smokes)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install nats-server
+        run: |
+          curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
+          tar -xzf nats-server.tar.gz --strip-components=1
+          sudo mv nats-server /usr/local/bin/
+          nats-server --version
+      - name: Build current client-sdk
+        working-directory: client-sdk/typescript
+        run: |
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "CLIENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      - name: Build current agent-sdk
+        working-directory: agent-sdk/typescript
+        run: |
+          # CI-only: replace the relative file: link with an absolute tgz so the packed agent-service artifact resolves after install.
+          npm pkg set "dependencies.@synadia-ai/agents=file:$CLIENT_SDK_TGZ"
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "AGENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      - name: Install dependencies
+        working-directory: agents/acp
+        run: |
+          bun install
+          npm install --no-save "$CLIENT_SDK_TGZ" "$AGENT_SDK_TGZ"
+      - name: Typecheck
+        working-directory: agents/acp
+        run: bun run typecheck
+      - name: Unit tests
+        working-directory: agents/acp
+        run: bun test
+      - name: Protocol smoke
+        working-directory: agents/acp
+        run: bun run smoke:protocol
+      # The managed-runtime smoke drives a fake ACP agent subprocess over the
+      # real NDJSON wire; no grok/gemini binary is required. Real-agent runs
+      # stay a local/manual validation gate.
+      - name: Fake runtime smoke
+        working-directory: agents/acp
+        run: bun run smoke:acp-fake-runtime
+      - name: Package contents
+        working-directory: agents/acp
         run: npm pack --dry-run --json

--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -12,6 +12,7 @@ on:
       - "agents/opencode/**"
       - "agents/codex/**"
       - "agents/acp/**"
+      - "agents/grok/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -22,6 +23,7 @@ on:
       - "agents/opencode/**"
       - "agents/codex/**"
       - "agents/acp/**"
+      - "agents/grok/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -222,7 +224,7 @@ jobs:
         run: npm pack --dry-run --json
 
   acp:
-    name: agents/acp (typecheck + package-safe smokes)
+    name: agents/acp + agents/grok (typecheck + package-safe smokes)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -274,3 +276,15 @@ jobs:
       - name: Package contents
         working-directory: agents/acp
         run: npm pack --dry-run --json
+      # The grok wrapper is a thin pin over agents/acp (file:../acp link
+      # pre-publish), so it rides in the same job: pure-argv unit tests, no
+      # NATS or grok binary required.
+      - name: Install grok wrapper deps
+        working-directory: agents/grok
+        run: bun install
+      - name: Typecheck grok wrapper
+        working-directory: agents/grok
+        run: bun run typecheck
+      - name: Grok wrapper unit tests
+        working-directory: agents/grok
+        run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ compatibility between the two SDKs.
 | `agents/flue/` | `@synadia-ai/flue-nats-channel` | npm (public) | Flue sidecar channel |
 | `agents/opencode/` | `@synadia-ai/opencode-nats-channel` | npm (public) | OpenCode plugin channel |
 | `agents/codex/` | `@synadia-ai/codex-nats-channel` | npm (public) | Codex app-server-backed channel |
-| `agents/acp/` | `@synadia-ai/acp-nats-channel` | npm (public) | Generic ACP channel (grok, gemini, custom) |
+| `agents/acp/` | `@synadia-ai/acp-nats-channel` | npm (public) | Generic ACP channel (grok preset + custom) |
 | `agents/grok/` | `@synadia-ai/grok-nats-channel` | npm (public) | Grok Build front door — thin pin over `agents/acp` |
 | `examples/pi-headless/` | `@synadia-ai/nats-pi-headless` | npm (public) | depends on `@synadia-ai/agents@^0.5.x` |
 | `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | github only | local-clone test client; `private: true` so it never publishes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ compatibility between the two SDKs.
 | `agents/flue/` | `@synadia-ai/flue-nats-channel` | npm (public) | Flue sidecar channel |
 | `agents/opencode/` | `@synadia-ai/opencode-nats-channel` | npm (public) | OpenCode plugin channel |
 | `agents/codex/` | `@synadia-ai/codex-nats-channel` | npm (public) | Codex app-server-backed channel |
+| `agents/acp/` | `@synadia-ai/acp-nats-channel` | npm (public) | Generic ACP channel (grok, gemini, custom) |
 | `examples/pi-headless/` | `@synadia-ai/nats-pi-headless` | npm (public) | depends on `@synadia-ai/agents@^0.5.x` |
 | `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | github only | local-clone test client; `private: true` so it never publishes |
 | `examples/dspy/` | `@synadia-ai/nats-dspy-agent` | private | uses `file:` link to local SDK |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ compatibility between the two SDKs.
 | `agents/opencode/` | `@synadia-ai/opencode-nats-channel` | npm (public) | OpenCode plugin channel |
 | `agents/codex/` | `@synadia-ai/codex-nats-channel` | npm (public) | Codex app-server-backed channel |
 | `agents/acp/` | `@synadia-ai/acp-nats-channel` | npm (public) | Generic ACP channel (grok, gemini, custom) |
+| `agents/grok/` | `@synadia-ai/grok-nats-channel` | npm (public) | Grok Build front door — thin pin over `agents/acp` |
 | `examples/pi-headless/` | `@synadia-ai/nats-pi-headless` | npm (public) | depends on `@synadia-ai/agents@^0.5.x` |
 | `examples/agent-web-ui/` | `@synadia-ai/nats-ai-testui` | github only | local-clone test client; `private: true` so it never publishes |
 | `examples/dspy/` | `@synadia-ai/nats-dspy-agent` | private | uses `file:` link to local SDK |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [OpenCode](agents/opencode/) | `opencode` | `@synadia-ai/opencode-nats-channel` — OpenCode plugin that registers projects as NATS agents |
 | [Codex](agents/codex/) | `codex` | `@synadia-ai/codex-nats-channel` — Codex app-server-backed channel for managed or attached sessions |
 | [ACP](agents/acp/) | `grok`, `gemini`, … | `@synadia-ai/acp-nats-channel` — generic channel for [ACP](https://agentclientprotocol.com)-speaking agents (Grok Build, Gemini CLI, custom) |
+| [Grok Build](agents/grok/) | `grok` | `@synadia-ai/grok-nats-channel` — grok-pinned front door to the ACP channel (`grok-agent start`) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 
 Subjects follow a verb-first pattern: `agents.{verb}.{token}.{owner}.{session}` where `verb` is `prompt`, `hb`, or `status`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [OpenCode](agents/opencode/) | `opencode` | `@synadia-ai/opencode-nats-channel` — OpenCode plugin that registers projects as NATS agents |
 | [Codex](agents/codex/) | `codex` | `@synadia-ai/codex-nats-channel` — Codex app-server-backed channel for managed or attached sessions |
-| [ACP](agents/acp/) | `grok`, `gemini`, … | `@synadia-ai/acp-nats-channel` — generic channel for [ACP](https://agentclientprotocol.com)-speaking agents (Grok Build, Gemini CLI, custom) |
+| [ACP](agents/acp/) | `grok`, … | `@synadia-ai/acp-nats-channel` — generic channel for [ACP](https://agentclientprotocol.com)-speaking agents (Grok Build preset + custom for adapters, e.g. Antigravity) |
 | [Grok Build](agents/grok/) | `grok` | `@synadia-ai/grok-nats-channel` — grok-pinned front door to the ACP channel (`grok-agent start`) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Pre-built channel plugins that put existing AI harnesses on NATS. Each registers
 | [open-agent](agents/open-agent/) | `open-agent` | `@synadia-ai/open-agent` (private) — inbound bridge for [`vercel-labs/open-agents`](https://github.com/vercel-labs/open-agents); LocalSandbox + companion [`examples/open-agent-vercel/`](examples/open-agent-vercel/) |
 | [OpenCode](agents/opencode/) | `opencode` | `@synadia-ai/opencode-nats-channel` — OpenCode plugin that registers projects as NATS agents |
 | [Codex](agents/codex/) | `codex` | `@synadia-ai/codex-nats-channel` — Codex app-server-backed channel for managed or attached sessions |
+| [ACP](agents/acp/) | `grok`, `gemini`, … | `@synadia-ai/acp-nats-channel` — generic channel for [ACP](https://agentclientprotocol.com)-speaking agents (Grok Build, Gemini CLI, custom) |
 | [DSPy ReAct](examples/dspy/) | `dspy` | standalone example (not published) — built from scratch with ax-llm ReAct |
 
 Subjects follow a verb-first pattern: `agents.{verb}.{token}.{owner}.{session}` where `verb` is `prompt`, `hb`, or `status`.

--- a/agents/acp/.env.example
+++ b/agents/acp/.env.example
@@ -1,0 +1,26 @@
+# NATS connection
+NATS_URL=nats://127.0.0.1:4222
+# NATS_CONTEXT=
+# NATS_CREDS=
+
+# Which ACP agent to bridge: grok, gemini, or custom.
+SYNADIA_ACP_AGENT=grok
+
+# Public protocol identity. These become subject tokens, so keep them lowercase
+# alphanumeric plus '-' or '_'. Per-agent vars (SYNADIA_GROK_*) win over the
+# channel-level SYNADIA_ACP_* vars, which win over fleet-wide SYNADIA_OWNER /
+# SYNADIA_NAME.
+SYNADIA_GROK_OWNER=local
+SYNADIA_GROK_SESSION=main
+
+# Runtime mode: fake (protocol smokes) or managed (spawns the agent).
+SYNADIA_ACP_MODE=managed
+SYNADIA_ACP_PERMISSION_POLICY=reject
+
+# Managed grok runs in an isolated ephemeral GROK_HOME by default (removed on
+# shutdown) — which is unauthenticated. Point at an authenticated home to
+# reuse existing credentials:
+# SYNADIA_ACP_HOME=~/.grok
+
+# Working directory for the ACP session (defaults to the process cwd):
+# SYNADIA_ACP_CWD=/path/to/workspace

--- a/agents/acp/.env.example
+++ b/agents/acp/.env.example
@@ -3,7 +3,7 @@ NATS_URL=nats://127.0.0.1:4222
 # NATS_CONTEXT=
 # NATS_CREDS=
 
-# Which ACP agent to bridge: grok, gemini, or custom.
+# Which ACP agent to bridge: grok or custom.
 SYNADIA_ACP_AGENT=grok
 
 # Public protocol identity. These become subject tokens, so keep them lowercase

--- a/agents/acp/CHANGELOG.md
+++ b/agents/acp/CHANGELOG.md
@@ -12,8 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial generic ACP (Agent Client Protocol) Synadia Agent Protocol adapter package:
   one channel for every ACP-speaking coding agent, driven over `session/prompt` +
   `session/update` via the official `@agentclientprotocol/sdk`.
-- Presets: `grok` (Grok Build via `grok agent stdio`, isolated `GROK_HOME` by default)
-  and `gemini` (Gemini CLI via `--experimental-acp`), plus a `custom` escape hatch.
+- Presets: `grok` (Grok Build via `grok agent stdio`, isolated `GROK_HOME` by
+  default) plus a `custom` escape hatch for any other ACP-speaking agent or
+  adapter (e.g. Google Antigravity via a community ACP adapter until `agy`
+  ships native ACP). A `gemini` preset existed briefly during development and
+  was removed before release — Gemini CLI was superseded by Antigravity.
 - Managed mode (adapter-owned agent subprocess, one long-lived ACP session) and fake
   mode for deterministic protocol smoke tests.
 - Permission mapping: ACP `session/request_permission` -> protocol §7 query chunks

--- a/agents/acp/CHANGELOG.md
+++ b/agents/acp/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `@synadia-ai/acp-nats-channel` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-18
+
+### Added
+
+- Initial generic ACP (Agent Client Protocol) Synadia Agent Protocol adapter package:
+  one channel for every ACP-speaking coding agent, driven over `session/prompt` +
+  `session/update` via the official `@agentclientprotocol/sdk`.
+- Presets: `grok` (Grok Build via `grok agent stdio`, isolated `GROK_HOME` by default)
+  and `gemini` (Gemini CLI via `--experimental-acp`), plus a `custom` escape hatch.
+- Managed mode (adapter-owned agent subprocess, one long-lived ACP session) and fake
+  mode for deterministic protocol smoke tests.
+- Permission mapping: ACP `session/request_permission` -> protocol §7 query chunks
+  (`query` policy), with `reject` (default) and `allow` policies.
+- Protocol and fake-runtime validation harnesses (no real agent binary required).
+- README setup, presets, configuration, permissions, and auth documentation.

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -35,7 +35,6 @@ terminators come from `@synadia-ai/agent-service`, exactly as in the
 | Preset | `metadata.agent` | Subject token | Spawns | Home isolation |
 | --- | --- | --- | --- | --- |
 | `grok` (default) | `grok` | `grok` | `grok agent stdio` | `GROK_HOME` → ephemeral temp dir |
-| `gemini` | `gemini-cli` | `gemini` | `gemini --experimental-acp` | — |
 | `custom` | `--agent-id` | `--agent-id` (or `--subject-token`) | `--acp-bin` + `--acp-args` | — |
 
 Any agent on the [ACP agents list](https://agentclientprotocol.com/get-started/agents)
@@ -46,14 +45,34 @@ The grok preset also ships as a pinned front-door package —
 [`agents/grok/`](../grok/) (`@synadia-ai/grok-nats-channel`, bin
 `grok-agent`) — with grok-specific setup and permission docs.
 
+### Antigravity (`agy`) — via the custom preset
+
+Google Antigravity superseded Gemini CLI (whose preset was removed
+pre-release) but has **no native ACP mode yet**
+([feature request](https://github.com/google-antigravity/antigravity-cli/issues/31)).
+Until `agy` ships an `--acp` flag, drive it through a community ACP adapter
+such as [`antigravity-acp`](https://github.com/shubzkothekar/antigravity-acp)
+(review third-party adapters before use — they run with your `agy` auth):
+
+```sh
+npm install -g antigravity-acp     # adapter binary: agy-acp
+acp-agent start --agent custom --agent-id antigravity --acp-bin agy-acp
+```
+
+Live-validated (agy 1.1.4, adapter 1.0.0): text prompts round-trip over the
+bus end-to-end; tool calls surface as status chunks, but the adapter's
+edit/permission flow is still maturing — writes did not complete in our
+runs. A first-party `antigravity` preset lands once `agy` speaks ACP
+natively.
+
 ## Prerequisites
 
 - Bun 1.3+ for local development and smoke tests.
 - `nats-server` on `PATH` for the smoke tests (they start disposable loopback
   servers).
-- The agent binary for managed mode: [`grok`](https://x.ai/cli) or
-  [`gemini`](https://github.com/google-gemini/gemini-cli). Not required for
-  `fake` mode or the deterministic smokes.
+- The agent binary for managed mode: [`grok`](https://x.ai/cli), or your
+  custom agent/adapter binary. Not required for `fake` mode or the
+  deterministic smokes.
 
 ## Quickstart (grok)
 
@@ -118,7 +137,7 @@ config file > derived defaults. Config file:
 
 | Variable | Meaning | Default |
 | --- | --- | --- |
-| `SYNADIA_ACP_AGENT` | Preset: `grok`, `gemini`, `custom` | `grok` |
+| `SYNADIA_ACP_AGENT` | Preset: `grok`, `custom` | `grok` |
 | `SYNADIA_GROK_OWNER`, `SYNADIA_ACP_OWNER`, `SYNADIA_OWNER` | Owner (4th subject token) | sanitized `$USER` |
 | `SYNADIA_GROK_SESSION`, `SYNADIA_ACP_SESSION`, `SYNADIA_NAME` | Session (5th subject token) | sanitized cwd basename |
 | `SYNADIA_ACP_MODE` | `fake` or `managed` | `fake` |
@@ -170,7 +189,7 @@ unauthenticated, so `session/new` fails with an auth error until you either
 - authenticate a dedicated home once: `GROK_HOME=/srv/grok-bot grok`, then
   `--agent-home /srv/grok-bot`.
 
-Gemini CLI has no home env var in the preset; it uses its normal user
+Custom-preset agents have no home isolation; they use their normal user
 configuration and auth.
 
 ## Protocol compliance and limitations

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -187,7 +187,7 @@ config file > derived defaults. Config file:
 | `SYNADIA_GROK_HOME`, `SYNADIA_ACP_HOME` | Agent home dir (reuse auth) | ephemeral temp dir (grok) |
 | `SYNADIA_ACP_CWD` | ACP session working directory | process cwd |
 | `SYNADIA_GROK_PERMISSION_POLICY`, `SYNADIA_ACP_PERMISSION_POLICY` | `reject`, `query`, `allow` | `reject` |
-| `NATS_URL` / `NATS_CONTEXT` / `NATS_CREDS` | NATS connection | `nats://127.0.0.1:4222` |
+| `NATS_URL` / `NATS_CONTEXT` / `NATS_CREDS` | NATS connection. A context carries its own auth, so `NATS_CREDS` applies only when no context is set. | `nats://127.0.0.1:4222` |
 
 Run `acp-agent doctor` to print the resolved identity, spawn command, and a
 `--version` probe of the agent binary.

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -1,0 +1,199 @@
+# ACP NATS Channel
+
+`@synadia-ai/acp-nats-channel` exposes **ACP-speaking coding agents** — Grok
+Build, Gemini CLI, and any other agent that implements the
+[Agent Client Protocol](https://agentclientprotocol.com) — through the
+[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs) v0.3.
+
+One generic bridge instead of one bespoke channel per agent: the adapter
+spawns the agent in ACP-over-stdio mode, opens a long-lived ACP session, and
+maps the two protocols onto each other:
+
+| Synadia Agent Protocol (NATS) | ACP |
+| --- | --- |
+| prompt envelope (§5) | `session/prompt` |
+| response chunks (§6.3) | `agent_message_chunk` updates |
+| status chunks (§6.4) | `tool_call` / `plan` updates (terse summaries) |
+| mid-stream query chunks (§7) | `session/request_permission` |
+| stream terminator (§6.5) | `session/prompt` resolves with a stop reason |
+
+Service registration, heartbeats, keepalives, error mapping, and stream
+terminators come from `@synadia-ai/agent-service`, exactly as in the
+[codex channel](../codex/) this adapter is modeled on.
+
+## Package surface
+
+- Package: `@synadia-ai/acp-nats-channel`
+- Binary: `acp-agent`
+- Prompt subject: `agents.prompt.<token>.<owner>.<session>` where `<token>`
+  comes from the preset (`grok`, `gemini`, or your custom token)
+- Status subject: `agents.status.<token>.<owner>.<session>`
+- Heartbeat subject: `agents.hb.<token>.<owner>.<session>`
+
+## Presets
+
+| Preset | `metadata.agent` | Subject token | Spawns | Home isolation |
+| --- | --- | --- | --- | --- |
+| `grok` (default) | `grok` | `grok` | `grok agent stdio` | `GROK_HOME` → ephemeral temp dir |
+| `gemini` | `gemini-cli` | `gemini` | `gemini --experimental-acp` | — |
+| `custom` | `--agent-id` | `--agent-id` (or `--subject-token`) | `--acp-bin` + `--acp-args` | — |
+
+Any agent on the [ACP agents list](https://agentclientprotocol.com/get-started/agents)
+that supports core `initialize` / `session/new` / `session/prompt` should work
+via `custom`; presets just bundle the spawn command and env-var conventions.
+
+## Prerequisites
+
+- Bun 1.3+ for local development and smoke tests.
+- `nats-server` on `PATH` for the smoke tests (they start disposable loopback
+  servers).
+- The agent binary for managed mode: [`grok`](https://x.ai/cli) or
+  [`gemini`](https://github.com/google-gemini/gemini-cli). Not required for
+  `fake` mode or the deterministic smokes.
+
+## Quickstart (grok)
+
+```sh
+# 1. Install grok and authenticate it once (browser flow):
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok   # complete auth, then quit
+
+# 2. Start the channel against your NATS server, reusing that auth:
+acp-agent start --agent grok --mode managed --agent-home ~/.grok \
+  --nats-url nats://127.0.0.1:4222
+
+# -> acp-agent (grok, managed) listening on agents.prompt.grok.<you>.<cwd-name>
+```
+
+Prompt it from anywhere on the bus:
+
+```sh
+nats req agents.prompt.grok.<you>.<session> "hello grok" \
+  --replies=0 --reply-timeout=30s --timeout=120s
+```
+
+Or with the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK:
+
+```ts
+import { connect } from "@nats-io/transport-node";
+import { Agents } from "@synadia-ai/agents";
+
+const nc = await connect({ servers: "nats://127.0.0.1:4222" });
+const agents = new Agents({ nc });
+const [agent] = await agents.discover({ filter: { agent: "grok" } });
+for await (const msg of await agent!.prompt("summarize this repo")) {
+  if (msg.type === "response") process.stdout.write(msg.text);
+  if (msg.type === "query") await msg.reply("yes");   // permission relay (§7)
+}
+await agents.close();
+await nc.close();
+```
+
+The ACP session is long-lived: consecutive prompts share conversation memory
+until the channel restarts.
+
+## Modes
+
+- **`managed`** — the adapter spawns and owns the agent subprocess and one ACP
+  session. This is the real mode.
+- **`fake`** (default) — a deterministic in-process bridge used by the
+  protocol smoke tests; no subprocess. The config-file template ships with
+  `mode = "managed"`.
+
+There is **no automatic restart / supervision**: if the agent process crashes,
+in-flight and subsequent prompts fail with protocol 500s until the channel is
+restarted (same crash model as the codex channel).
+
+## Configuration
+
+Precedence: CLI flags > per-agent env (`SYNADIA_GROK_*`) > channel env
+(`SYNADIA_ACP_*`) > fleet-wide env (`SYNADIA_OWNER` / `SYNADIA_NAME`) > TOML
+config file > derived defaults. Config file:
+`~/.config/synadia/acp-nats-channel.toml` (print a starter with
+`acp-agent configure --print-template`).
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `SYNADIA_ACP_AGENT` | Preset: `grok`, `gemini`, `custom` | `grok` |
+| `SYNADIA_GROK_OWNER`, `SYNADIA_ACP_OWNER`, `SYNADIA_OWNER` | Owner (4th subject token) | sanitized `$USER` |
+| `SYNADIA_GROK_SESSION`, `SYNADIA_ACP_SESSION`, `SYNADIA_NAME` | Session (5th subject token) | sanitized cwd basename |
+| `SYNADIA_ACP_MODE` | `fake` or `managed` | `fake` |
+| `SYNADIA_GROK_BIN`, `SYNADIA_ACP_BIN` | Agent binary override | preset (`grok`) |
+| `SYNADIA_GROK_ARGS`, `SYNADIA_ACP_ARGS` | Spawn args override (space-separated) | preset (`agent stdio`) |
+| `SYNADIA_GROK_HOME`, `SYNADIA_ACP_HOME` | Agent home dir (reuse auth) | ephemeral temp dir (grok) |
+| `SYNADIA_ACP_CWD` | ACP session working directory | process cwd |
+| `SYNADIA_GROK_PERMISSION_POLICY`, `SYNADIA_ACP_PERMISSION_POLICY` | `reject`, `query`, `allow` | `reject` |
+| `NATS_URL` / `NATS_CONTEXT` / `NATS_CREDS` | NATS connection | `nats://127.0.0.1:4222` |
+
+Run `acp-agent doctor` to print the resolved identity, spawn command, and a
+`--version` probe of the agent binary.
+
+## Permissions
+
+ACP agents ask the *client* for tool-call authorization
+(`session/request_permission`). The adapter policy decides the answer:
+
+- **`reject`** (default) — deny every request (`reject_once` option). The
+  agent keeps working within whatever it may do without approval.
+- **`query`** — relay the request to the NATS caller as a protocol §7 query
+  chunk. Reply `approve` (or `yes`) to allow once; anything else denies; no
+  reply within 30 s cancels.
+- **`allow`** — approve everything (`allow_once`). Headless demos only; the
+  agent runs commands without a human in the loop.
+
+## Auth and home isolation (grok)
+
+Managed grok runs with `GROK_HOME` pointed at an **ephemeral temp directory**
+by default, removed on shutdown. That keeps the channel's agent state — and
+grok's leader socket, which lives under `GROK_HOME` — fully isolated from any
+interactive grok session you may have open. The tradeoff: a fresh home is
+unauthenticated, so `session/new` fails with an auth error until you either
+
+- pass `--agent-home ~/.grok` (or `SYNADIA_GROK_HOME=~/.grok`) to reuse the
+  auth from an interactive `grok` login, or
+- authenticate a dedicated home once: `GROK_HOME=/srv/grok-bot grok`, then
+  `--agent-home /srv/grok-bot`.
+
+Gemini CLI has no home env var in the preset; it uses its normal user
+configuration and auth.
+
+## Protocol compliance and limitations
+
+Implements the Synadia Agent Protocol for NATS v0.3 host checklist via
+`@synadia-ai/agent-service`: `agents` micro service registration, `prompt` +
+`status` endpoints, heartbeats, leading + periodic `ack` status chunks, typed
+response chunks, §7 queries, §9 error frames, and the empty-body terminator.
+
+Current limitations (v0.1):
+
+- **Attachments are not supported** — the prompt endpoint advertises
+  `attachments_ok=false` and rejects envelopes with attachments (400). ACP
+  content blocks make native attachment mapping possible later.
+- Responses stream **assistant text only**; agent thoughts are dropped and
+  tool calls/plans surface as terse status chunks.
+- One ACP session per channel instance; prompts are serialized per session
+  (concurrent NATS requests queue).
+- No subprocess supervision (see Modes above).
+
+## Validation
+
+| Command | What it proves | Needs |
+| --- | --- | --- |
+| `bun test` | Config/presets/bridge/permission mapping + managed runtime against the fake ACP agent | — |
+| `bun run smoke:protocol` | Full wire compliance (discovery, metadata, heartbeat, §6/§7/§9 shapes) with the fake bridge | `nats-server` |
+| `bun run smoke:acp-fake-runtime` | NATS → managed runtime → spawned fake ACP agent end-to-end | `nats-server` |
+| `acp-agent start --agent grok --mode managed ...` | The real thing | `grok` binary + auth |
+| `bun run manual:acp-live -- --session <name> "<prompt>"` | Discover + prompt a running channel, auto-answering §7 queries | a running channel |
+
+The fake ACP agent (`scripts/fake-acp-agent.ts`) speaks raw newline-delimited
+JSON-RPC with no SDK dependency, so the smokes exercise the adapter against
+the actual wire shape without any real agent binary or model credentials.
+
+## Troubleshooting
+
+- **`failed to start managed ACP agent ... auth`** — the isolated home is
+  unauthenticated; see *Auth and home isolation* above.
+- **`spawn grok ENOENT`** — the binary is not on `PATH`; check
+  `acp-agent doctor` and `--acp-bin`.
+- **Prompt returns 500 mid-stream** — the agent process likely exited; the
+  error carries the tail of its stderr. Restart the channel.

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -55,15 +55,44 @@ such as [`antigravity-acp`](https://github.com/shubzkothekar/antigravity-acp)
 (review third-party adapters before use — they run with your `agy` auth):
 
 ```sh
+# One-time: install agy (https://antigravity.google) and authenticate it,
+# then install the adapter:
 npm install -g antigravity-acp     # adapter binary: agy-acp
-acp-agent start --agent custom --agent-id antigravity --acp-bin agy-acp
+
+# Sanity check — resolved identity + `agy-acp --version` probe:
+acp-agent doctor --agent custom --agent-id antigravity --acp-bin agy-acp
+```
+
+Start it on the bus. `--mode managed` is **required** (bare `acp-agent`
+defaults to `fake`); `AGY_BIN` points the adapter at your installed,
+authenticated `agy` instead of letting it download its own copy:
+
+```sh
+AGY_SKIP_DOWNLOAD=1 AGY_BIN="$(which agy)" \
+acp-agent start --mode managed \
+  --agent custom --agent-id antigravity --acp-bin agy-acp \
+  --permission-policy query --session agy-demo
+# -> acp-agent (antigravity, managed) listening on agents.prompt.antigravity.<you>.agy-demo
+```
+
+Prompt it from anywhere on the bus:
+
+```sh
+nats req "agents.prompt.antigravity.<you>.agy-demo" \
+  "explain what NATS subjects are, in two sentences" \
+  --replies=0 --reply-timeout=60s --timeout=180s
+
+# or, from this directory, with pretty-printed status/tool/query chunks:
+bun scripts/live-acp-harness.ts --agent antigravity --session agy-demo \
+  "summarize the files in this directory"
 ```
 
 Live-validated (agy 1.1.4, adapter 1.0.0): text prompts round-trip over the
 bus end-to-end; tool calls surface as status chunks, but the adapter's
 edit/permission flow is still maturing — writes did not complete in our
-runs. A first-party `antigravity` preset lands once `agy` speaks ACP
-natively.
+runs, so keep prompts on the read/chat/analysis side for now. A first-party
+`antigravity` preset (and a grok-style front-door package) lands once `agy`
+speaks ACP natively.
 
 ## Prerequisites
 
@@ -73,6 +102,18 @@ natively.
 - The agent binary for managed mode: [`grok`](https://x.ai/cli), or your
   custom agent/adapter binary. Not required for `fake` mode or the
   deterministic smokes.
+
+## Running from a repo clone
+
+The package is not on npm yet. From a checkout, `bun install` here, then
+either run `bun src/cli.ts` in place of `acp-agent`, or put the bin on your
+PATH (symlink, not copy — the file resolves its imports from this directory):
+
+```sh
+cd agents/acp && bun install
+ln -sf "$PWD/src/cli.ts" ~/.local/bin/acp-agent
+acp-agent doctor
+```
 
 ## Quickstart (grok)
 

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -42,6 +42,10 @@ Any agent on the [ACP agents list](https://agentclientprotocol.com/get-started/a
 that supports core `initialize` / `session/new` / `session/prompt` should work
 via `custom`; presets just bundle the spawn command and env-var conventions.
 
+The grok preset also ships as a pinned front-door package —
+[`agents/grok/`](../grok/) (`@synadia-ai/grok-nats-channel`, bin
+`grok-agent`) — with grok-specific setup and permission docs.
+
 ## Prerequisites
 
 - Bun 1.3+ for local development and smoke tests.

--- a/agents/acp/README.md
+++ b/agents/acp/README.md
@@ -141,6 +141,18 @@ ACP agents ask the *client* for tool-call authorization
 - **`allow`** — approve everything (`allow_once`). Headless demos only; the
   agent runs commands without a human in the loop.
 
+**The agent decides *when* to ask.** The adapter policy only answers requests
+the agent actually sends. Grok runs its own authorization pipeline first
+(hooks → allow/ask/deny rules → built-in read-only auto-approvals → its
+*permission mode*), configured in the agent home's `config.toml`. In grok's
+`default` mode, file writes and non-read-only commands produce
+`session/request_permission` — which `query` relays to the bus. But if the
+agent home sets `permission_mode = "always-approve"` (common in interactive
+setups — check `~/.grok/config.toml` before reusing it via `--agent-home`),
+grok auto-approves internally and **no queries ever reach the caller**. For a
+bus-governed agent, use a dedicated home containing just the auth state and no
+`permission_mode` override.
+
 ## Auth and home isolation (grok)
 
 Managed grok runs with `GROK_HOME` pointed at an **ephemeral temp directory**
@@ -197,3 +209,6 @@ the actual wire shape without any real agent binary or model credentials.
   `acp-agent doctor` and `--acp-bin`.
 - **Prompt returns 500 mid-stream** — the agent process likely exited; the
   error carries the tail of its stderr. Restart the channel.
+- **`query` policy set but no queries arrive** — the agent isn't asking. For
+  grok, check the agent home's `config.toml` for
+  `permission_mode = "always-approve"` (see *Permissions* above).

--- a/agents/acp/bun.lock
+++ b/agents/acp/bun.lock
@@ -1,0 +1,52 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@synadia-ai/acp-nats-channel",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^1.2.1",
+        "@nats-io/nats-core": "^3.4.0",
+        "@nats-io/transport-node": "^3.4.0",
+        "@synadia-ai/agent-service": "^0.5.2",
+        "@synadia-ai/agents": "^0.5.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^20.16.0",
+        "typescript": "~5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
+
+    "@nats-io/nats-core": ["@nats-io/nats-core@3.4.0", "", { "dependencies": { "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
+
+    "@nats-io/nuid": ["@nats-io/nuid@3.0.0", "", {}, "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg=="],
+
+    "@nats-io/services": ["@nats-io/services@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0" } }, "sha512-hS9l4F5VCbdg4u7/qgEUU9gtQ+ZOLJxtj+lJj0oSw7Okkm0fLkYq6odbobFa50IGkghfLrzag95dWHSF8F8+CA=="],
+
+    "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
+
+    "@synadia-ai/agent-service": ["@synadia-ai/agent-service@0.5.2", "", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@synadia-ai/agents": "^0.5.1" } }, "sha512-6y4odN+JbWM9zBFK3XlEOlyJJHnGqPUUQHpfbJqbsPBrI038fQPlhoPcr08SzlY0dXnh4voLoc29mip6Q970rQ=="],
+
+    "@synadia-ai/agents": ["@synadia-ai/agents@0.5.2", "", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@nats-io/transport-node": "^3.4.0" } }, "sha512-7N8C/sBH5wIf0Q3boodDJEpG9dq4sBFLyiS8slLBU5fTrcU12ftHPRzfT+r3zcLYdaYKaMhdeYXEh+qxVomiDw=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+  }
+}

--- a/agents/acp/package.json
+++ b/agents/acp/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@synadia-ai/acp-nats-channel",
+  "version": "0.1.0",
+  "description": "Synadia Agent Protocol for NATS adapter for ACP-speaking coding agents (grok-build, Gemini CLI, ...).",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "agents/acp"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/agents/acp",
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "acp-agent": "./src/cli.ts"
+  },
+  "files": [
+    "src",
+    "scripts",
+    "README.md",
+    "CHANGELOG.md",
+    ".env.example"
+  ],
+  "scripts": {
+    "start": "bun src/cli.ts start",
+    "doctor": "bun src/cli.ts doctor",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "smoke:protocol": "bun scripts/protocol-smoke.ts",
+    "smoke:acp-fake-runtime": "bun scripts/acp-runtime-smoke.ts",
+    "manual:acp-live": "bun scripts/live-acp-harness.ts"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^1.2.1",
+    "@nats-io/nats-core": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
+    "@synadia-ai/agents": "^0.5.2",
+    "@synadia-ai/agent-service": "^0.5.2"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^20.16.0",
+    "typescript": "~5.6.0"
+  }
+}

--- a/agents/acp/scripts/acp-runtime-smoke.ts
+++ b/agents/acp/scripts/acp-runtime-smoke.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+// End-to-end managed-runtime smoke: NATS caller -> AgentService -> managed
+// ACP runtime -> fake ACP agent subprocess (real NDJSON JSON-RPC wire).
+// Deterministic — no real coding-agent binary required.
+import { createConnection, createServer } from "node:net";
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { Agents, type StreamMessage } from "@synadia-ai/agents";
+import { ManagedAcpRuntime } from "../src/managed-runtime.js";
+import { createAcpAgentService } from "../src/service.js";
+import type { AcpChannelConfig } from "../src/config.js";
+
+const nats = await ensureNats();
+const config: AcpChannelConfig = {
+  nats: { url: nats.url },
+  agent: { owner: "smoke", session: "managed", subjectToken: "grok", heartbeatIntervalS: 1, keepaliveIntervalS: 1 },
+  acp: {
+    mode: "managed",
+    preset: "grok",
+    agentId: "grok",
+    bin: "grok",
+    args: ["agent", "stdio"],
+    homeEnvVar: "GROK_HOME",
+    cwd: process.cwd(),
+    permissionPolicy: "reject",
+  },
+};
+
+const nc = await natsConnect({ servers: nats.url });
+const callerNc = await natsConnect({ servers: nats.url });
+const runtime = new ManagedAcpRuntime({ config, command: "bun", args: ["scripts/fake-acp-agent.ts"] });
+const service = createAcpAgentService({ nc, config, version: "0.1.0-smoke", client: runtime });
+try {
+  await runtime.start();
+  await service.start();
+  const agents = new Agents({ nc: callerNc });
+  const found = await agents.discover({ timeoutMs: 1000, filter: { agent: "grok", name: "managed" } });
+  if (found.length !== 1) throw new Error(`expected one managed grok agent, found ${found.length}`);
+  const messages: StreamMessage[] = [];
+  for await (const msg of await found[0]!.prompt("hello runtime")) messages.push(msg);
+  const responseText = messages.filter((m): m is Extract<StreamMessage, { type: "response" }> => m.type === "response").map((m) => m.text).join("");
+  if (!responseText.includes("fake ACP response to hello runtime")) throw new Error(`missing managed response text: ${responseText}`);
+  if (responseText.includes("pondering")) throw new Error("thought chunk leaked into the response stream");
+  if (messages.some((m) => m.type === "response" && m.text === "")) throw new Error("managed bridge emitted an empty response chunk");
+  if (!messages.some((m) => m.type === "status" && m.status.includes("tool: echo fixture tool"))) throw new Error("missing tool_call status chunk");
+  console.log(JSON.stringify({ ok: true, natsUrl: nats.url, subject: service.subject.prompt, messageTypes: messages.map((m) => m.type), responseText, isolatedHome: runtime.agentHome !== undefined }, null, 2));
+} finally {
+  await service.stop();
+  await runtime.close();
+  await nc.drain();
+  await callerNc.drain();
+  await nats.close();
+}
+
+async function ensureNats(): Promise<{ url: string; close(): Promise<void> }> {
+  const port = await freePort();
+  const url = `nats://127.0.0.1:${port}`;
+  const proc = Bun.spawn(["nats-server", "-a", "127.0.0.1", "-p", String(port)], { stdout: "ignore", stderr: "pipe" });
+  await waitForPort(port, 5000).catch(async (err) => {
+    proc.kill();
+    const stderr = proc.stderr ? await new Response(proc.stderr).text() : "";
+    throw new Error(`failed to start disposable nats-server: ${(err as Error).message}${stderr ? `\n${stderr}` : ""}`);
+  });
+  return { url, close: async () => { proc.kill(); await proc.exited.catch(() => undefined); } };
+}
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => typeof address === "object" && address ? resolve(address.port) : reject(new Error("failed to allocate free port")));
+    });
+    server.on("error", reject);
+  });
+}
+async function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = createConnection({ host: "127.0.0.1", port }, () => { socket.end(); resolve(); });
+        socket.on("error", reject);
+      });
+      return;
+    } catch { await Bun.sleep(50); }
+  }
+  throw new Error(`port ${port} did not open within ${timeoutMs}ms`);
+}

--- a/agents/acp/scripts/fake-acp-agent.ts
+++ b/agents/acp/scripts/fake-acp-agent.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+// Deterministic fake ACP agent for tests and smokes. Speaks raw
+// newline-delimited JSON-RPC 2.0 on stdio — deliberately no SDK dependency,
+// so it exercises our client against the actual wire shape (the ACP analog
+// of agents/codex/scripts/fake-codex-app-server.ts).
+//
+// Behaviors keyed off the prompt text:
+//   - contains "explode"    -> JSON-RPC error (drives handler-500 coverage)
+//   - contains "permission" -> server-side session/request_permission
+//                              round-trip, then echoes the outcome
+//   - otherwise             -> thought chunk (dropped by the bridge), text
+//                              chunks, a tool_call status, end_turn
+const decoder = new TextDecoder();
+let buffer = "";
+let nextSession = 1;
+let nextServerRequest = 1;
+const pendingServerRequests = new Map<string, (message: any) => void>();
+
+process.stdin.on("data", (chunk) => {
+  buffer += decoder.decode(chunk);
+  for (;;) {
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) break;
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (!line) continue;
+    void handle(JSON.parse(line));
+  }
+});
+
+async function handle(message: any): Promise<void> {
+  if (!message.method && ("result" in message || "error" in message)) {
+    const resolve = pendingServerRequests.get(String(message.id));
+    if (resolve) {
+      pendingServerRequests.delete(String(message.id));
+      resolve(message);
+    }
+    return;
+  }
+  if (message.method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? 1,
+        agentCapabilities: {
+          loadSession: false,
+          promptCapabilities: { image: false, audio: false, embeddedContext: false },
+        },
+        authMethods: [],
+      },
+    });
+    return;
+  }
+  if (message.method === "session/new") {
+    send({ jsonrpc: "2.0", id: message.id, result: { sessionId: `sess-${nextSession++}` } });
+    return;
+  }
+  if (message.method === "session/prompt") {
+    const sessionId = message.params?.sessionId ?? "sess-1";
+    const text: string = (message.params?.prompt ?? [])
+      .filter((block: any) => block?.type === "text")
+      .map((block: any) => block.text)
+      .join(" ");
+
+    if (text.includes("explode")) {
+      send({ jsonrpc: "2.0", id: message.id, error: { code: -32603, message: "fake ACP agent exploded" } });
+      return;
+    }
+
+    if (text.includes("permission")) {
+      const response = await serverRequest("session/request_permission", {
+        sessionId,
+        options: [
+          { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+          { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+        ],
+        toolCall: {
+          toolCallId: "tc-1",
+          title: "touch /tmp/fake-acp",
+          kind: "execute",
+          status: "pending",
+          rawInput: { command: "touch /tmp/fake-acp" },
+        },
+      });
+      const outcome = response?.result?.outcome;
+      const label = outcome?.outcome === "selected" ? outcome.optionId : outcome?.outcome ?? "missing";
+      update(sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: `permission:${label}` } });
+      send({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } });
+      return;
+    }
+
+    update(sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "pondering (should be dropped)" } });
+    update(sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "fake " } });
+    update(sessionId, {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-echo",
+      title: "echo fixture tool",
+      kind: "execute",
+      status: "pending",
+    });
+    update(sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: `ACP response to ${text}` } });
+    send({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } });
+    return;
+  }
+  if (message.method === "session/cancel") return; // notification
+  if (message.id !== undefined) {
+    send({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: `unknown method ${message.method}` } });
+  }
+}
+
+function send(message: unknown): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function update(sessionId: string, updateBody: unknown): void {
+  send({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update: updateBody } });
+}
+
+async function serverRequest(method: string, params: unknown): Promise<any> {
+  const id = `srv-${nextServerRequest++}`;
+  const settled = new Promise((resolve) => {
+    pendingServerRequests.set(id, resolve);
+    setTimeout(() => {
+      if (pendingServerRequests.delete(id)) resolve({ result: { outcome: { outcome: "timeout" } } });
+    }, 5_000);
+  });
+  send({ jsonrpc: "2.0", id, method, params });
+  return await settled;
+}

--- a/agents/acp/scripts/fake-acp-agent.ts
+++ b/agents/acp/scripts/fake-acp-agent.ts
@@ -24,7 +24,13 @@ process.stdin.on("data", (chunk) => {
     const line = buffer.slice(0, newline).trim();
     buffer = buffer.slice(newline + 1);
     if (!line) continue;
-    void handle(JSON.parse(line));
+    try {
+      void handle(JSON.parse(line));
+    } catch (err) {
+      // Malformed input should surface as a visible fixture diagnostic, not
+      // an unhandled crash mid-test.
+      process.stderr.write(`[fake-acp-agent] dropping malformed line: ${(err as Error).message}\n`);
+    }
   }
 });
 

--- a/agents/acp/scripts/live-acp-harness.ts
+++ b/agents/acp/scripts/live-acp-harness.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// Manual live-validation harness: discover a running acp-agent channel on
+// NATS, send one prompt, stream the reply, and auto-answer §7 permission
+// queries. Requires a real channel (e.g. managed grok) already running —
+// this script starts nothing itself.
+//
+// Usage:
+//   NATS_URL=nats://127.0.0.1:4222 bun scripts/live-acp-harness.ts \
+//     --agent grok --session live-test --answer approve "your prompt here"
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { Agents } from "@synadia-ai/agents";
+
+const args = process.argv.slice(2);
+let agentId = "grok";
+let session: string | undefined;
+let answer = "approve";
+const rest: string[] = [];
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i]!;
+  if (arg === "--agent") agentId = args[++i] ?? agentId;
+  else if (arg === "--session") session = args[++i];
+  else if (arg === "--answer") answer = args[++i] ?? answer;
+  else rest.push(arg);
+}
+const prompt = rest.join(" ").trim();
+if (!prompt) {
+  console.error("usage: live-acp-harness.ts [--agent id] [--session name] [--answer approve|deny] <prompt>");
+  process.exit(1);
+}
+
+const nc = await natsConnect({ servers: process.env.NATS_URL ?? "nats://127.0.0.1:4222" });
+const agents = new Agents({ nc });
+const found = await agents.discover({
+  timeoutMs: 2000,
+  filter: { agent: agentId, ...(session !== undefined ? { name: session } : {}) },
+});
+if (found.length === 0) throw new Error(`no ${agentId} agent found on the bus`);
+const agent = found[0]!;
+console.error(`[harness] prompting ${agent.promptEndpoint.subject}`);
+
+const events: Array<Record<string, unknown>> = [];
+let responseText = "";
+for await (const msg of await agent.prompt(prompt, { inactivityTimeoutMs: 180_000 })) {
+  if (msg.type === "response") {
+    responseText += msg.text;
+    process.stderr.write(msg.text);
+    events.push({ type: "response", bytes: msg.text.length });
+  } else if (msg.type === "status") {
+    console.error(`\n[status] ${msg.status}`);
+    events.push({ type: "status", status: msg.status });
+  } else if (msg.type === "query") {
+    console.error(`\n[query] ${msg.prompt}\n[query] auto-answering: ${answer}`);
+    events.push({ type: "query", prompt: msg.prompt.slice(0, 200), answered: answer });
+    await msg.reply(answer);
+  }
+}
+
+console.error("\n[harness] stream complete");
+console.log(JSON.stringify({ subject: agent.promptEndpoint.subject, events, responseText }, null, 2));
+await agents.close();
+await nc.close();

--- a/agents/acp/scripts/protocol-smoke.ts
+++ b/agents/acp/scripts/protocol-smoke.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env bun
+// Full-protocol smoke against the fake bridge: discovery, metadata, status
+// endpoint, heartbeat, SDK prompt round-trip, and raw-wire shapes including
+// §9 error frames. Mirrors agents/codex/scripts/protocol-smoke.ts.
+import { createConnection, createServer } from "node:net";
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { Agents, type StreamMessage } from "@synadia-ai/agents";
+import { FakeAcpBridgeClient } from "../src/bridge.js";
+import type { AcpChannelConfig } from "../src/config.js";
+import { createAcpAgentService } from "../src/service.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const name = `smoke-${Math.random().toString(36).slice(2, 8)}`;
+
+const nats = await ensureNats();
+const config: AcpChannelConfig = {
+  nats: { url: nats.url },
+  agent: {
+    owner: "smoke",
+    session: name,
+    subjectToken: "grok",
+    heartbeatIntervalS: 1,
+    keepaliveIntervalS: 1,
+  },
+  acp: {
+    mode: "fake",
+    preset: "grok",
+    agentId: "grok",
+    bin: "grok",
+    args: ["agent", "stdio"],
+    homeEnvVar: "GROK_HOME",
+    cwd: process.cwd(),
+    permissionPolicy: "reject",
+  },
+};
+
+const nc = await natsConnect({ servers: nats.url });
+const callerNc = await natsConnect({ servers: nats.url });
+const service = createAcpAgentService({
+  nc,
+  config,
+  version: "0.1.0-smoke",
+  client: new FakeAcpBridgeClient(),
+});
+
+const heartbeatSub = callerNc.subscribe(service.subject.heartbeat);
+
+try {
+  await callerNc.flush();
+  await service.start();
+
+  const rawInfo = await requestJson(callerNc, "$SRV.INFO.agents", "");
+  if (!isRecord(rawInfo) || rawInfo.name !== "agents") throw new Error("$SRV.INFO.agents did not return the agents service");
+
+  const agents = new Agents({ nc: callerNc });
+  const found = await agents.discover({ timeoutMs: 1000, filter: { agent: "grok", name } });
+  if (found.length !== 1) throw new Error(`expected one grok smoke agent, found ${found.length}`);
+  const agent = found[0]!;
+
+  assertEqual(agent.metadata["agent"], "grok", "service metadata agent");
+  assertEqual(agent.metadata["owner"], "smoke", "service metadata owner");
+  assertEqual(agent.metadata["session"], name, "service metadata session");
+  assertEqual(agent.metadata["protocol_version"], "0.3", "service metadata protocol_version");
+  assertEqual(agent.metadata["acp_preset"], "grok", "service metadata acp_preset");
+  assertEqual(agent.metadata["acp_mode"], "fake", "service metadata acp_mode");
+  assertEqual(agent.metadata["permission_policy"], "reject", "service metadata permission_policy");
+  assertEqual(agent.promptEndpoint.subject, service.subject.prompt, "prompt endpoint subject");
+  assertEqual(agent.promptEndpoint.queueGroup, "agents", "prompt endpoint queue group");
+  assertEqual(agent.promptEndpoint.attachmentsOk, false, "prompt endpoint attachments_ok");
+  if (!agent.promptEndpoint.metadata["max_payload"]) throw new Error("prompt endpoint missing max_payload");
+  const statusEndpoint = agent.endpoints.find((e) => e.name === "status");
+  assertEqual(statusEndpoint?.subject, service.subject.status, "status endpoint subject");
+  assertEqual(statusEndpoint?.queueGroup, "agents", "status endpoint queue group");
+
+  const status = await requestJson(callerNc, service.subject.status, "");
+  assertEqual(status["agent"], "grok", "status agent");
+  assertEqual(status["owner"], "smoke", "status owner");
+  assertEqual(status["session"], name, "status session");
+
+  const heartbeat = await nextJson(heartbeatSub, 2500, "timed out waiting for heartbeat");
+  assertEqual(heartbeat["agent"], "grok", "heartbeat agent");
+  assertEqual(heartbeat["owner"], "smoke", "heartbeat owner");
+  assertEqual(heartbeat["session"], name, "heartbeat session");
+
+  const messages: StreamMessage[] = [];
+  for await (const msg of await agent.prompt("hello smoke")) {
+    messages.push(msg);
+  }
+
+  const first = messages[0];
+  if (first?.type !== "status" || first.status !== "ack") throw new Error("missing leading ack status");
+  if (!messages.some((m) => m.type === "status" && m.status.includes("ACP fake bridge selected"))) throw new Error("missing fake bridge status chunk");
+  if (!messages.some((m) => m.type === "response" && m.text.includes("fake ACP response to hello smoke"))) throw new Error("missing fake ACP response chunk");
+  const last = messages.at(-1);
+  if (last?.type !== "status" || last.status !== "done") throw new Error("missing done terminator status");
+
+  const rawSuccess = await rawPromptRoundTrip(callerNc, service.subject.prompt, "hello raw");
+  assertRawSuccess(rawSuccess.frames);
+  const rawJsonSuccess = await rawPromptRoundTrip(callerNc, service.subject.prompt, JSON.stringify({ prompt: "hello json envelope" }));
+  assertRawSuccess(rawJsonSuccess.frames);
+  const rawAttachment400 = await rawPromptRoundTrip(callerNc, service.subject.prompt, JSON.stringify({
+    prompt: "attachment should be rejected",
+    attachments: [{ filename: "note.txt", content: "QUJD" }],
+  }));
+  assertErrorCode(rawAttachment400.frames, "400", "unsupported attachment");
+  const rawHandler500 = await rawPromptRoundTrip(callerNc, service.subject.prompt, "explode upstream");
+  assertErrorCode(rawHandler500.frames, "500", "upstream handler failure");
+
+  console.log(JSON.stringify({
+    natsUrl: nats.url,
+    srvInfo: { name: rawInfo.name, version: rawInfo.version, metadata: rawInfo.metadata },
+    subject: service.subject.prompt,
+    status: service.subject.status,
+    heartbeat: service.subject.heartbeat,
+    metadata: agent.metadata,
+    promptEndpoint: agent.promptEndpoint,
+    statusPayload: summarizeStatus(status),
+    heartbeatPayload: summarizeStatus(heartbeat),
+    sdkClientMessageTypes: messages.map((m) => m.type),
+    sdkClientLastMessage: last,
+    rawWire: {
+      plainTextSuccess: summarizeFrames(rawSuccess.frames),
+      jsonNoAttachmentSuccess: summarizeFrames(rawJsonSuccess.frames),
+      unsupportedAttachment400: summarizeFrames(rawAttachment400.frames),
+      handlerFailure500: summarizeFrames(rawHandler500.frames),
+    },
+  }, null, 2));
+} finally {
+  heartbeatSub.unsubscribe();
+  await service.stop();
+  await nc.drain();
+  await callerNc.drain();
+  await nats.close();
+}
+
+interface RawFrame {
+  readonly kind: "chunk" | "error" | "terminator";
+  readonly bytes: number;
+  readonly errorCode?: string;
+  readonly errorDescription?: string;
+  readonly decoded?: unknown;
+}
+
+async function requestJson(caller: typeof nc, subject: string, payload: string): Promise<Record<string, unknown>> {
+  const msg = await caller.request(subject, encoder.encode(payload), { timeout: 2500 });
+  const decoded = decodeBody(msg.data);
+  if (!isRecord(decoded)) throw new Error(`expected JSON object response on ${subject}`);
+  return decoded;
+}
+
+async function nextJson(sub: AsyncIterable<{ data: Uint8Array }>, timeoutMs: number, message: string): Promise<Record<string, unknown>> {
+  const iterator = sub[Symbol.asyncIterator]();
+  const result = await withTimeout(iterator.next(), timeoutMs, message);
+  if (result.done) throw new Error(message);
+  const decoded = decodeBody(result.value.data);
+  if (!isRecord(decoded)) throw new Error("expected JSON object heartbeat");
+  return decoded;
+}
+
+async function rawPromptRoundTrip(caller: typeof nc, subject: string, payload: string): Promise<{ frames: RawFrame[] }> {
+  const reply = `_INBOX.acp-raw-${Math.random().toString(36).slice(2, 8)}`;
+  const sub = caller.subscribe(reply);
+  const frames: RawFrame[] = [];
+  await caller.flush();
+  caller.publish(subject, encoder.encode(payload), { reply });
+  const iterator = sub[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      const result = await withTimeout(iterator.next(), 5000, `timed out waiting for raw protocol frames on ${reply}`);
+      if (result.done) break;
+      const msg = result.value;
+      const frame = describeFrame(msg);
+      frames.push(frame);
+      if (frame.kind === "terminator") break;
+    }
+  } finally {
+    sub.unsubscribe();
+  }
+  if (!frames.some((frame) => frame.kind === "terminator")) throw new Error("raw prompt stream did not include zero-byte terminator");
+  return { frames };
+}
+
+function describeFrame(msg: { data: Uint8Array; headers?: { get(name: string): string | null } | undefined }): RawFrame {
+  const errorCode = msg.headers?.get("Nats-Service-Error-Code") ?? undefined;
+  const errorDescription = msg.headers?.get("Nats-Service-Error") ?? undefined;
+  if (!msg.headers && msg.data.length === 0) return { kind: "terminator", bytes: 0 };
+  if (errorCode) {
+    return {
+      kind: "error",
+      bytes: msg.data.length,
+      errorCode,
+      ...(errorDescription ? { errorDescription } : {}),
+      decoded: decodeBody(msg.data),
+    };
+  }
+  return { kind: "chunk", bytes: msg.data.length, decoded: decodeBody(msg.data) };
+}
+
+function decodeBody(data: Uint8Array): unknown {
+  if (data.length === 0) return null;
+  const text = decoder.decode(data);
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+function assertRawSuccess(frames: readonly RawFrame[]): void {
+  const chunks = frames.filter((frame) => frame.kind === "chunk");
+  const first = chunks[0]?.decoded;
+  if (!isRecord(first) || first.type !== "status" || first.data !== "ack") throw new Error("raw success missing leading ack chunk");
+  if (!chunks.some((frame) => isWireChunk(frame.decoded, "status", "ACP fake bridge selected"))) throw new Error("raw success missing bridge status chunk");
+  if (!chunks.some((frame) => isWireChunk(frame.decoded, "response", "fake ACP response"))) throw new Error("raw success missing response chunk");
+  if (!frames.some((frame) => frame.kind === "terminator")) throw new Error("raw success missing terminator");
+}
+
+function assertErrorCode(frames: readonly RawFrame[], expectedCode: string, label: string): void {
+  const error = frames.find((frame) => frame.kind === "error");
+  assertEqual(error?.errorCode, expectedCode, `${label} error code`);
+  if (!frames.some((frame) => frame.kind === "terminator")) throw new Error(`${label} missing terminator after error`);
+}
+
+function isWireChunk(decoded: unknown, type: string, dataIncludes: string): boolean {
+  return isRecord(decoded) && decoded.type === type && typeof decoded.data === "string" && decoded.data.includes(dataIncludes);
+}
+
+function summarizeFrames(frames: readonly RawFrame[]): Array<Record<string, unknown>> {
+  return frames.map((frame) => {
+    const out: Record<string, unknown> = { kind: frame.kind, bytes: frame.bytes };
+    if (frame.errorCode) out.errorCode = frame.errorCode;
+    if (frame.errorDescription) out.errorDescription = frame.errorDescription;
+    if (isRecord(frame.decoded)) {
+      out.type = frame.decoded.type;
+      if (typeof frame.decoded.data === "string") out.data = frame.decoded.data;
+    } else if (typeof frame.decoded === "string") {
+      out.data = frame.decoded;
+    }
+    return out;
+  });
+}
+
+function summarizeStatus(value: Record<string, unknown>): Record<string, unknown> {
+  return {
+    agent: value.agent,
+    owner: value.owner,
+    session: value.session,
+    interval_s: value.interval_s,
+  };
+}
+
+function assertEqual(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected) throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+async function ensureNats(): Promise<{ url: string; close(): Promise<void> }> {
+  if (process.env["ACP_SMOKE_USE_EXTERNAL_NATS"] === "1" && process.env["NATS_URL"]) {
+    return { url: process.env["NATS_URL"], close: async () => {} };
+  }
+  const port = await freePort();
+  const url = `nats://127.0.0.1:${port}`;
+  const proc = Bun.spawn(["nats-server", "-a", "127.0.0.1", "-p", String(port)], {
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  try {
+    await waitForPort(port, 5000);
+  } catch (err) {
+    proc.kill();
+    const stderr = proc.stderr ? await new Response(proc.stderr).text() : "";
+    throw new Error(`failed to start disposable nats-server: ${(err as Error).message}${stderr ? `\n${stderr}` : ""}`);
+  }
+  return {
+    url,
+    close: async () => {
+      proc.kill();
+      await proc.exited.catch(() => undefined);
+    },
+  };
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => {
+        if (typeof address === "object" && address) resolve(address.port);
+        else reject(new Error("failed to allocate free port"));
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+async function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = createConnection({ host: "127.0.0.1", port }, () => {
+          socket.end();
+          resolve();
+        });
+        socket.on("error", reject);
+      });
+      return;
+    } catch {
+      await Bun.sleep(50);
+    }
+  }
+  throw new Error(`port ${port} did not open within ${timeoutMs}ms`);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new Error(message)), timeoutMs); }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/agents/acp/src/acp-client.ts
+++ b/agents/acp/src/acp-client.ts
@@ -1,0 +1,158 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import {
+  client as acpClientApp,
+  methods,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type ActiveSession,
+  type ClientConnection,
+  type ClientContext,
+  type InitializeResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+import { selectPermissionOutcome } from "./permissions.js";
+
+const STDERR_TAIL_BYTES = 12_000;
+
+export interface AcpAgentClientOptions {
+  /** Binary to spawn (e.g. `grok`). */
+  readonly command: string;
+  /** Args that put it in ACP-over-stdio mode (e.g. `["agent", "stdio"]`). */
+  readonly args: readonly string[];
+  /** Working directory for the child process. */
+  readonly cwd: string;
+  /** Extra env merged over `process.env` (e.g. an isolated `GROK_HOME`). */
+  readonly env?: Record<string, string | undefined>;
+}
+
+export type PermissionRequestHandler = (
+  params: RequestPermissionRequest,
+) => Promise<RequestPermissionResponse> | RequestPermissionResponse;
+
+/**
+ * Spawns an ACP agent subprocess and drives it over newline-delimited
+ * JSON-RPC via the official `@agentclientprotocol/sdk` client.
+ *
+ * The class owns the child process and the ACP connection; permission
+ * requests from the agent route through a swappable handler (default:
+ * deny). Session updates are consumed through the SDK's `ActiveSession`
+ * helper (see {@link startSession}), not a callback — the managed runtime
+ * reads them turn-by-turn.
+ */
+export class AcpAgentClient {
+  readonly #child: ChildProcessWithoutNullStreams;
+  readonly #connection: ClientConnection;
+  readonly #exit: Promise<never>;
+  #stderrTail = "";
+  #closing = false;
+  #permissionHandler: PermissionRequestHandler | undefined;
+
+  private constructor(child: ChildProcessWithoutNullStreams, command: string) {
+    this.#child = child;
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      this.#stderrTail = (this.#stderrTail + chunk.toString("utf8")).slice(-STDERR_TAIL_BYTES);
+    });
+
+    // Rejects when the child dies unexpectedly. Raced against every request
+    // so a crashed agent surfaces as a rejected promise instead of a hang
+    // (the SDK connection may or may not fail pending requests on stream
+    // end — this guard makes crash behavior deterministic either way).
+    this.#exit = new Promise<never>((_, reject) => {
+      child.once("exit", (code, signal) => {
+        if (this.#closing) return;
+        const stderr = this.#stderrTail.trim();
+        reject(new Error(
+          `ACP agent (${command}) exited code=${code} signal=${signal}` +
+          (stderr ? `; stderr tail: ${stderr.slice(-500)}` : ""),
+        ));
+      });
+      child.once("error", (err) => {
+        if (this.#closing) return;
+        reject(new Error(`ACP agent (${command}) failed to spawn: ${err.message}`, { cause: err }));
+      });
+    });
+    // Mark handled so an unobserved crash doesn't trip unhandledRejection;
+    // races re-observe it per call.
+    this.#exit.catch(() => {});
+
+    // Casts route through `unknown`: node:stream's toWeb() types and the
+    // bun-types/DOM web-stream declarations disagree on generics, but the
+    // runtime objects are the byte streams ndJsonStream expects.
+    const stream = ndJsonStream(
+      Writable.toWeb(child.stdin) as unknown as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout) as unknown as ReadableStream<Uint8Array>,
+    );
+    this.#connection = acpClientApp({ name: "synadia-acp-nats-channel" })
+      .onRequest(methods.client.session.requestPermission, (ctx) => this.#onPermission(ctx.params))
+      .connect(stream);
+  }
+
+  static spawn(opts: AcpAgentClientOptions): AcpAgentClient {
+    const child = spawn(opts.command, [...opts.args], {
+      cwd: opts.cwd,
+      env: { ...process.env, ...opts.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return new AcpAgentClient(child, opts.command);
+  }
+
+  /** Last ~12KB of the agent's stderr, for diagnostics. */
+  get stderrTail(): string {
+    return this.#stderrTail;
+  }
+
+  /** Typed context for agent-side ACP methods. */
+  get agent(): ClientContext {
+    return this.#connection.agent;
+  }
+
+  /**
+   * Swap the permission-request handler. `undefined` restores the default
+   * (deny via a `reject_*` option, else the `cancelled` outcome).
+   */
+  setPermissionHandler(handler: PermissionRequestHandler | undefined): void {
+    this.#permissionHandler = handler;
+  }
+
+  #onPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> | RequestPermissionResponse {
+    const handler = this.#permissionHandler;
+    if (handler) return handler(params);
+    return selectPermissionOutcome(params.options, "deny");
+  }
+
+  /** `initialize` handshake. Advertises no fs/terminal capabilities — the agent does its own I/O. */
+  async initialize(): Promise<InitializeResponse> {
+    return await this.raceExit(this.#connection.agent.request(methods.agent.initialize, {
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+    }));
+  }
+
+  /** `session/new` wrapped in the SDK's ActiveSession update router. */
+  async startSession(cwd: string): Promise<ActiveSession> {
+    return await this.raceExit(this.#connection.agent.buildSession(cwd).start());
+  }
+
+  /** Race a pending ACP call against unexpected child exit. */
+  async raceExit<T>(promise: Promise<T>): Promise<T> {
+    return await Promise.race([promise, this.#exit]);
+  }
+
+  async close(): Promise<void> {
+    this.#closing = true;
+    try {
+      this.#connection.close();
+    } catch {
+      /* stream may already be gone */
+    }
+    if (this.#child.exitCode === null && !this.#child.killed) {
+      this.#child.kill("SIGTERM");
+    }
+  }
+}

--- a/agents/acp/src/acp-client.ts
+++ b/agents/acp/src/acp-client.ts
@@ -154,5 +154,28 @@ export class AcpAgentClient {
     if (this.#child.exitCode === null && !this.#child.killed) {
       this.#child.kill("SIGTERM");
     }
+    // Deterministic cleanup: wait for the child to actually exit so no agent
+    // process outlives the channel. Escalate to SIGKILL after a short grace
+    // period (agents exiting cleanly on SIGTERM never hit it).
+    if (this.#child.exitCode === null) {
+      await new Promise<void>((resolvePromise) => {
+        if (this.#child.exitCode !== null) {
+          resolvePromise();
+          return;
+        }
+        const timer = setTimeout(() => {
+          try {
+            this.#child.kill("SIGKILL");
+          } catch {
+            /* already gone */
+          }
+          resolvePromise();
+        }, 1_500);
+        this.#child.once("exit", () => {
+          clearTimeout(timer);
+          resolvePromise();
+        });
+      });
+    }
   }
 }

--- a/agents/acp/src/attachments.ts
+++ b/agents/acp/src/attachments.ts
@@ -1,0 +1,7 @@
+import { ProtocolError, type RequestEnvelope } from "@synadia-ai/agents";
+
+export function rejectUnsupportedAttachments(envelope: RequestEnvelope): void {
+  if ((envelope.attachments?.length ?? 0) > 0) {
+    throw new ProtocolError("attachments are not supported by the ACP NATS adapter v1");
+  }
+}

--- a/agents/acp/src/bridge.ts
+++ b/agents/acp/src/bridge.ts
@@ -2,7 +2,7 @@ import type { RequestEnvelope } from "@synadia-ai/agents";
 import type { PromptResponse } from "@synadia-ai/agent-service";
 import { rejectUnsupportedAttachments } from "./attachments.js";
 import type { AcpPermissionDecision } from "./permissions.js";
-import type { AcpMapping } from "./types.js";
+import type { AcpMapping, AcpPermissionPolicy } from "./types.js";
 
 export interface AcpBridgeClient {
   readonly mode: "fake" | "managed";
@@ -13,7 +13,7 @@ export interface AcpBridgeClient {
 export interface AcpPromptRequest {
   readonly prompt: string;
   readonly publicSession: string;
-  readonly permissionPolicy: string;
+  readonly permissionPolicy: AcpPermissionPolicy;
   readonly askPermission?: (prompt: string) => Promise<AcpPermissionDecision>;
 }
 

--- a/agents/acp/src/bridge.ts
+++ b/agents/acp/src/bridge.ts
@@ -1,0 +1,70 @@
+import type { RequestEnvelope } from "@synadia-ai/agents";
+import type { PromptResponse } from "@synadia-ai/agent-service";
+import { rejectUnsupportedAttachments } from "./attachments.js";
+import type { AcpPermissionDecision } from "./permissions.js";
+import type { AcpMapping } from "./types.js";
+
+export interface AcpBridgeClient {
+  readonly mode: "fake" | "managed";
+  prompt(prompt: AcpPromptRequest): AsyncIterable<AcpBridgeEvent>;
+  close?(): Promise<void>;
+}
+
+export interface AcpPromptRequest {
+  readonly prompt: string;
+  readonly publicSession: string;
+  readonly permissionPolicy: string;
+  readonly askPermission?: (prompt: string) => Promise<AcpPermissionDecision>;
+}
+
+export type AcpBridgeEvent =
+  | { readonly type: "status"; readonly text: string }
+  | { readonly type: "response"; readonly text: string }
+  | { readonly type: "done" };
+
+export interface BridgePromptInput {
+  readonly envelope: RequestEnvelope;
+  readonly response: PromptResponse;
+  readonly mapping: AcpMapping;
+  readonly client: AcpBridgeClient;
+}
+
+export async function bridgePromptToAcp(input: BridgePromptInput): Promise<void> {
+  rejectUnsupportedAttachments(input.envelope);
+  await input.response.send({ type: "status", status: `ACP ${input.client.mode} bridge selected (${input.mapping.acp.agentId})` });
+  const request: AcpPromptRequest = {
+    prompt: input.envelope.prompt,
+    publicSession: input.mapping.session,
+    permissionPolicy: input.mapping.acp.permissionPolicy,
+    ...(input.mapping.acp.permissionPolicy === "query"
+      ? { askPermission: (prompt: string) => askPermissionViaProtocol(input.response, prompt) }
+      : {}),
+  };
+  for await (const event of input.client.prompt(request)) {
+    if (event.type === "status") await input.response.send({ type: "status", status: event.text });
+    if (event.type === "response") await input.response.send(event.text);
+  }
+}
+
+async function askPermissionViaProtocol(response: PromptResponse, prompt: string): Promise<AcpPermissionDecision> {
+  try {
+    const reply = await response.ask(prompt, { timeoutMs: 30_000 });
+    const normalized = reply.prompt.trim().toLowerCase();
+    if (normalized === "approve" || normalized === "approved" || normalized === "yes" || normalized === "y") return "approve";
+    if (normalized === "deny" || normalized === "decline" || normalized === "no" || normalized === "n") return "deny";
+    return "cancel";
+  } catch {
+    return "cancel";
+  }
+}
+
+export class FakeAcpBridgeClient implements AcpBridgeClient {
+  readonly mode = "fake" as const;
+
+  async *prompt(input: AcpPromptRequest): AsyncIterable<AcpBridgeEvent> {
+    if (input.prompt.includes("explode")) throw new Error("fake ACP bridge exploded");
+    yield { type: "status", text: `fake ACP session ${input.publicSession} ready` };
+    yield { type: "response", text: `fake ACP response to ${input.prompt}` };
+    yield { type: "done" };
+  }
+}

--- a/agents/acp/src/cli.ts
+++ b/agents/acp/src/cli.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+import { connect as natsConnect } from "@nats-io/transport-node";
+import { readFileSync } from "node:fs";
+import { FakeAcpBridgeClient, type AcpBridgeClient } from "./bridge.js";
+import { helpText, loadConfigFromSources, parseArgs, renderConfigTemplate } from "./config.js";
+import { runDoctor } from "./doctor.js";
+import { ManagedAcpRuntime } from "./managed-runtime.js";
+import { resolveNatsOptions } from "./nats.js";
+import { createAcpAgentService } from "./service.js";
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const command = resolveCliCommand(argv);
+  if (command === "help" || argv.includes("--help") || argv.includes("-h")) {
+    console.log(helpText());
+    return;
+  }
+  if (command === "configure" && argv.includes("--print-template")) {
+    console.log(renderConfigTemplate());
+    return;
+  }
+
+  const config = loadConfigFromSources();
+  if (command === "doctor") {
+    console.log(JSON.stringify(runDoctor(config), null, 2));
+    return;
+  }
+  if (command !== "start") throw new Error(`unknown command ${command}`);
+
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version?: string };
+  const client = await createBridgeClient(config);
+  const nc = await natsConnect(await resolveNatsOptions(config.nats));
+  const service = createAcpAgentService({
+    nc,
+    config,
+    version: pkg.version ?? "0.0.0",
+    client,
+  });
+  await service.start();
+  console.log(`acp-agent (${config.acp.agentId}, ${config.acp.mode}) listening on ${service.subject.prompt}`);
+  await waitForShutdown();
+  await service.stop();
+  await client.close?.();
+  await nc.drain();
+}
+
+export function resolveCliCommand(argv: readonly string[]): string {
+  return parseArgs(argv).command;
+}
+
+async function createBridgeClient(config: ReturnType<typeof loadConfigFromSources>): Promise<AcpBridgeClient> {
+  if (config.acp.mode === "fake") return new FakeAcpBridgeClient();
+  // Managed: start eagerly so spawn/auth failures surface at boot with a
+  // clear message instead of as a 500 on the first NATS prompt.
+  const runtime = new ManagedAcpRuntime({ config });
+  await runtime.start();
+  return runtime;
+}
+
+async function waitForShutdown(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const done = (): void => resolve();
+    process.once("SIGINT", done);
+    process.once("SIGTERM", done);
+  });
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/agents/acp/src/cli.ts
+++ b/agents/acp/src/cli.ts
@@ -8,8 +8,12 @@ import { ManagedAcpRuntime } from "./managed-runtime.js";
 import { resolveNatsOptions } from "./nats.js";
 import { createAcpAgentService } from "./service.js";
 
-async function main(): Promise<void> {
-  const argv = process.argv.slice(2);
+/**
+ * Run the acp-agent CLI against an explicit argv (no trailing node/bun
+ * prefix). Exported so thin per-agent wrapper packages (e.g.
+ * `@synadia-ai/grok-nats-channel`) can pin preset defaults and delegate.
+ */
+export async function runCli(argv: readonly string[]): Promise<void> {
   const command = resolveCliCommand(argv);
   if (command === "help" || argv.includes("--help") || argv.includes("-h")) {
     console.log(helpText());
@@ -20,7 +24,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const config = loadConfigFromSources();
+  const config = loadConfigFromSources({ argv });
   if (command === "doctor") {
     console.log(JSON.stringify(runDoctor(config), null, 2));
     return;
@@ -66,7 +70,7 @@ async function waitForShutdown(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((err: unknown) => {
+  runCli(process.argv.slice(2)).catch((err: unknown) => {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   });

--- a/agents/acp/src/config.ts
+++ b/agents/acp/src/config.ts
@@ -1,0 +1,329 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { resolvePreset, presetKeys, type AcpAgentPreset } from "./presets.js";
+import { requireSubjectToken, sanitizeDerivedSubjectToken } from "./subject.js";
+import type {
+  AcpChannelConfig,
+  AcpMapping,
+  AcpMode,
+  AcpPermissionPolicy,
+  AcpRuntimeConfig,
+  AgentIdentityConfig,
+  NatsConfig,
+} from "./types.js";
+
+export type {
+  AcpChannelConfig,
+  AcpMapping,
+  AcpMode,
+  AcpPermissionPolicy,
+  AcpRuntimeConfig,
+  AgentIdentityConfig,
+  NatsConfig,
+} from "./types.js";
+
+export interface ParsedArgs {
+  readonly command: string;
+  readonly config?: string;
+  readonly natsUrl?: string;
+  readonly natsContext?: string;
+  readonly natsCreds?: string;
+  readonly owner?: string;
+  readonly session?: string;
+  readonly subjectToken?: string;
+  readonly agent?: string;
+  readonly agentId?: string;
+  readonly mode?: AcpMode;
+  readonly acpBin?: string;
+  readonly acpArgs?: string;
+  readonly agentHome?: string;
+  readonly acpCwd?: string;
+  readonly permissionPolicy?: AcpPermissionPolicy;
+  readonly heartbeatIntervalS?: number;
+  readonly keepaliveIntervalS?: number;
+  readonly printTemplate?: boolean;
+  readonly help?: boolean;
+}
+
+export interface LoadConfigSources {
+  readonly argv?: readonly string[];
+  readonly env?: Record<string, string | undefined>;
+  readonly readFile?: (path: string) => string;
+  readonly cwd?: string;
+}
+
+export const DEFAULT_CONFIG_PATH = join(homedir(), ".config", "synadia", "acp-nats-channel.toml");
+
+const flagMap: Record<string, keyof Omit<ParsedArgs, "command">> = {
+  "--config": "config",
+  "--nats-url": "natsUrl",
+  "--nats-context": "natsContext",
+  "--nats-creds": "natsCreds",
+  "--owner": "owner",
+  "--session": "session",
+  "--subject-token": "subjectToken",
+  "--agent": "agent",
+  "--agent-id": "agentId",
+  "--mode": "mode",
+  "--acp-bin": "acpBin",
+  "--acp-args": "acpArgs",
+  "--agent-home": "agentHome",
+  "--cwd": "acpCwd",
+  "--permission-policy": "permissionPolicy",
+  "--heartbeat-interval-s": "heartbeatIntervalS",
+  "--keepalive-interval-s": "keepaliveIntervalS",
+};
+
+const numericFlags = new Set<keyof ParsedArgs>(["heartbeatIntervalS", "keepaliveIntervalS"]);
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const [first = "help", ...rest] = argv;
+  const out: Record<string, unknown> = { command: first };
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === undefined) continue;
+    if (arg === "--help" || arg === "-h") { out.help = true; continue; }
+    if (arg === "--print-template") { out.printTemplate = true; continue; }
+    const key = flagMap[arg];
+    if (!key) throw new Error(`unknown flag ${arg}`);
+    const value = rest[++i];
+    if (value === undefined) throw new Error(`${arg} requires a value`);
+    if (numericFlags.has(key)) {
+      out[key] = parsePositiveNumber(value, arg);
+    } else if (key === "mode") {
+      out[key] = parseAcpMode(value, arg);
+    } else if (key === "permissionPolicy") {
+      out[key] = parsePermissionPolicy(value, arg);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out as unknown as ParsedArgs;
+}
+
+type TomlTree = Record<string, Record<string, string>>;
+
+// Tiny TOML reader for the adapter's generated config template: sections plus
+// simple string/numeric/boolean key-value pairs with inline comments. It is not
+// a general TOML parser; use the documented template shape for config files.
+// Mirrors agents/codex/src/config.ts.
+function parseTinyToml(source: string): TomlTree {
+  const tree: TomlTree = {};
+  let section = "";
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const sec = /^\[([^\]]+)\]$/.exec(line);
+    if (sec) { section = sec[1] ?? ""; tree[section] ??= {}; continue; }
+    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+?)(?:\s+#.*)?$/.exec(line);
+    if (!kv || !section) continue;
+    const key = kv[1] ?? "";
+    let value = (kv[2] ?? "").trim();
+    value = value.replace(/^"|"$/g, "");
+    tree[section]![key] = value;
+  }
+  return tree;
+}
+
+function readConfig(path: string, readFile: (path: string) => string): TomlTree {
+  try {
+    const source = readFile(path);
+    return source ? parseTinyToml(source) : {};
+  } catch {
+    return {};
+  }
+}
+
+const get = (...values: Array<string | undefined>): string | undefined => values.find((v) => v !== undefined && v !== "");
+
+export function loadConfigFromSources(sources: LoadConfigSources = {}): AcpChannelConfig {
+  const env = sources.env ?? process.env;
+  const args = parseArgs(sources.argv ?? process.argv.slice(2));
+  const cwd = sources.cwd ?? process.cwd();
+  const configPath = args.config ?? env.SYNADIA_ACP_CONFIG ?? DEFAULT_CONFIG_PATH;
+  const readFile = sources.readFile ?? ((p: string) => existsSync(p) ? readFileSync(p, "utf8") : "");
+  const file = readConfig(configPath, readFile);
+  const natsSection = file.nats ?? {};
+  const agentSection = file.agent ?? {};
+  const acpSection = file.acp ?? {};
+
+  // Preset resolves first — the per-agent SYNADIA_<AGENT>_* env vars below
+  // depend on which preset is active.
+  const presetKey = get(args.agent, env.SYNADIA_ACP_AGENT, acpSection.agent, "grok")!;
+  const preset: AcpAgentPreset | undefined = presetKey === "custom" ? undefined : resolvePreset(presetKey);
+  if (presetKey !== "custom" && preset === undefined) {
+    throw new Error(`acp.agent must be one of: ${presetKeys()}`);
+  }
+  // Per-agent identity env var lookup (SYNADIA_GROK_OWNER etc.). Custom
+  // agents only have the channel-level SYNADIA_ACP_* vars.
+  const perAgent = (suffix: string): string | undefined =>
+    preset ? env[`${preset.envPrefix}_${suffix}`] : undefined;
+
+  const defaultSession = sanitizeDerivedSubjectToken(basename(resolve(cwd))) || "main";
+  // Identity precedence (SYNADIA_* convention shared across agents/*):
+  // CLI > per-agent env > channel env (SYNADIA_ACP_*) > fleet-wide env > file > derived.
+  const owner = requireSubjectToken(
+    get(args.owner, perAgent("OWNER"), env.SYNADIA_ACP_OWNER, env.SYNADIA_OWNER, agentSection.owner, sanitizeDerivedSubjectToken(env.USER ?? "unknown") || "unknown")!,
+    "agent.owner",
+  );
+  const session = requireSubjectToken(
+    get(args.session, perAgent("SESSION"), env.SYNADIA_ACP_SESSION, env.SYNADIA_NAME, agentSection.session, defaultSession)!,
+    "agent.session",
+  );
+
+  // Unlike the codex adapter, the subject token is per-preset, not fixed:
+  // the ACP channel hosts many agent identities. Overrides are validated,
+  // never rewritten.
+  const agentId = preset
+    ? preset.agentId
+    : requireSubjectToken(
+        get(args.agentId, env.SYNADIA_ACP_AGENT_ID, acpSection.agent_id) ?? missing("custom agent requires --agent-id (metadata.agent identifier)"),
+        "acp.agent_id",
+      );
+  const subjectToken = requireSubjectToken(
+    get(args.subjectToken, acpSection.subject_token, preset ? preset.subjectToken : agentId)!,
+    "agent.subject_token",
+  );
+
+  const natsContext = get(args.natsContext, env.NATS_CONTEXT, natsSection.context);
+  const natsCreds = get(args.natsCreds, env.NATS_CREDS, env.NATS_CREDENTIALS, natsSection.creds);
+  const nats: NatsConfig = {
+    url: get(args.natsUrl, env.NATS_URL, natsSection.url, "nats://127.0.0.1:4222")!,
+    ...(natsContext ? { context: natsContext } : {}),
+    ...(natsCreds ? { creds: natsCreds } : {}),
+  };
+
+  const bin = get(args.acpBin, perAgent("BIN"), env.SYNADIA_ACP_BIN, acpSection.bin, preset?.bin)
+    ?? missing("custom agent requires --acp-bin (binary to spawn in ACP stdio mode)");
+  const rawArgs = get(args.acpArgs, perAgent("ARGS"), env.SYNADIA_ACP_ARGS, acpSection.args);
+  const acpArgs: readonly string[] = rawArgs !== undefined
+    ? rawArgs.split(/\s+/).filter(Boolean)
+    : preset?.args ?? [];
+
+  const agentHome = get(args.agentHome, perAgent("HOME"), env.SYNADIA_ACP_HOME, acpSection.agent_home);
+  if (agentHome !== undefined && preset?.homeEnvVar === undefined) {
+    throw new Error(
+      `acp.agent_home requires a preset with a home env var (currently: grok via GROK_HOME); ` +
+      `for other agents point the agent at its home through your own environment`,
+    );
+  }
+
+  const acpMode = parseAcpMode(get(args.mode, env.SYNADIA_ACP_MODE, acpSection.mode, "fake")!, "acp.mode");
+  const acp: AcpRuntimeConfig = {
+    mode: acpMode,
+    preset: presetKey,
+    agentId,
+    bin,
+    args: acpArgs,
+    ...(preset?.homeEnvVar !== undefined ? { homeEnvVar: preset.homeEnvVar } : {}),
+    ...(agentHome !== undefined ? { agentHome } : {}),
+    cwd: resolve(get(args.acpCwd, env.SYNADIA_ACP_CWD, acpSection.cwd) ?? cwd),
+    permissionPolicy: parsePermissionPolicy(
+      get(args.permissionPolicy, perAgent("PERMISSION_POLICY"), env.SYNADIA_ACP_PERMISSION_POLICY, acpSection.permission_policy, "reject")!,
+      "acp.permission_policy",
+    ),
+  };
+
+  const agent: AgentIdentityConfig = {
+    owner,
+    session,
+    subjectToken,
+    heartbeatIntervalS: parsePositiveNumber(get(args.heartbeatIntervalS?.toString(), agentSection.heartbeat_interval_s, "30")!, "agent.heartbeat_interval_s"),
+    keepaliveIntervalS: parsePositiveNumber(get(args.keepaliveIntervalS?.toString(), agentSection.keepalive_interval_s, "30")!, "agent.keepalive_interval_s"),
+  };
+
+  return { nats, agent, acp };
+}
+
+function missing(message: string): never {
+  throw new Error(message);
+}
+
+function parsePositiveNumber(value: string, field: string): number {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) throw new Error(`${field} must be a positive number`);
+  return number;
+}
+
+function parseAcpMode(value: string, field: string): AcpMode {
+  if (value === "fake" || value === "managed") return value;
+  throw new Error(`${field} must be fake or managed`);
+}
+
+function parsePermissionPolicy(value: string, field: string): AcpPermissionPolicy {
+  if (value === "reject" || value === "query" || value === "allow") return value;
+  throw new Error(`${field} must be reject, query, or allow`);
+}
+
+export function mappingFromConfig(config: AcpChannelConfig): AcpMapping {
+  return {
+    owner: config.agent.owner,
+    session: config.agent.session,
+    subjectToken: config.agent.subjectToken,
+    acp: config.acp,
+  };
+}
+
+export function renderConfigTemplate(): string {
+  return `[nats]
+url = "nats://127.0.0.1:4222"
+context = ""
+creds = ""
+
+[agent]
+owner = "local"
+session = "main"
+# Defaults to the preset's token (grok -> "grok", gemini -> "gemini").
+subject_token = ""
+heartbeat_interval_s = 30
+keepalive_interval_s = 30
+
+[acp]
+# Preset: grok, gemini, or custom (custom requires agent_id + bin).
+agent = "grok"
+# Managed spawns an adapter-owned ACP agent subprocess; fake is for protocol smoke tests.
+mode = "managed"
+bin = ""
+args = ""
+agent_id = ""
+# Point at an already-authenticated agent home (e.g. ~/.grok) to reuse auth.
+# Leave empty for an ephemeral isolated home (removed on shutdown).
+agent_home = ""
+# Working directory for the ACP session. Defaults to the process cwd.
+cwd = ""
+permission_policy = "reject"
+`;
+}
+
+export function helpText(): string {
+  return `Usage: acp-agent <start|doctor|configure> [options]
+
+Commands:
+  start                 Register an ACP-backed agent on NATS using the configured bridge mode
+  doctor                Print resolved config and ACP binary readiness
+  configure --print-template
+
+Options:
+  --config PATH
+  --nats-url URL
+  --nats-context NAME
+  --nats-creds PATH
+  --owner TOKEN
+  --session TOKEN
+  --subject-token TOKEN
+  --agent ${presetKeys()}
+  --agent-id TOKEN          (custom preset: metadata.agent identifier)
+  --mode fake|managed
+  --acp-bin PATH_OR_NAME
+  --acp-args "ARGS..."      (space-separated, e.g. "agent stdio")
+  --agent-home PATH         (reuse an authenticated agent home, e.g. ~/.grok)
+  --cwd PATH                (working directory for the ACP session)
+  --permission-policy reject|query|allow
+  --heartbeat-interval-s SECONDS
+  --keepalive-interval-s SECONDS
+
+Presets spawn: grok -> \`grok agent stdio\` (GROK_HOME isolated per run unless
+--agent-home is set), gemini -> \`gemini --experimental-acp\`.
+`;
+}

--- a/agents/acp/src/config.ts
+++ b/agents/acp/src/config.ts
@@ -274,7 +274,7 @@ creds = ""
 [agent]
 owner = "local"
 session = "main"
-# Defaults to the preset's token (grok -> "grok", gemini -> "gemini").
+# Defaults to the preset's token (e.g. grok -> "grok").
 subject_token = ""
 heartbeat_interval_s = 30
 keepalive_interval_s = 30

--- a/agents/acp/src/config.ts
+++ b/agents/acp/src/config.ts
@@ -280,7 +280,7 @@ heartbeat_interval_s = 30
 keepalive_interval_s = 30
 
 [acp]
-# Preset: grok, gemini, or custom (custom requires agent_id + bin).
+# Preset: grok or custom (custom requires agent_id + bin).
 agent = "grok"
 # Managed spawns an adapter-owned ACP agent subprocess; fake is for protocol smoke tests.
 mode = "managed"
@@ -324,6 +324,7 @@ Options:
   --keepalive-interval-s SECONDS
 
 Presets spawn: grok -> \`grok agent stdio\` (GROK_HOME isolated per run unless
---agent-home is set), gemini -> \`gemini --experimental-acp\`.
+--agent-home is set). Use --agent custom with --agent-id/--acp-bin for any
+other ACP-speaking agent or adapter (e.g. Antigravity via an ACP adapter).
 `;
 }

--- a/agents/acp/src/doctor.ts
+++ b/agents/acp/src/doctor.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import type { AcpChannelConfig } from "./types.js";
+
+export interface DoctorBinaryCheck {
+  readonly ok: boolean;
+  readonly version?: string;
+  readonly error?: string;
+}
+
+export interface DoctorReport {
+  readonly identity: {
+    readonly owner: string;
+    readonly session: string;
+    readonly subjectToken: string;
+    readonly promptSubject: string;
+  };
+  readonly acp: {
+    readonly preset: string;
+    readonly agentId: string;
+    readonly mode: string;
+    readonly bin: string;
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly permissionPolicy: string;
+    readonly agentHome: string;
+  };
+  readonly nats: {
+    readonly target: string;
+    readonly credsConfigured: boolean;
+  };
+  readonly binary: DoctorBinaryCheck;
+}
+
+/** Probe `<bin> --version` without starting a full ACP session (no auth side effects). */
+export function checkBinary(bin: string): DoctorBinaryCheck {
+  try {
+    const result = spawnSync(bin, ["--version"], { encoding: "utf8", timeout: 5_000 });
+    if (result.error) return { ok: false, error: result.error.message };
+    if (result.status !== 0) {
+      return { ok: false, error: `exit code ${result.status}${result.stderr ? `: ${result.stderr.trim().slice(0, 200)}` : ""}` };
+    }
+    return { ok: true, version: result.stdout.trim().slice(0, 120) };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export function runDoctor(config: AcpChannelConfig): DoctorReport {
+  const { agent, acp, nats } = config;
+  return {
+    identity: {
+      owner: agent.owner,
+      session: agent.session,
+      subjectToken: agent.subjectToken,
+      promptSubject: `agents.prompt.${agent.subjectToken}.${agent.owner}.${agent.session}`,
+    },
+    acp: {
+      preset: acp.preset,
+      agentId: acp.agentId,
+      mode: acp.mode,
+      bin: acp.bin,
+      args: acp.args,
+      cwd: acp.cwd,
+      permissionPolicy: acp.permissionPolicy,
+      agentHome: acp.agentHome ?? (acp.homeEnvVar !== undefined ? `(ephemeral temp dir via ${acp.homeEnvVar})` : "(agent default)"),
+    },
+    nats: {
+      target: nats.context ? `context:${nats.context}` : nats.url ?? "nats://127.0.0.1:4222",
+      credsConfigured: nats.creds !== undefined,
+    },
+    binary: checkBinary(acp.bin),
+  };
+}

--- a/agents/acp/src/doctor.ts
+++ b/agents/acp/src/doctor.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { buildPromptSubject } from "./subject.js";
 import type { AcpChannelConfig } from "./types.js";
 
 export interface DoctorBinaryCheck {
@@ -52,7 +53,7 @@ export function runDoctor(config: AcpChannelConfig): DoctorReport {
       owner: agent.owner,
       session: agent.session,
       subjectToken: agent.subjectToken,
-      promptSubject: `agents.prompt.${agent.subjectToken}.${agent.owner}.${agent.session}`,
+      promptSubject: buildPromptSubject(agent.subjectToken, agent.owner, agent.session),
     },
     acp: {
       preset: acp.preset,

--- a/agents/acp/src/index.ts
+++ b/agents/acp/src/index.ts
@@ -1,4 +1,5 @@
 export { AcpAgentClient, type AcpAgentClientOptions, type PermissionRequestHandler } from "./acp-client.js";
+export { runCli } from "./cli.js";
 export { rejectUnsupportedAttachments } from "./attachments.js";
 export { bridgePromptToAcp, FakeAcpBridgeClient, type AcpBridgeClient, type AcpBridgeEvent, type AcpPromptRequest } from "./bridge.js";
 export { DEFAULT_CONFIG_PATH, helpText, loadConfigFromSources, mappingFromConfig, parseArgs, renderConfigTemplate } from "./config.js";

--- a/agents/acp/src/index.ts
+++ b/agents/acp/src/index.ts
@@ -1,0 +1,18 @@
+export { AcpAgentClient, type AcpAgentClientOptions, type PermissionRequestHandler } from "./acp-client.js";
+export { rejectUnsupportedAttachments } from "./attachments.js";
+export { bridgePromptToAcp, FakeAcpBridgeClient, type AcpBridgeClient, type AcpBridgeEvent, type AcpPromptRequest } from "./bridge.js";
+export { DEFAULT_CONFIG_PATH, helpText, loadConfigFromSources, mappingFromConfig, parseArgs, renderConfigTemplate } from "./config.js";
+export { checkBinary, runDoctor, type DoctorBinaryCheck, type DoctorReport } from "./doctor.js";
+export { ManagedAcpRuntime, mapSessionUpdate, type ManagedAcpRuntimeOptions } from "./managed-runtime.js";
+export { resolveNatsOptions } from "./nats.js";
+export {
+  permissionPromptText,
+  resolvePermissionRequest,
+  selectPermissionOutcome,
+  type AcpPermissionDecision,
+  type PermissionSink,
+} from "./permissions.js";
+export { ACP_PRESETS, presetKeys, resolvePreset, type AcpAgentPreset } from "./presets.js";
+export { buildAgentServiceOptions, createAcpAgentService } from "./service.js";
+export { buildHeartbeatSubject, buildPromptSubject, buildStatusSubject, requireSubjectToken, sanitizeDerivedSubjectToken } from "./subject.js";
+export type { AcpChannelConfig, AcpMapping, AcpMode, AcpPermissionPolicy, AcpRuntimeConfig, AgentIdentityConfig, NatsConfig } from "./types.js";

--- a/agents/acp/src/managed-runtime.ts
+++ b/agents/acp/src/managed-runtime.ts
@@ -1,0 +1,197 @@
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { ActiveSession, InitializeResponse, SessionUpdate } from "@agentclientprotocol/sdk";
+import { AcpAgentClient } from "./acp-client.js";
+import type { AcpBridgeClient, AcpBridgeEvent, AcpPromptRequest } from "./bridge.js";
+import { resolvePermissionRequest, type AcpPermissionDecision } from "./permissions.js";
+import type { AcpChannelConfig, AcpPermissionPolicy } from "./types.js";
+
+export interface ManagedAcpRuntimeOptions {
+  readonly config: AcpChannelConfig;
+  /** Override the spawned command (tests/smokes point this at the fake agent). */
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly env?: Record<string, string | undefined>;
+  readonly permissionTimeoutMs?: number;
+}
+
+/**
+ * Adapter-owned ACP agent: spawns the configured binary in ACP-stdio mode,
+ * opens one long-lived session (so conversation memory persists across NATS
+ * prompts), and streams each turn's `session/update` notifications as bridge
+ * events.
+ *
+ * When the preset defines a home env var (grok: `GROK_HOME`) and no explicit
+ * `agent_home` is configured, the runtime isolates the agent in an ephemeral
+ * temp home which is removed on close — this also keeps grok's leader socket
+ * (which lives under GROK_HOME) from multiplexing into a user's interactive
+ * session. A fresh isolated home is unauthenticated; see the README auth
+ * section.
+ *
+ * There is no subprocess supervision: if the agent crashes, in-flight and
+ * subsequent prompts fail (surfaced to NATS callers as 500s) until the
+ * channel is restarted. Mirrors the codex adapter's crash model.
+ */
+export class ManagedAcpRuntime implements AcpBridgeClient {
+  readonly mode = "managed" as const;
+  agentHome: string | undefined;
+  readonly #opts: ManagedAcpRuntimeOptions;
+  readonly #ownsHome: boolean;
+  #client: AcpAgentClient | undefined;
+  #session: ActiveSession | undefined;
+  #initInfo: InitializeResponse | undefined;
+  #turnLock: Promise<void> = Promise.resolve();
+
+  constructor(opts: ManagedAcpRuntimeOptions) {
+    this.#opts = opts;
+    const acp = opts.config.acp;
+    this.#ownsHome = acp.homeEnvVar !== undefined && acp.agentHome === undefined;
+    if (acp.agentHome !== undefined) {
+      this.agentHome = resolve(acp.agentHome);
+    }
+  }
+
+  get ready(): boolean {
+    return this.#session !== undefined;
+  }
+
+  get initializeResponse(): InitializeResponse | undefined {
+    return this.#initInfo;
+  }
+
+  get stderrTail(): string {
+    return this.#client?.stderrTail ?? "";
+  }
+
+  async start(): Promise<void> {
+    if (this.#session) return;
+    const acp = this.#opts.config.acp;
+    const env: Record<string, string | undefined> = { ...this.#opts.env };
+    if (acp.homeEnvVar !== undefined) {
+      env[acp.homeEnvVar] = this.#ensureHome();
+    }
+    const client = AcpAgentClient.spawn({
+      command: this.#opts.command ?? acp.bin,
+      args: this.#opts.args ?? acp.args,
+      cwd: acp.cwd,
+      env,
+    });
+    this.#client = client;
+    try {
+      this.#initInfo = await client.initialize();
+      this.#session = await client.startSession(acp.cwd);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const stderr = client.stderrTail.trim();
+      const hint = acp.homeEnvVar !== undefined && this.#ownsHome
+        ? ` Hint: managed mode runs ${acp.bin} in an isolated ${acp.homeEnvVar}; if the agent requires authentication, ` +
+          `authenticate it once and pass --agent-home pointing at that home (e.g. ~/.grok).`
+        : "";
+      await this.close();
+      throw new Error(
+        `failed to start managed ACP agent (${acp.bin}): ${message}` +
+        (stderr ? `; agent stderr tail: ${stderr.slice(-500)}` : "") +
+        hint,
+        { cause: err },
+      );
+    }
+  }
+
+  async *prompt(input: AcpPromptRequest): AsyncIterable<AcpBridgeEvent> {
+    await this.start();
+    const client = this.#client;
+    const session = this.#session;
+    if (!client || !session) throw new Error("managed ACP runtime failed to start");
+
+    // ACP allows one in-flight `session/prompt` per session; serialize turns
+    // so overlapping NATS requests queue instead of violating the protocol.
+    const release = await this.#acquireTurn();
+    try {
+      yield { type: "status", text: "managed ACP agent ready" };
+      client.setPermissionHandler((params) => resolvePermissionRequest(params, {
+        policy: input.permissionPolicy as AcpPermissionPolicy,
+        ...(input.askPermission !== undefined
+          ? { sink: (prompt: string): Promise<AcpPermissionDecision> => input.askPermission!(prompt) }
+          : {}),
+        timeoutMs: this.#opts.permissionTimeoutMs ?? 30_000,
+      }));
+      try {
+        const turn = session.prompt(input.prompt);
+        // On success the SDK also queues a `stop` message, so the loop below
+        // ends via nextUpdate(). On failure nothing is queued — race the
+        // rejection in so a JSON-RPC error can't hang the stream.
+        const failed = new Promise<never>((_, reject) => { turn.catch(reject); });
+        for (;;) {
+          const message = await client.raceExit(Promise.race([session.nextUpdate(), failed]));
+          if (message.kind === "stop") {
+            if (message.stopReason !== "end_turn") {
+              yield { type: "status", text: `stop: ${message.stopReason}` };
+            }
+            break;
+          }
+          const event = mapSessionUpdate(message.update);
+          if (event) yield event;
+        }
+      } finally {
+        client.setPermissionHandler(undefined);
+      }
+    } finally {
+      release();
+    }
+    yield { type: "done" };
+  }
+
+  async close(): Promise<void> {
+    this.#session?.dispose();
+    this.#session = undefined;
+    await this.#client?.close();
+    this.#client = undefined;
+    if (this.#ownsHome && this.agentHome !== undefined) {
+      rmSync(this.agentHome, { recursive: true, force: true });
+      this.agentHome = undefined;
+    }
+  }
+
+  #ensureHome(): string {
+    if (this.agentHome === undefined) this.agentHome = mkdtempSync(join(tmpdir(), "synadia-acp-home-"));
+    mkdirSync(this.agentHome, { recursive: true });
+    return this.agentHome;
+  }
+
+  async #acquireTurn(): Promise<() => void> {
+    const prev = this.#turnLock;
+    let release!: () => void;
+    this.#turnLock = new Promise<void>((res) => { release = res; });
+    await prev;
+    return release;
+  }
+}
+
+/**
+ * Map one ACP `session/update` onto a bridge event. Assistant text becomes
+ * response chunks; tool calls and plans surface as terse status chunks;
+ * thoughts and echo/user chunks are dropped.
+ */
+export function mapSessionUpdate(update: SessionUpdate): AcpBridgeEvent | undefined {
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk":
+      if (update.content.type === "text" && update.content.text.length > 0) {
+        return { type: "response", text: update.content.text };
+      }
+      return undefined;
+    case "tool_call":
+      return { type: "status", text: `tool: ${update.title ?? update.toolCallId}` };
+    case "tool_call_update": {
+      const status = update.status;
+      if (status === "completed" || status === "failed") {
+        return { type: "status", text: `tool ${status}: ${update.title ?? update.toolCallId}` };
+      }
+      return undefined;
+    }
+    case "plan":
+      return { type: "status", text: `plan: ${update.entries.length} step(s)` };
+    default:
+      return undefined;
+  }
+}

--- a/agents/acp/src/managed-runtime.ts
+++ b/agents/acp/src/managed-runtime.ts
@@ -5,7 +5,7 @@ import type { ActiveSession, InitializeResponse, SessionUpdate } from "@agentcli
 import { AcpAgentClient } from "./acp-client.js";
 import type { AcpBridgeClient, AcpBridgeEvent, AcpPromptRequest } from "./bridge.js";
 import { resolvePermissionRequest, type AcpPermissionDecision } from "./permissions.js";
-import type { AcpChannelConfig, AcpPermissionPolicy } from "./types.js";
+import type { AcpChannelConfig } from "./types.js";
 
 export interface ManagedAcpRuntimeOptions {
   readonly config: AcpChannelConfig;
@@ -35,9 +35,9 @@ export interface ManagedAcpRuntimeOptions {
  */
 export class ManagedAcpRuntime implements AcpBridgeClient {
   readonly mode = "managed" as const;
-  agentHome: string | undefined;
   readonly #opts: ManagedAcpRuntimeOptions;
   readonly #ownsHome: boolean;
+  #agentHome: string | undefined;
   #client: AcpAgentClient | undefined;
   #session: ActiveSession | undefined;
   #initInfo: InitializeResponse | undefined;
@@ -48,8 +48,13 @@ export class ManagedAcpRuntime implements AcpBridgeClient {
     const acp = opts.config.acp;
     this.#ownsHome = acp.homeEnvVar !== undefined && acp.agentHome === undefined;
     if (acp.agentHome !== undefined) {
-      this.agentHome = resolve(acp.agentHome);
+      this.#agentHome = resolve(acp.agentHome);
     }
+  }
+
+  /** Resolved agent home (explicit or ephemeral); read-only for callers. */
+  get agentHome(): string | undefined {
+    return this.#agentHome;
   }
 
   get ready(): boolean {
@@ -110,7 +115,7 @@ export class ManagedAcpRuntime implements AcpBridgeClient {
     try {
       yield { type: "status", text: "managed ACP agent ready" };
       client.setPermissionHandler((params) => resolvePermissionRequest(params, {
-        policy: input.permissionPolicy as AcpPermissionPolicy,
+        policy: input.permissionPolicy,
         ...(input.askPermission !== undefined
           ? { sink: (prompt: string): Promise<AcpPermissionDecision> => input.askPermission!(prompt) }
           : {}),
@@ -147,16 +152,16 @@ export class ManagedAcpRuntime implements AcpBridgeClient {
     this.#session = undefined;
     await this.#client?.close();
     this.#client = undefined;
-    if (this.#ownsHome && this.agentHome !== undefined) {
-      rmSync(this.agentHome, { recursive: true, force: true });
-      this.agentHome = undefined;
+    if (this.#ownsHome && this.#agentHome !== undefined) {
+      rmSync(this.#agentHome, { recursive: true, force: true });
+      this.#agentHome = undefined;
     }
   }
 
   #ensureHome(): string {
-    if (this.agentHome === undefined) this.agentHome = mkdtempSync(join(tmpdir(), "synadia-acp-home-"));
-    mkdirSync(this.agentHome, { recursive: true });
-    return this.agentHome;
+    if (this.#agentHome === undefined) this.#agentHome = mkdtempSync(join(tmpdir(), "synadia-acp-home-"));
+    mkdirSync(this.#agentHome, { recursive: true });
+    return this.#agentHome;
   }
 
   async #acquireTurn(): Promise<() => void> {

--- a/agents/acp/src/nats.ts
+++ b/agents/acp/src/nats.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { credsAuthenticator } from "@nats-io/nats-core";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import { loadContextOptions, parseNatsUrl, withAgentReconnectDefaults } from "@synadia-ai/agents";
+import type { NatsConfig } from "./types.js";
+
+export async function resolveNatsOptions(config: NatsConfig): Promise<NodeConnectionOptions> {
+  const base = config.context
+    ? await loadContextOptions(config.context)
+    : parseNatsUrl(config.url ?? "nats://127.0.0.1:4222");
+
+  if (!config.context && config.creds) {
+    base.authenticator = credsAuthenticator(readFileSync(config.creds));
+  }
+
+  return withAgentReconnectDefaults(base);
+}

--- a/agents/acp/src/permissions.ts
+++ b/agents/acp/src/permissions.ts
@@ -1,0 +1,91 @@
+import type {
+  PermissionOption,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+import type { AcpPermissionPolicy } from "./types.js";
+
+export type AcpPermissionDecision = "approve" | "deny" | "cancel";
+
+export type PermissionSink = (prompt: string) => Promise<AcpPermissionDecision> | AcpPermissionDecision;
+
+/**
+ * Human-readable §7 query prompt for an ACP `session/request_permission`.
+ * ACP surfaces the tool call being authorized plus the selectable options;
+ * we compress that into one line the caller can answer with approve/deny.
+ */
+export function permissionPromptText(params: RequestPermissionRequest): string {
+  const title = params.toolCall?.title ?? params.toolCall?.toolCallId ?? "a tool call";
+  const kind = params.toolCall?.kind;
+  let details = "";
+  const rawInput = params.toolCall?.rawInput;
+  if (rawInput !== undefined) {
+    try {
+      details = JSON.stringify(rawInput).slice(0, 1200);
+    } catch {
+      /* non-serializable rawInput — omit */
+    }
+  }
+  return `ACP agent requests permission: ${title}${kind ? ` [${kind}]` : ""}. ` +
+    `Reply approve to allow once; anything else denies.${details ? ` Details: ${details}` : ""}`;
+}
+
+function findOption(options: readonly PermissionOption[], kinds: readonly string[]): PermissionOption | undefined {
+  for (const kind of kinds) {
+    const match = options.find((option) => option.kind === kind);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+/**
+ * Map an approve/deny/cancel decision onto the agent-offered options.
+ * approve -> allow_once (falling back to allow_always), deny -> reject_once
+ * (falling back to reject_always). When the agent offered no matching option,
+ * or on cancel, respond with the `cancelled` outcome — the spec's "user
+ * dismissed" answer.
+ */
+export function selectPermissionOutcome(
+  options: readonly PermissionOption[],
+  decision: AcpPermissionDecision,
+): RequestPermissionResponse {
+  const chosen = decision === "approve"
+    ? findOption(options, ["allow_once", "allow_always"])
+    : decision === "deny"
+      ? findOption(options, ["reject_once", "reject_always"])
+      : undefined;
+  if (chosen === undefined) return { outcome: { outcome: "cancelled" } };
+  return { outcome: { outcome: "selected", optionId: chosen.optionId } };
+}
+
+/**
+ * Resolve an inbound permission request per the adapter policy:
+ * - `allow`  — approve every request (allow_once). Headless demos only.
+ * - `query`  — relay to the caller as a §7 query chunk via `sink`; timeout
+ *              or missing sink degrades to cancel.
+ * - `reject` — deny without asking (the safe default).
+ */
+export async function resolvePermissionRequest(
+  params: RequestPermissionRequest,
+  opts: { readonly policy: AcpPermissionPolicy; readonly sink?: PermissionSink; readonly timeoutMs?: number },
+): Promise<RequestPermissionResponse> {
+  if (opts.policy === "allow") return selectPermissionOutcome(params.options, "approve");
+  if (opts.policy === "query" && opts.sink) {
+    const decision = await withTimeout(opts.sink(permissionPromptText(params)), opts.timeoutMs ?? 30_000);
+    return selectPermissionOutcome(params.options, decision);
+  }
+  return selectPermissionOutcome(params.options, "deny");
+}
+
+async function withTimeout(
+  value: Promise<AcpPermissionDecision> | AcpPermissionDecision,
+  timeoutMs: number,
+): Promise<AcpPermissionDecision> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timed = new Promise<"cancel">((resolve) => { timer = setTimeout(() => resolve("cancel"), timeoutMs); });
+    return await Promise.race([Promise.resolve(value), timed]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/agents/acp/src/presets.ts
+++ b/agents/acp/src/presets.ts
@@ -39,15 +39,10 @@ export const ACP_PRESETS: readonly AcpAgentPreset[] = [
     envPrefix: "SYNADIA_GROK",
     description: "Grok Build (xAI) — native ACP via `grok agent stdio`",
   },
-  {
-    key: "gemini",
-    agentId: "gemini-cli",
-    subjectToken: "gemini",
-    bin: "gemini",
-    args: ["--experimental-acp"],
-    envPrefix: "SYNADIA_GEMINI",
-    description: "Gemini CLI (Google) — native ACP via `gemini --experimental-acp`",
-  },
+  // A `gemini` preset existed briefly pre-release; Gemini CLI was superseded
+  // by Google Antigravity (`agy`), which has no native ACP mode yet — drive
+  // it via `--agent custom` with an ACP adapter (see README), and add a
+  // first-party preset once `agy` ships an --acp flag.
 ];
 
 export function resolvePreset(key: string): AcpAgentPreset | undefined {

--- a/agents/acp/src/presets.ts
+++ b/agents/acp/src/presets.ts
@@ -1,0 +1,59 @@
+/**
+ * Per-agent presets for ACP-speaking coding agents.
+ *
+ * A preset bundles the spawn command, subject-token defaults, and the
+ * `SYNADIA_<AGENT>_*` env-var prefix for one agent. The generic bridge is the
+ * same for every preset — only identity and process bootstrap differ.
+ *
+ * `agentId` is the canonical identifier advertised as `metadata.agent`
+ * (spec Appendix C); `subjectToken` is the wire subject's 3rd token. They
+ * differ only when the canonical name is longer than the conventional
+ * abbreviation (mirrors `claude-code` / `cc`).
+ */
+export interface AcpAgentPreset {
+  /** Preset key used by `--agent <key>`. */
+  readonly key: string;
+  /** Canonical agent identifier (`metadata.agent`). */
+  readonly agentId: string;
+  /** Default 3rd subject token. */
+  readonly subjectToken: string;
+  /** Default binary to spawn. */
+  readonly bin: string;
+  /** Default args that put the binary in ACP-over-stdio mode. */
+  readonly args: readonly string[];
+  /** Env var the agent reads its home/state dir from, if it has one. */
+  readonly homeEnvVar?: string;
+  /** Per-agent identity env var prefix (`SYNADIA_GROK`, ...). */
+  readonly envPrefix: string;
+  readonly description: string;
+}
+
+export const ACP_PRESETS: readonly AcpAgentPreset[] = [
+  {
+    key: "grok",
+    agentId: "grok",
+    subjectToken: "grok",
+    bin: "grok",
+    args: ["agent", "stdio"],
+    homeEnvVar: "GROK_HOME",
+    envPrefix: "SYNADIA_GROK",
+    description: "Grok Build (xAI) — native ACP via `grok agent stdio`",
+  },
+  {
+    key: "gemini",
+    agentId: "gemini-cli",
+    subjectToken: "gemini",
+    bin: "gemini",
+    args: ["--experimental-acp"],
+    envPrefix: "SYNADIA_GEMINI",
+    description: "Gemini CLI (Google) — native ACP via `gemini --experimental-acp`",
+  },
+];
+
+export function resolvePreset(key: string): AcpAgentPreset | undefined {
+  return ACP_PRESETS.find((preset) => preset.key === key);
+}
+
+export function presetKeys(): string {
+  return [...ACP_PRESETS.map((preset) => preset.key), "custom"].join(", ");
+}

--- a/agents/acp/src/service.ts
+++ b/agents/acp/src/service.ts
@@ -1,0 +1,47 @@
+import type { NatsConnection } from "@nats-io/nats-core";
+import { AgentService, type AgentServiceOptions } from "@synadia-ai/agent-service";
+import type { AcpBridgeClient } from "./bridge.js";
+import { bridgePromptToAcp } from "./bridge.js";
+import type { AcpChannelConfig } from "./config.js";
+import { mappingFromConfig } from "./config.js";
+
+export interface BuildAgentServiceOptionsInput {
+  readonly nc: NatsConnection;
+  readonly config: AcpChannelConfig;
+  readonly version: string;
+  readonly extraMetadata?: Record<string, string>;
+}
+
+export function buildAgentServiceOptions(input: BuildAgentServiceOptionsInput): AgentServiceOptions {
+  const mapping = mappingFromConfig(input.config);
+  return {
+    nc: input.nc,
+    agent: mapping.acp.agentId,
+    subjectToken: mapping.subjectToken,
+    owner: mapping.owner,
+    name: mapping.session,
+    session: mapping.session,
+    description: `${mapping.acp.agentId} (ACP ${mapping.acp.mode}) session ${mapping.owner}/${mapping.session}`,
+    version: input.version,
+    attachmentsOk: false,
+    heartbeatIntervalS: input.config.agent.heartbeatIntervalS,
+    keepaliveIntervalS: input.config.agent.keepaliveIntervalS,
+    extraMetadata: {
+      acp_preset: mapping.acp.preset,
+      acp_mode: mapping.acp.mode,
+      permission_policy: mapping.acp.permissionPolicy,
+      ...input.extraMetadata,
+    },
+  };
+}
+
+export function createAcpAgentService(
+  input: BuildAgentServiceOptionsInput & { readonly client: AcpBridgeClient },
+): AgentService {
+  const service = new AgentService(buildAgentServiceOptions(input));
+  const mapping = mappingFromConfig(input.config);
+  service.onPrompt(async (envelope, response) => {
+    await bridgePromptToAcp({ envelope, response, mapping, client: input.client });
+  });
+  return service;
+}

--- a/agents/acp/src/subject.ts
+++ b/agents/acp/src/subject.ts
@@ -1,0 +1,33 @@
+const SUBJECT_TOKEN_RE = /^[a-z0-9_-]+$/;
+
+/**
+ * Best-effort sanitizer for derived defaults only. User/config-supplied
+ * subject tokens are validated with requireSubjectToken instead of silently
+ * rewriting onto a different route.
+ */
+export function sanitizeDerivedSubjectToken(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+}
+
+export function requireSubjectToken(value: string, label: string): string {
+  if (!value) throw new Error(`${label} must not be empty`);
+  if (!SUBJECT_TOKEN_RE.test(value)) {
+    throw new Error(`${label} must match ${SUBJECT_TOKEN_RE.source}`);
+  }
+  return value;
+}
+
+export function buildPromptSubject(subjectToken: string, owner: string, session: string): string {
+  return `agents.prompt.${requireSubjectToken(subjectToken, "agent.subject_token")}.${requireSubjectToken(owner, "agent.owner")}.${requireSubjectToken(session, "agent.session")}`;
+}
+
+export function buildStatusSubject(subjectToken: string, owner: string, session: string): string {
+  return `agents.status.${requireSubjectToken(subjectToken, "agent.subject_token")}.${requireSubjectToken(owner, "agent.owner")}.${requireSubjectToken(session, "agent.session")}`;
+}
+
+export function buildHeartbeatSubject(subjectToken: string, owner: string, session: string): string {
+  return `agents.hb.${requireSubjectToken(subjectToken, "agent.subject_token")}.${requireSubjectToken(owner, "agent.owner")}.${requireSubjectToken(session, "agent.session")}`;
+}

--- a/agents/acp/src/types.ts
+++ b/agents/acp/src/types.ts
@@ -1,0 +1,52 @@
+export type AcpMode = "fake" | "managed";
+export type AcpPermissionPolicy = "reject" | "query" | "allow";
+
+export interface NatsConfig {
+  readonly url?: string;
+  readonly context?: string;
+  readonly creds?: string;
+}
+
+export interface AgentIdentityConfig {
+  readonly owner: string;
+  readonly session: string;
+  readonly subjectToken: string;
+  readonly heartbeatIntervalS: number;
+  readonly keepaliveIntervalS: number;
+}
+
+export interface AcpRuntimeConfig {
+  readonly mode: AcpMode;
+  /** Preset name this config was resolved from (`grok`, `gemini`, or `custom`). */
+  readonly preset: string;
+  /** Canonical agent identifier advertised as `metadata.agent`. */
+  readonly agentId: string;
+  /** Binary spawned in `agent stdio` (ACP) mode. */
+  readonly bin: string;
+  readonly args: readonly string[];
+  /**
+   * Env var the agent reads its home/state directory from (e.g. `GROK_HOME`).
+   * When set and `agentHome` is not, managed mode isolates the agent in an
+   * ephemeral temp home (removed on close). Preset-defined; absent for agents
+   * without a documented home env var.
+   */
+  readonly homeEnvVar?: string;
+  /** Explicit home directory (e.g. an already-authenticated `~/.grok`). */
+  readonly agentHome?: string;
+  /** Working directory for the ACP session. Absolute. */
+  readonly cwd: string;
+  readonly permissionPolicy: AcpPermissionPolicy;
+}
+
+export interface AcpChannelConfig {
+  readonly nats: NatsConfig;
+  readonly agent: AgentIdentityConfig;
+  readonly acp: AcpRuntimeConfig;
+}
+
+export interface AcpMapping {
+  readonly owner: string;
+  readonly session: string;
+  readonly subjectToken: string;
+  readonly acp: AcpRuntimeConfig;
+}

--- a/agents/acp/test/bridge.test.ts
+++ b/agents/acp/test/bridge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { FakeAcpBridgeClient, bridgePromptToAcp, type AcpBridgeClient } from "../src/bridge.js";
+import type { AcpMapping } from "../src/types.js";
+
+const mapping = (permissionPolicy: "reject" | "query" | "allow"): AcpMapping => ({
+  owner: "local",
+  session: "main",
+  subjectToken: "grok",
+  acp: {
+    mode: "managed",
+    preset: "grok",
+    agentId: "grok",
+    bin: "grok",
+    args: ["agent", "stdio"],
+    homeEnvVar: "GROK_HOME",
+    cwd: "/tmp",
+    permissionPolicy,
+  },
+});
+
+describe("fake ACP bridge", () => {
+  test("emits deterministic status and response events", async () => {
+    const client = new FakeAcpBridgeClient();
+    const events = [];
+    for await (const event of client.prompt({ prompt: "hello", publicSession: "main", permissionPolicy: "reject" })) {
+      events.push(event);
+    }
+    expect(events).toEqual([
+      { type: "status", text: "fake ACP session main ready" },
+      { type: "response", text: "fake ACP response to hello" },
+      { type: "done" },
+    ]);
+  });
+
+  test("surfaces fake upstream failures for handler 500 coverage", async () => {
+    const client = new FakeAcpBridgeClient();
+    await expect(async () => {
+      for await (const _event of client.prompt({ prompt: "explode", publicSession: "main", permissionPolicy: "reject" })) {
+        // drain
+      }
+    }).toThrow("fake ACP bridge exploded");
+  });
+
+  test("maps query permission policy to a protocol ask callback", async () => {
+    const sent: unknown[] = [];
+    const client: AcpBridgeClient = {
+      mode: "managed",
+      async *prompt(input) {
+        const decision = await input.askPermission?.("approve command?");
+        yield { type: "response", text: `decision:${decision}` };
+      },
+    };
+    const response = {
+      send: async (chunk: unknown) => { sent.push(chunk); },
+      ask: async (prompt: string) => {
+        sent.push({ ask: prompt });
+        return { prompt: "approve", attachments: [] };
+      },
+    };
+    await bridgePromptToAcp({
+      envelope: { prompt: "needs permission", attachments: [] },
+      response: response as never,
+      client,
+      mapping: mapping("query"),
+    });
+    expect(sent).toContainEqual({ ask: "approve command?" });
+    expect(sent).toContain("decision:approve");
+  });
+
+  test("reject policy does not wire an ask callback", async () => {
+    let sawAsk: unknown = "unset";
+    const client: AcpBridgeClient = {
+      mode: "managed",
+      async *prompt(input) {
+        sawAsk = input.askPermission;
+        yield { type: "done" };
+      },
+    };
+    await bridgePromptToAcp({
+      envelope: { prompt: "hello", attachments: [] },
+      response: { send: async () => {} } as never,
+      client,
+      mapping: mapping("reject"),
+    });
+    expect(sawAsk).toBeUndefined();
+  });
+});

--- a/agents/acp/test/config.test.ts
+++ b/agents/acp/test/config.test.ts
@@ -5,11 +5,11 @@ const base = { argv: ["start"], env: { USER: "alice" }, readFile: () => "", cwd:
 
 describe("config", () => {
   test("parses CLI flags", () => {
-    const flags = parseArgs(["start", "--owner", "alice", "--session", "project-main", "--agent", "gemini", "--mode", "fake", "--permission-policy", "reject"]);
+    const flags = parseArgs(["start", "--owner", "alice", "--session", "project-main", "--agent", "custom", "--mode", "fake", "--permission-policy", "reject"]);
     expect(flags.command).toBe("start");
     expect(flags.owner).toBe("alice");
     expect(flags.session).toBe("project-main");
-    expect(flags.agent).toBe("gemini");
+    expect(flags.agent).toBe("custom");
     expect(flags.mode).toBe("fake");
     expect(flags.permissionPolicy).toBe("reject");
   });
@@ -26,15 +26,6 @@ describe("config", () => {
     expect(cfg.acp.permissionPolicy).toBe("reject");
     expect(cfg.agent.owner).toBe("alice");
     expect(cfg.agent.session).toBe("project-main");
-  });
-
-  test("gemini preset splits canonical agent id from subject token", () => {
-    const cfg = loadConfigFromSources({ ...base, argv: ["start", "--agent", "gemini"] });
-    expect(cfg.acp.agentId).toBe("gemini-cli");
-    expect(cfg.agent.subjectToken).toBe("gemini");
-    expect(cfg.acp.bin).toBe("gemini");
-    expect(cfg.acp.args).toEqual(["--experimental-acp"]);
-    expect(cfg.acp.homeEnvVar).toBeUndefined();
   });
 
   test("unknown preset is rejected with the available list", () => {
@@ -99,7 +90,7 @@ describe("config", () => {
   test("agent-home requires a preset with a home env var", () => {
     const cfg = loadConfigFromSources({ ...base, argv: ["start", "--agent-home", "/tmp/grok-home"] });
     expect(cfg.acp.agentHome).toBe("/tmp/grok-home");
-    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "gemini", "--agent-home", "/tmp/gem-home"] })).toThrow("home env var");
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "custom", "--agent-id", "antigravity", "--acp-bin", "agy-acp", "--agent-home", "/tmp/agy-home"] })).toThrow("home env var");
   });
 
   test("rejects invalid numeric and enum config values", () => {

--- a/agents/acp/test/config.test.ts
+++ b/agents/acp/test/config.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG_PATH, loadConfigFromSources, parseArgs, renderConfigTemplate } from "../src/config.js";
+
+const base = { argv: ["start"], env: { USER: "alice" }, readFile: () => "", cwd: "/tmp/project-main" };
+
+describe("config", () => {
+  test("parses CLI flags", () => {
+    const flags = parseArgs(["start", "--owner", "alice", "--session", "project-main", "--agent", "gemini", "--mode", "fake", "--permission-policy", "reject"]);
+    expect(flags.command).toBe("start");
+    expect(flags.owner).toBe("alice");
+    expect(flags.session).toBe("project-main");
+    expect(flags.agent).toBe("gemini");
+    expect(flags.mode).toBe("fake");
+    expect(flags.permissionPolicy).toBe("reject");
+  });
+
+  test("defaults to the grok preset", () => {
+    const cfg = loadConfigFromSources(base);
+    expect(cfg.acp.preset).toBe("grok");
+    expect(cfg.acp.agentId).toBe("grok");
+    expect(cfg.agent.subjectToken).toBe("grok");
+    expect(cfg.acp.bin).toBe("grok");
+    expect(cfg.acp.args).toEqual(["agent", "stdio"]);
+    expect(cfg.acp.homeEnvVar).toBe("GROK_HOME");
+    expect(cfg.acp.mode).toBe("fake");
+    expect(cfg.acp.permissionPolicy).toBe("reject");
+    expect(cfg.agent.owner).toBe("alice");
+    expect(cfg.agent.session).toBe("project-main");
+  });
+
+  test("gemini preset splits canonical agent id from subject token", () => {
+    const cfg = loadConfigFromSources({ ...base, argv: ["start", "--agent", "gemini"] });
+    expect(cfg.acp.agentId).toBe("gemini-cli");
+    expect(cfg.agent.subjectToken).toBe("gemini");
+    expect(cfg.acp.bin).toBe("gemini");
+    expect(cfg.acp.args).toEqual(["--experimental-acp"]);
+    expect(cfg.acp.homeEnvVar).toBeUndefined();
+  });
+
+  test("unknown preset is rejected with the available list", () => {
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "clippy"] })).toThrow("acp.agent must be one of");
+  });
+
+  test("custom preset requires agent id and bin", () => {
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "custom"] })).toThrow("--agent-id");
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "custom", "--agent-id", "myagent"] })).toThrow("--acp-bin");
+    const cfg = loadConfigFromSources({ ...base, argv: ["start", "--agent", "custom", "--agent-id", "myagent", "--acp-bin", "my-agent", "--acp-args", "acp --stdio"] });
+    expect(cfg.acp.agentId).toBe("myagent");
+    expect(cfg.agent.subjectToken).toBe("myagent");
+    expect(cfg.acp.bin).toBe("my-agent");
+    expect(cfg.acp.args).toEqual(["acp", "--stdio"]);
+  });
+
+  test("per-agent env beats channel env beats fleet env", () => {
+    const cfg = loadConfigFromSources({
+      ...base,
+      env: {
+        USER: "alice",
+        SYNADIA_OWNER: "fleet-owner",
+        SYNADIA_ACP_OWNER: "channel-owner",
+        SYNADIA_GROK_OWNER: "grok-owner",
+        SYNADIA_NAME: "fleet-session",
+        SYNADIA_ACP_SESSION: "channel-session",
+      },
+    });
+    expect(cfg.agent.owner).toBe("grok-owner");
+    expect(cfg.agent.session).toBe("channel-session");
+    const fleetOnly = loadConfigFromSources({ ...base, env: { USER: "alice", SYNADIA_OWNER: "fleet-owner", SYNADIA_NAME: "fleet-session" } });
+    expect(fleetOnly.agent.owner).toBe("fleet-owner");
+    expect(fleetOnly.agent.session).toBe("fleet-session");
+  });
+
+  test("CLI overrides env, file, and defaults", () => {
+    const file = `[nats]\nurl = "nats://file:4222"\n\n[agent]\nowner = "file-owner"\nsession = "file-session"\n\n[acp]\nmode = "managed"\npermission_policy = "allow"\n`;
+    const cfg = loadConfigFromSources({
+      argv: ["start", "--owner", "cli-owner", "--session", "cli-session", "--mode", "fake", "--permission-policy", "reject"],
+      env: {
+        USER: "env-user",
+        SYNADIA_GROK_OWNER: "env-owner",
+        SYNADIA_ACP_MODE: "managed",
+        SYNADIA_ACP_PERMISSION_POLICY: "query",
+      },
+      readFile: () => file,
+      cwd: "/tmp/project-name",
+    });
+    expect(cfg.agent.owner).toBe("cli-owner");
+    expect(cfg.agent.session).toBe("cli-session");
+    expect(cfg.acp.mode).toBe("fake");
+    expect(cfg.acp.permissionPolicy).toBe("reject");
+    expect(cfg.nats.url).toBe("nats://file:4222");
+  });
+
+  test("subject token override is validated, not rewritten", () => {
+    const cfg = loadConfigFromSources({ ...base, argv: ["start", "--subject-token", "g"] });
+    expect(cfg.agent.subjectToken).toBe("g");
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--subject-token", "Not.Valid"] })).toThrow("agent.subject_token");
+  });
+
+  test("agent-home requires a preset with a home env var", () => {
+    const cfg = loadConfigFromSources({ ...base, argv: ["start", "--agent-home", "/tmp/grok-home"] });
+    expect(cfg.acp.agentHome).toBe("/tmp/grok-home");
+    expect(() => loadConfigFromSources({ ...base, argv: ["start", "--agent", "gemini", "--agent-home", "/tmp/gem-home"] })).toThrow("home env var");
+  });
+
+  test("rejects invalid numeric and enum config values", () => {
+    expect(() => loadConfigFromSources({ ...base, readFile: () => `[agent]\nheartbeat_interval_s = nope\n` })).toThrow("agent.heartbeat_interval_s must be a positive number");
+    expect(() => loadConfigFromSources({ ...base, readFile: () => `[acp]\nmode = "magic"\n` })).toThrow("acp.mode must be fake or managed");
+    expect(() => loadConfigFromSources({ ...base, readFile: () => `[acp]\npermission_policy = "maybe"\n` })).toThrow("acp.permission_policy must be reject, query, or allow");
+  });
+
+  test("strips inline TOML comments before parsing numeric fields", () => {
+    const cfg = loadConfigFromSources({ ...base, readFile: () => `[agent]\nheartbeat_interval_s = 30 # seconds\nkeepalive_interval_s = 45 # seconds\n` });
+    expect(cfg.agent.heartbeatIntervalS).toBe(30);
+    expect(cfg.agent.keepaliveIntervalS).toBe(45);
+  });
+
+  test("renders a config template", () => {
+    const template = renderConfigTemplate();
+    expect(template).toContain("[nats]");
+    expect(template).toContain("[agent]");
+    expect(template).toContain("[acp]");
+    expect(template).toContain('agent = "grok"');
+    expect(template).toContain('permission_policy = "reject"');
+    expect(DEFAULT_CONFIG_PATH).toContain("acp-nats-channel.toml");
+  });
+});

--- a/agents/acp/test/managed-runtime.test.ts
+++ b/agents/acp/test/managed-runtime.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ManagedAcpRuntime } from "../src/managed-runtime.js";
+import type { AcpChannelConfig } from "../src/config.js";
+
+function config(overrides: Partial<AcpChannelConfig["acp"]> = {}): AcpChannelConfig {
+  return {
+    nats: { url: "nats://127.0.0.1:4222" },
+    agent: { owner: "test", session: "managed", subjectToken: "grok", heartbeatIntervalS: 1, keepaliveIntervalS: 1 },
+    acp: {
+      mode: "managed",
+      preset: "grok",
+      agentId: "grok",
+      bin: "grok",
+      args: ["agent", "stdio"],
+      homeEnvVar: "GROK_HOME",
+      cwd: process.cwd(),
+      permissionPolicy: "reject",
+      ...overrides,
+    },
+  };
+}
+
+const fixture = { command: "bun", args: ["scripts/fake-acp-agent.ts"] } as const;
+
+describe("ManagedAcpRuntime", () => {
+  test("defers isolated home creation until start and removes it on close", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config(), ...fixture });
+    expect(runtime.agentHome).toBeUndefined();
+    try {
+      await runtime.start();
+      const home = runtime.agentHome;
+      expect(home).toBeDefined();
+      expect(existsSync(home!)).toBe(true);
+    } finally {
+      const home = runtime.agentHome;
+      await runtime.close();
+      if (home) expect(existsSync(home)).toBe(false);
+    }
+  });
+
+  test("creates a user-supplied agent home on start and does not delete it on close", async () => {
+    const root = mkdtempSync(join(tmpdir(), "managed-acp-user-home-test-"));
+    const agentHome = join(root, "existing-auth-home");
+    const runtime = new ManagedAcpRuntime({ config: config({ agentHome }), ...fixture });
+    expect(runtime.agentHome).toBe(agentHome);
+    expect(existsSync(agentHome)).toBe(false);
+    try {
+      await runtime.start();
+      expect(existsSync(agentHome)).toBe(true);
+    } finally {
+      await runtime.close();
+      expect(existsSync(agentHome)).toBe(true);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("streams text chunks, drops thoughts, surfaces tool calls as status", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config(), ...fixture });
+    try {
+      await runtime.start();
+      const events = [];
+      for await (const event of runtime.prompt({ prompt: "hello", publicSession: "managed", permissionPolicy: "reject" })) events.push(event);
+      const text = events.filter((e) => e.type === "response").map((e) => (e as { text: string }).text).join("");
+      expect(text).toBe("fake ACP response to hello");
+      expect(text).not.toContain("pondering");
+      expect(events.some((e) => e.type === "response" && (e as { text: string }).text === "")).toBe(false);
+      expect(events.some((e) => e.type === "status" && (e as { text: string }).text.includes("tool: echo fixture tool"))).toBe(true);
+      expect(events.at(-1)).toEqual({ type: "done" });
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  test("defaults permission requests to deny (reject_once)", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config(), ...fixture, permissionTimeoutMs: 100 });
+    try {
+      await runtime.start();
+      const chunks: string[] = [];
+      for await (const event of runtime.prompt({ prompt: "permission", publicSession: "managed", permissionPolicy: "reject" })) {
+        if (event.type === "response") chunks.push(event.text);
+      }
+      expect(chunks.join("")).toContain("permission:reject-once");
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  test("query policy relays approval through the adapter callback", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config({ permissionPolicy: "query" }), ...fixture, permissionTimeoutMs: 100 });
+    try {
+      await runtime.start();
+      const chunks: string[] = [];
+      for await (const event of runtime.prompt({
+        prompt: "permission",
+        publicSession: "managed",
+        permissionPolicy: "query",
+        askPermission: async () => "approve",
+      })) {
+        if (event.type === "response") chunks.push(event.text);
+      }
+      expect(chunks.join("")).toContain("permission:allow-once");
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  test("query timeout degrades to the cancelled outcome", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config({ permissionPolicy: "query" }), ...fixture, permissionTimeoutMs: 50 });
+    try {
+      await runtime.start();
+      const chunks: string[] = [];
+      for await (const event of runtime.prompt({
+        prompt: "permission",
+        publicSession: "managed",
+        permissionPolicy: "query",
+        askPermission: () => new Promise(() => { /* never answers */ }),
+      })) {
+        if (event.type === "response") chunks.push(event.text);
+      }
+      expect(chunks.join("")).toContain("permission:cancelled");
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  test("agent-side prompt errors propagate for handler 500 coverage", async () => {
+    const runtime = new ManagedAcpRuntime({ config: config(), ...fixture });
+    try {
+      await runtime.start();
+      await expect(async () => {
+        for await (const _event of runtime.prompt({ prompt: "explode", publicSession: "managed", permissionPolicy: "reject" })) {
+          // drain
+        }
+      }).toThrow("fake ACP agent exploded");
+    } finally {
+      await runtime.close();
+    }
+  });
+});

--- a/agents/acp/test/package.test.ts
+++ b/agents/acp/test/package.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import packageJson from "../package.json";
+
+const changelog = readFileSync(join(import.meta.dir, "..", "CHANGELOG.md"), "utf8");
+
+describe("package metadata", () => {
+  test("uses the required published package and binary names", () => {
+    expect(packageJson.name).toBe("@synadia-ai/acp-nats-channel");
+    expect(packageJson.bin).toEqual({ "acp-agent": "./src/cli.ts" });
+    expect(packageJson.publishConfig).toEqual({ access: "public" });
+  });
+
+  test("declares protocol and ACP dependencies by semver, not file links", () => {
+    expect(packageJson.dependencies["@synadia-ai/agent-service"]).toMatch(/^\^\d+\.\d+\.\d+/);
+    expect(packageJson.dependencies["@synadia-ai/agents"]).toMatch(/^\^\d+\.\d+\.\d+/);
+    expect(packageJson.dependencies["@agentclientprotocol/sdk"]).toMatch(/^\^\d+\.\d+\.\d+/);
+    expect(packageJson.dependencies["@synadia-ai/agent-service"]).not.toContain("file:");
+    expect(packageJson.dependencies["@synadia-ai/agents"]).not.toContain("file:");
+    expect(packageJson.dependencies["@nats-io/nats-core"]).toBeTruthy();
+    expect(packageJson.dependencies["@nats-io/transport-node"]).toBeTruthy();
+  });
+
+  test("includes release notes in the publishable package", () => {
+    expect(packageJson.files).toContain("CHANGELOG.md");
+    expect(changelog).toContain("## [0.1.0]");
+    expect(changelog).toContain("ACP");
+  });
+
+  test("keeps the smoke ladder deterministic (fake fixture, no real agent binary)", () => {
+    expect(packageJson.scripts["smoke:protocol"]).toContain("protocol-smoke.ts");
+    expect(packageJson.scripts["smoke:acp-fake-runtime"]).toContain("acp-runtime-smoke.ts");
+  });
+});

--- a/agents/acp/test/permissions.test.ts
+++ b/agents/acp/test/permissions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import { permissionPromptText, resolvePermissionRequest, selectPermissionOutcome } from "../src/permissions.js";
+
+const options: PermissionOption[] = [
+  { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+  { optionId: "allow-always", name: "Always allow", kind: "allow_always" },
+  { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+];
+
+const request = (opts: PermissionOption[] = options): RequestPermissionRequest => ({
+  sessionId: "sess-1",
+  options: opts,
+  toolCall: {
+    toolCallId: "tc-1",
+    title: "touch /tmp/thing",
+    kind: "execute",
+    rawInput: { command: "touch /tmp/thing" },
+  },
+});
+
+describe("permission mapping", () => {
+  test("approve selects allow_once, falling back to allow_always", () => {
+    expect(selectPermissionOutcome(options, "approve")).toEqual({ outcome: { outcome: "selected", optionId: "allow-once" } });
+    const alwaysOnly = options.filter((o) => o.kind !== "allow_once");
+    expect(selectPermissionOutcome(alwaysOnly, "approve")).toEqual({ outcome: { outcome: "selected", optionId: "allow-always" } });
+  });
+
+  test("deny selects reject_once; missing options degrade to cancelled", () => {
+    expect(selectPermissionOutcome(options, "deny")).toEqual({ outcome: { outcome: "selected", optionId: "reject-once" } });
+    expect(selectPermissionOutcome([], "deny")).toEqual({ outcome: { outcome: "cancelled" } });
+    expect(selectPermissionOutcome(options, "cancel")).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  test("reject policy denies without consulting a sink", async () => {
+    let asked = false;
+    const outcome = await resolvePermissionRequest(request(), {
+      policy: "reject",
+      sink: () => { asked = true; return "approve"; },
+    });
+    expect(outcome).toEqual({ outcome: { outcome: "selected", optionId: "reject-once" } });
+    expect(asked).toBe(false);
+  });
+
+  test("allow policy approves without consulting a sink", async () => {
+    const outcome = await resolvePermissionRequest(request(), { policy: "allow" });
+    expect(outcome).toEqual({ outcome: { outcome: "selected", optionId: "allow-once" } });
+  });
+
+  test("query policy relays through the sink and maps the decision", async () => {
+    const prompts: string[] = [];
+    const outcome = await resolvePermissionRequest(request(), {
+      policy: "query",
+      sink: (prompt) => { prompts.push(prompt); return "approve"; },
+    });
+    expect(outcome).toEqual({ outcome: { outcome: "selected", optionId: "allow-once" } });
+    expect(prompts[0]).toContain("touch /tmp/thing");
+  });
+
+  test("query sink timeout degrades to cancelled", async () => {
+    const outcome = await resolvePermissionRequest(request(), {
+      policy: "query",
+      sink: () => new Promise(() => { /* never resolves */ }),
+      timeoutMs: 20,
+    });
+    expect(outcome).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  test("prompt text includes the tool call and truncated raw input", () => {
+    const text = permissionPromptText(request());
+    expect(text).toContain("touch /tmp/thing");
+    expect(text).toContain("[execute]");
+    expect(text).toContain("approve to allow once");
+    const huge = request();
+    const withHugeInput: RequestPermissionRequest = {
+      ...huge,
+      toolCall: { ...huge.toolCall, rawInput: { blob: "x".repeat(10_000) } },
+    };
+    expect(permissionPromptText(withHugeInput).length).toBeLessThan(1500);
+  });
+});

--- a/agents/acp/test/presets.test.ts
+++ b/agents/acp/test/presets.test.ts
@@ -12,17 +12,13 @@ describe("presets", () => {
     expect(grok?.envPrefix).toBe("SYNADIA_GROK");
   });
 
-  test("gemini preset uses the canonical gemini-cli id with the gemini wire token", () => {
-    const gemini = resolvePreset("gemini");
-    expect(gemini?.agentId).toBe("gemini-cli");
-    expect(gemini?.subjectToken).toBe("gemini");
-    expect(gemini?.args).toEqual(["--experimental-acp"]);
-    expect(gemini?.homeEnvVar).toBeUndefined();
-  });
-
   test("preset listing includes custom", () => {
     expect(resolvePreset("custom")).toBeUndefined();
     expect(presetKeys()).toContain("custom");
-    expect(ACP_PRESETS.length).toBeGreaterThanOrEqual(2);
+    expect(ACP_PRESETS.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("no gemini preset — superseded by Antigravity (custom-preset route)", () => {
+    expect(resolvePreset("gemini")).toBeUndefined();
   });
 });

--- a/agents/acp/test/presets.test.ts
+++ b/agents/acp/test/presets.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { ACP_PRESETS, presetKeys, resolvePreset } from "../src/presets.js";
+
+describe("presets", () => {
+  test("grok preset spawns `grok agent stdio` with GROK_HOME isolation", () => {
+    const grok = resolvePreset("grok");
+    expect(grok?.agentId).toBe("grok");
+    expect(grok?.subjectToken).toBe("grok");
+    expect(grok?.bin).toBe("grok");
+    expect(grok?.args).toEqual(["agent", "stdio"]);
+    expect(grok?.homeEnvVar).toBe("GROK_HOME");
+    expect(grok?.envPrefix).toBe("SYNADIA_GROK");
+  });
+
+  test("gemini preset uses the canonical gemini-cli id with the gemini wire token", () => {
+    const gemini = resolvePreset("gemini");
+    expect(gemini?.agentId).toBe("gemini-cli");
+    expect(gemini?.subjectToken).toBe("gemini");
+    expect(gemini?.args).toEqual(["--experimental-acp"]);
+    expect(gemini?.homeEnvVar).toBeUndefined();
+  });
+
+  test("preset listing includes custom", () => {
+    expect(resolvePreset("custom")).toBeUndefined();
+    expect(presetKeys()).toContain("custom");
+    expect(ACP_PRESETS.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/agents/acp/test/readme.test.ts
+++ b/agents/acp/test/readme.test.ts
@@ -7,10 +7,16 @@ const readme = readFileSync(join(import.meta.dir, "..", "README.md"), "utf8");
 // Honesty guards in the codex-channel tradition: the README must not
 // overclaim what the adapter does.
 describe("README", () => {
-  test("documents both presets and the custom escape hatch", () => {
+  test("documents the grok preset and the custom escape hatch", () => {
     expect(readme).toContain("grok agent stdio");
-    expect(readme).toContain("--experimental-acp");
     expect(readme).toContain("`custom`");
+    expect(readme).not.toContain("--experimental-acp"); // gemini preset removed
+  });
+
+  test("documents the Antigravity custom-preset route honestly", () => {
+    expect(readme).toContain("no native ACP mode yet");
+    expect(readme).toContain("--agent custom --agent-id antigravity");
+    expect(readme).toContain("review third-party adapters before use");
   });
 
   test("is honest about attachments", () => {

--- a/agents/acp/test/readme.test.ts
+++ b/agents/acp/test/readme.test.ts
@@ -17,6 +17,16 @@ describe("README", () => {
     expect(readme).toContain("no native ACP mode yet");
     expect(readme).toContain("--agent custom --agent-id antigravity");
     expect(readme).toContain("review third-party adapters before use");
+    // Regression guard: bare acp-agent defaults to fake mode, so the
+    // documented start command must carry --mode managed and point the
+    // adapter at the locally-authenticated agy.
+    expect(readme).toMatch(/--mode managed[\s\S]{0,200}--agent custom --agent-id antigravity/);
+    expect(readme).toContain('AGY_BIN="$(which agy)"');
+  });
+
+  test("documents running from a repo clone", () => {
+    expect(readme).toContain("ln -sf");
+    expect(readme).toContain("~/.local/bin/acp-agent");
   });
 
   test("is honest about attachments", () => {

--- a/agents/acp/test/readme.test.ts
+++ b/agents/acp/test/readme.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const readme = readFileSync(join(import.meta.dir, "..", "README.md"), "utf8");
+
+// Honesty guards in the codex-channel tradition: the README must not
+// overclaim what the adapter does.
+describe("README", () => {
+  test("documents both presets and the custom escape hatch", () => {
+    expect(readme).toContain("grok agent stdio");
+    expect(readme).toContain("--experimental-acp");
+    expect(readme).toContain("`custom`");
+  });
+
+  test("is honest about attachments", () => {
+    expect(readme).toContain("Attachments are not supported");
+    expect(readme).toContain("attachments_ok=false");
+  });
+
+  test("is honest about crash handling", () => {
+    expect(readme).toContain("no automatic restart");
+  });
+
+  test("documents home isolation and the auth consequence", () => {
+    expect(readme).toContain("GROK_HOME");
+    expect(readme).toContain("unauthenticated");
+    expect(readme).toContain("--agent-home");
+  });
+
+  test("documents all three permission policies", () => {
+    expect(readme).toContain("**`reject`** (default)");
+    expect(readme).toContain("**`query`**");
+    expect(readme).toContain("**`allow`**");
+  });
+
+  test("keeps the validation ladder honest about fake versus real agents", () => {
+    expect(readme).toContain("smoke:acp-fake-runtime");
+    expect(readme).toContain("fake-acp-agent.ts");
+    expect(readme).toContain("without any real agent binary");
+  });
+});

--- a/agents/acp/test/service.test.ts
+++ b/agents/acp/test/service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import type { AcpChannelConfig } from "../src/config.js";
+import { buildAgentServiceOptions } from "../src/service.js";
+
+function cfg(): AcpChannelConfig {
+  return {
+    nats: { url: "nats://127.0.0.1:4222" },
+    agent: { owner: "alice", session: "project-main", subjectToken: "grok", heartbeatIntervalS: 30, keepaliveIntervalS: 30 },
+    acp: {
+      mode: "managed",
+      preset: "grok",
+      agentId: "grok",
+      bin: "grok",
+      args: ["agent", "stdio"],
+      homeEnvVar: "GROK_HOME",
+      cwd: "/tmp/project-main",
+      permissionPolicy: "reject",
+    },
+  };
+}
+
+describe("service construction", () => {
+  test("builds AgentService options from the preset identity", () => {
+    const opts = buildAgentServiceOptions({ nc: {} as never, config: cfg(), version: "0.1.0" });
+    expect(opts.agent).toBe("grok");
+    expect(opts.subjectToken).toBe("grok");
+    expect(opts.owner).toBe("alice");
+    expect(opts.name).toBe("project-main");
+    expect(opts.session).toBe("project-main");
+    expect(opts.attachmentsOk).toBe(false);
+    expect(opts.extraMetadata).toEqual({
+      acp_preset: "grok",
+      acp_mode: "managed",
+      permission_policy: "reject",
+    });
+  });
+});

--- a/agents/acp/test/subject.test.ts
+++ b/agents/acp/test/subject.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { buildHeartbeatSubject, buildPromptSubject, buildStatusSubject, requireSubjectToken, sanitizeDerivedSubjectToken } from "../src/subject.js";
+
+describe("subjects", () => {
+  test("builds v0.3 verb-first subjects", () => {
+    expect(buildPromptSubject("grok", "alice", "main")).toBe("agents.prompt.grok.alice.main");
+    expect(buildStatusSubject("grok", "alice", "main")).toBe("agents.status.grok.alice.main");
+    expect(buildHeartbeatSubject("grok", "alice", "main")).toBe("agents.hb.grok.alice.main");
+  });
+
+  test("rejects invalid supplied tokens instead of rewriting them", () => {
+    expect(() => requireSubjectToken("Not.Valid", "agent.owner")).toThrow("agent.owner");
+    expect(() => requireSubjectToken("", "agent.session")).toThrow("must not be empty");
+  });
+
+  test("sanitizes derived defaults only", () => {
+    expect(sanitizeDerivedSubjectToken("My Project (v2)")).toBe("my-project-v2");
+    expect(sanitizeDerivedSubjectToken("---")).toBe("");
+  });
+});

--- a/agents/acp/tsconfig.json
+++ b/agents/acp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true,
+    "types": ["bun-types", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
+}

--- a/agents/grok/.env.example
+++ b/agents/grok/.env.example
@@ -1,0 +1,22 @@
+# NATS connection
+NATS_URL=nats://127.0.0.1:4222
+# NATS_CONTEXT=
+# NATS_CREDS=
+
+# Public protocol identity (subject tokens: lowercase alphanumeric, '-', '_').
+SYNADIA_GROK_OWNER=local
+SYNADIA_GROK_SESSION=main
+
+# Home strategy (pick one):
+# - Dedicated authed home (recommended for a bus-governed grok — no
+#   permission_mode override, so §7 permission queries reach the caller):
+# SYNADIA_GROK_HOME=/srv/grok-bot
+# - Reuse your interactive login (inherits ~/.grok/config.toml, including any
+#   permission_mode = "always-approve" — grok then never asks):
+# SYNADIA_GROK_HOME=~/.grok
+
+# reject (default) | query (relay grok's permission asks as §7 queries) | allow
+SYNADIA_GROK_PERMISSION_POLICY=query
+
+# Working directory for the grok session (defaults to the process cwd):
+# SYNADIA_ACP_CWD=/path/to/workspace

--- a/agents/grok/CHANGELOG.md
+++ b/agents/grok/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `@synadia-ai/grok-nats-channel` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-18
+
+### Added
+
+- Initial grok-pinned front door to the generic ACP channel
+  (`@synadia-ai/acp-nats-channel`): `grok-agent start` registers a managed
+  Grok Build session as a Synadia Agent Protocol for NATS v0.3 agent at
+  `agents.prompt.grok.<owner>.<session>`.
+- Grok-specific documentation: auth/home strategies (`--agent-home`),
+  the `permission_mode = "always-approve"` interaction with the §7 query
+  relay, and the live-verified approve/deny permission workflow.
+
+### Notes
+
+- Pre-publish, the dependency on `@synadia-ai/acp-nats-channel` is a
+  `file:../acp` link; it switches to a semver range when the ACP channel
+  ships to npm (release-ladder step).

--- a/agents/grok/README.md
+++ b/agents/grok/README.md
@@ -1,0 +1,133 @@
+# Grok Build NATS Channel
+
+`@synadia-ai/grok-nats-channel` puts [Grok Build](https://x.ai/cli) (the
+`grok` CLI coding agent) on the NATS bus as a spec-compliant
+[Synadia Agent Protocol for NATS](https://github.com/synadia-ai/synadia-agent-sdk-docs)
+v0.3 agent:
+
+```
+agents.prompt.grok.<owner>.<session>     prompt endpoint
+agents.status.grok.<owner>.<session>     status endpoint
+agents.hb.grok.<owner>.<session>         heartbeats
+```
+
+It is a **thin, grok-pinned front door** to the generic
+[ACP channel](../acp/) (`@synadia-ai/acp-nats-channel`) — grok speaks the
+[Agent Client Protocol](https://agentclientprotocol.com) natively via
+`grok agent stdio`, and all bridging logic (spawn, ACP session, streaming,
+§7 permission relay) lives in the ACP channel. This package pins the preset
+(`grok-agent start` ≡ `acp-agent start --agent grok --mode managed`) and
+documents the grok-specific workflow. For architecture, wire mapping, and
+limitations (no attachments yet, no subprocess supervision), see the
+[ACP channel README](../acp/README.md).
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.3+
+- The `grok` CLI, authenticated once interactively:
+  `curl -fsSL https://x.ai/cli/install.sh | bash && grok`
+- A NATS server (`nats-server` locally, or any reachable deployment)
+
+## Quickstart
+
+```sh
+grok-agent start --agent-home ~/.grok --nats-url nats://127.0.0.1:4222
+# -> acp-agent (grok, managed) listening on agents.prompt.grok.<you>.<cwd-name>
+```
+
+Prompt it from anywhere on the bus:
+
+```sh
+nats req agents.prompt.grok.<you>.<session> "hello grok" \
+  --replies=0 --reply-timeout=30s --timeout=120s
+```
+
+Or with the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK:
+
+```ts
+const [agent] = await agents.discover({ filter: { agent: "grok" } });
+for await (const msg of await agent!.prompt("summarize this repo")) {
+  if (msg.type === "response") process.stdout.write(msg.text);
+  if (msg.type === "query") await msg.reply("approve");   // §7 permission relay
+}
+```
+
+The grok session is long-lived: consecutive prompts share conversation
+memory until the channel restarts.
+
+## Choosing the agent home (`--agent-home`)
+
+Managed grok runs with `GROK_HOME` pointed at the home you choose; this
+decides both **auth** and **when grok asks permission**:
+
+| Strategy | Command | Effect |
+| --- | --- | --- |
+| Reuse your login | `--agent-home ~/.grok` | Works immediately, but inherits your `config.toml` — including `permission_mode = "always-approve"` if set, in which case grok never asks and §7 queries never fire. |
+| Dedicated authed home (recommended) | `GROK_HOME=/srv/grok-bot grok` once to authenticate, then `--agent-home /srv/grok-bot` | Clean default permission mode: file writes and non-read-only commands ask, and the asks reach the bus. |
+| Ephemeral (default, no flag) | — | Isolated temp home, removed on shutdown — unauthenticated, so `start` fails with an auth hint. Useful only with future non-interactive auth. |
+
+## The permission workflow, live-verified
+
+With `--permission-policy query`, grok's ACP `session/request_permission`
+becomes a protocol **§7 query chunk** the NATS caller answers. Verified
+against grok 0.2.103 (default permission mode, scratch authed home):
+
+**Approve** — caller replied `approve`, mapped to ACP `allow_once`:
+
+```
+[status] tool: write
+[query]  ACP agent requests permission: Write `.../query-proof.txt` [edit].
+         Reply approve to allow once; anything else denies.
+         Details: {"variant":"Write","file_path":"...","content":"the section-7 relay works\n"}
+[status] tool completed: call-cbd3f758-...
+-> file created with the exact content
+```
+
+**Deny** — caller replied `deny`, mapped to `reject_once`:
+
+```
+[query]  ACP agent requests permission: Write `.../should-not-exist.txt` [edit]. ...
+[status] tool failed: call-c1f5dd0e-...
+[status] stop: cancelled
+-> file not created
+```
+
+**Grok decides *when* to ask** (its hooks → allow/ask/deny rules → read-only
+auto-approvals → permission mode pipeline runs first); the channel policy
+only answers what arrives. `reject` (default policy) denies asks without
+relaying; `allow` auto-approves — see the
+[ACP channel README](../acp/README.md#permissions).
+
+## Configuration
+
+`grok-agent` accepts every `acp-agent` flag except `--agent` (pinned).
+Mode defaults to `managed` here (`--mode fake` still available for smoke
+runs). Identity env vars, precedence, and the TOML config file are the ACP
+channel's — the grok-specific vars:
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `SYNADIA_GROK_OWNER` | Owner (4th subject token) | sanitized `$USER` |
+| `SYNADIA_GROK_SESSION` | Session (5th subject token) | sanitized cwd basename |
+| `SYNADIA_GROK_HOME` | Agent home (see above) | ephemeral temp dir |
+| `SYNADIA_GROK_BIN`, `SYNADIA_GROK_ARGS` | Spawn override | `grok` / `agent stdio` |
+| `SYNADIA_GROK_PERMISSION_POLICY` | `reject`, `query`, `allow` | `reject` |
+
+Run `grok-agent doctor` to print the resolved identity and a `grok --version`
+probe.
+
+## Validation
+
+- `bun test` — wrapper pinning + package/README honesty guards.
+- The full protocol/runtime suites live in the [ACP channel](../acp/)
+  (`bun test`, `smoke:protocol`, `smoke:acp-fake-runtime` — deterministic,
+  no grok binary needed).
+- `bun run manual:live -- --session <name> --answer approve "<prompt>"` —
+  discover + prompt a running channel, auto-answering §7 queries.
+
+## Publishing note
+
+Until `@synadia-ai/acp-nats-channel` ships to npm, this package depends on
+it via a `file:../acp` link (repo-local development). The release-ladder
+step that publishes the ACP channel flips this to a semver range before
+`grok-nats-channel` itself is published.

--- a/agents/grok/README.md
+++ b/agents/grok/README.md
@@ -28,21 +28,79 @@ limitations (no attachments yet, no subprocess supervision), see the
   `curl -fsSL https://x.ai/cli/install.sh | bash && grok`
 - A NATS server (`nats-server` locally, or any reachable deployment)
 
-## Quickstart
+## Try it out (from a repo clone)
+
+The package is not on npm yet (see [Publishing note](#publishing-note)), so
+run it straight from the checkout — the `file:../acp` link resolves in-repo:
 
 ```sh
-grok-agent start --agent-home ~/.grok --nats-url nats://127.0.0.1:4222
-# -> acp-agent (grok, managed) listening on agents.prompt.grok.<you>.<cwd-name>
+git clone https://github.com/synadia-ai/synadia-agents.git
+cd synadia-agents/agents/grok
+bun install
 ```
 
-Prompt it from anywhere on the bus:
+**Optional — put `grok-agent` on your PATH.** The bin is an executable
+script with a `bun` shebang, so a symlink into any PATH directory is all it
+takes (prefer a symlink over a global *copy*, which would break the
+repo-local `file:../acp` link):
 
 ```sh
-nats req agents.prompt.grok.<you>.<session> "hello grok" \
+ln -sf "$PWD/src/cli.ts" ~/.local/bin/grok-agent
+grok-agent doctor    # sanity check: identity, spawn command, `grok --version` probe
+```
+
+Without the symlink, substitute `bun src/cli.ts` for `grok-agent` below.
+
+**1. Start a NATS server** (or point at your own via `--nats-url`,
+`NATS_URL`, or `NATS_CONTEXT`):
+
+```sh
+nats-server
+```
+
+**2. Start the channel.** Run it from the directory you want grok to work
+in — its basename becomes the session token (or pass `--cwd` / `--session`).
+Pick a home (details in
+[Choosing the agent home](#choosing-the-agent-home---agent-home)):
+
+```sh
+# Fastest start — reuses your interactive grok login. Caveat: inherits your
+# config.toml; with permission_mode = "always-approve" grok never asks, so
+# no §7 queries will appear on the bus.
+grok-agent start --agent-home ~/.grok
+
+# Bus-governed — grok asks, and the asks reach the caller as §7 queries:
+GROK_HOME=~/grok-bot grok    # once: authenticate in the browser, then quit
+grok-agent start --agent-home ~/grok-bot --permission-policy query
+```
+
+Either way you should see:
+
+```
+acp-agent (grok, managed) listening on agents.prompt.grok.<you>.<session>
+```
+
+**3. Prompt it from another shell:**
+
+```sh
+nats req "agents.prompt.grok.<you>.<session>" "hello grok" \
   --replies=0 --reply-timeout=30s --timeout=120s
 ```
 
-Or with the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK:
+**4. Watch the permission loop.** With the bus-governed setup from step 2,
+ask for a file write and answer the §7 query (the bundled harness prints
+the query — tool, path, content — and auto-answers):
+
+```sh
+bun run manual:live -- --session <session> --answer approve \
+  "create a file named hello.txt containing: hi from the bus"
+```
+
+Swap `--answer deny` to watch grok get refused mid-turn.
+
+## Prompting from code
+
+With the [`@synadia-ai/agents`](../../client-sdk/typescript) SDK:
 
 ```ts
 const [agent] = await agents.discover({ filter: { agent: "grok" } });

--- a/agents/grok/bun.lock
+++ b/agents/grok/bun.lock
@@ -1,0 +1,50 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@synadia-ai/grok-nats-channel",
+      "dependencies": {
+        "@synadia-ai/acp-nats-channel": "file:../acp",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^20.16.0",
+        "typescript": "~5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
+
+    "@nats-io/nats-core": ["@nats-io/nats-core@3.4.0", "", { "dependencies": { "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
+
+    "@nats-io/nuid": ["@nats-io/nuid@3.0.0", "", {}, "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg=="],
+
+    "@nats-io/services": ["@nats-io/services@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0" } }, "sha512-hS9l4F5VCbdg4u7/qgEUU9gtQ+ZOLJxtj+lJj0oSw7Okkm0fLkYq6odbobFa50IGkghfLrzag95dWHSF8F8+CA=="],
+
+    "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
+
+    "@synadia-ai/acp-nats-channel": ["@synadia-ai/acp-nats-channel@file:../acp", { "dependencies": { "@agentclientprotocol/sdk": "^1.2.1", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@synadia-ai/agent-service": "^0.5.2", "@synadia-ai/agents": "^0.5.2" }, "devDependencies": { "@types/bun": "latest", "@types/node": "^20.16.0", "typescript": "~5.6.0" }, "bin": { "acp-agent": "./src/cli.ts" } }],
+
+    "@synadia-ai/agent-service": ["@synadia-ai/agent-service@0.5.2", "", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@synadia-ai/agents": "^0.5.1" } }, "sha512-6y4odN+JbWM9zBFK3XlEOlyJJHnGqPUUQHpfbJqbsPBrI038fQPlhoPcr08SzlY0dXnh4voLoc29mip6Q970rQ=="],
+
+    "@synadia-ai/agents": ["@synadia-ai/agents@0.5.2", "", { "dependencies": { "@nats-io/nats-core": "^3.4.0", "@nats-io/services": "^3.4.0", "@nats-io/transport-node": "^3.4.0" } }, "sha512-7N8C/sBH5wIf0Q3boodDJEpG9dq4sBFLyiS8slLBU5fTrcU12ftHPRzfT+r3zcLYdaYKaMhdeYXEh+qxVomiDw=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+  }
+}

--- a/agents/grok/package.json
+++ b/agents/grok/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@synadia-ai/grok-nats-channel",
+  "version": "0.1.0",
+  "description": "Synadia Agent Protocol for NATS channel for Grok Build — a grok-pinned front door to the generic ACP channel.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "author": "Synadia Communications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synadia-ai/synadia-agents.git",
+    "directory": "agents/grok"
+  },
+  "homepage": "https://github.com/synadia-ai/synadia-agents/tree/main/agents/grok",
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "grok-agent": "./src/cli.ts"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    ".env.example"
+  ],
+  "scripts": {
+    "start": "bun src/cli.ts start",
+    "doctor": "bun src/cli.ts doctor",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "manual:live": "bun node_modules/@synadia-ai/acp-nats-channel/scripts/live-acp-harness.ts --agent grok"
+  },
+  "dependencies": {
+    "@synadia-ai/acp-nats-channel": "file:../acp"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^20.16.0",
+    "typescript": "~5.6.0"
+  }
+}

--- a/agents/grok/src/cli.ts
+++ b/agents/grok/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+// grok-agent — Grok Build on the NATS bus.
+//
+// A thin, grok-pinned front door to the generic ACP channel
+// (`@synadia-ai/acp-nats-channel`): every command is delegated to the ACP
+// channel's `runCli` with the grok preset and managed mode injected as
+// defaults. All bridging logic — spawn, ACP session, chunk mapping, §7
+// permission relay — lives in the ACP channel; this package pins identity
+// and documents the grok-specific workflow.
+import { runCli } from "@synadia-ai/acp-nats-channel";
+
+/**
+ * Build the delegated acp-agent argv: pin `--agent grok` and default
+ * `--mode managed` (the ACP channel's own default is `fake`, which only
+ * makes sense for its protocol smokes). User flags come after the injected
+ * defaults, so an explicit `--mode fake` still wins — but the preset is
+ * pinned: pass-through of `--agent` is rejected rather than silently
+ * re-targeting a differently-named binary.
+ */
+export function buildGrokArgv(argv: readonly string[]): string[] {
+  if (argv.includes("--agent")) {
+    throw new Error(
+      "grok-agent is pinned to the grok preset — use acp-agent from @synadia-ai/acp-nats-channel to bridge other agents",
+    );
+  }
+  const [command = "help", ...rest] = argv;
+  return [command, "--agent", "grok", "--mode", "managed", ...rest];
+}
+
+if (import.meta.main) {
+  runCli(buildGrokArgv(process.argv.slice(2))).catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/agents/grok/src/index.ts
+++ b/agents/grok/src/index.ts
@@ -1,0 +1,2 @@
+export { buildGrokArgv } from "./cli.js";
+export { runCli } from "@synadia-ai/acp-nats-channel";

--- a/agents/grok/test/cli.test.ts
+++ b/agents/grok/test/cli.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { loadConfigFromSources } from "@synadia-ai/acp-nats-channel";
+import { buildGrokArgv } from "../src/cli.js";
+
+const env = { USER: "alice" };
+
+describe("grok-agent argv pinning", () => {
+  test("pins the grok preset and defaults to managed mode", () => {
+    const argv = buildGrokArgv(["start"]);
+    expect(argv).toEqual(["start", "--agent", "grok", "--mode", "managed"]);
+    const cfg = loadConfigFromSources({ argv, env, readFile: () => "", cwd: "/tmp/project-main" });
+    expect(cfg.acp.preset).toBe("grok");
+    expect(cfg.acp.agentId).toBe("grok");
+    expect(cfg.agent.subjectToken).toBe("grok");
+    expect(cfg.acp.mode).toBe("managed");
+    expect(cfg.acp.bin).toBe("grok");
+    expect(cfg.acp.args).toEqual(["agent", "stdio"]);
+  });
+
+  test("user flags still win over the injected defaults", () => {
+    const argv = buildGrokArgv(["start", "--mode", "fake", "--session", "pinned-test"]);
+    const cfg = loadConfigFromSources({ argv, env, readFile: () => "", cwd: "/tmp/project-main" });
+    expect(cfg.acp.mode).toBe("fake");
+    expect(cfg.agent.session).toBe("pinned-test");
+    expect(cfg.acp.preset).toBe("grok");
+  });
+
+  test("rejects --agent instead of silently re-targeting", () => {
+    expect(() => buildGrokArgv(["start", "--agent", "gemini"])).toThrow("pinned to the grok preset");
+  });
+
+  test("passes doctor and configure through with the pin applied", () => {
+    expect(buildGrokArgv(["doctor"])[0]).toBe("doctor");
+    expect(buildGrokArgv(["configure", "--print-template"])).toContain("--print-template");
+    expect(buildGrokArgv([])[0]).toBe("help");
+  });
+});

--- a/agents/grok/test/package.test.ts
+++ b/agents/grok/test/package.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import packageJson from "../package.json";
+
+const changelog = readFileSync(join(import.meta.dir, "..", "CHANGELOG.md"), "utf8");
+
+describe("package metadata", () => {
+  test("uses the required published package and binary names", () => {
+    expect(packageJson.name).toBe("@synadia-ai/grok-nats-channel");
+    expect(packageJson.bin).toEqual({ "grok-agent": "./src/cli.ts" });
+    expect(packageJson.publishConfig).toEqual({ access: "public" });
+  });
+
+  test("stays a thin wrapper: the ACP channel is the only runtime dependency", () => {
+    expect(Object.keys(packageJson.dependencies)).toEqual(["@synadia-ai/acp-nats-channel"]);
+  });
+
+  test("documents the pre-publish file: link in the changelog", () => {
+    // Pre-publish the dep is a file:../acp link (see CHANGELOG Notes); the
+    // release-ladder step that publishes the ACP channel flips it to semver.
+    const dep = packageJson.dependencies["@synadia-ai/acp-nats-channel"];
+    if (dep.startsWith("file:")) {
+      expect(changelog).toContain("file:../acp");
+    } else {
+      expect(dep).toMatch(/^\^\d+\.\d+\.\d+/);
+    }
+  });
+
+  test("includes release notes in the publishable package", () => {
+    expect(packageJson.files).toContain("CHANGELOG.md");
+    expect(changelog).toContain("## [0.1.0]");
+  });
+});

--- a/agents/grok/test/readme.test.ts
+++ b/agents/grok/test/readme.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const readme = readFileSync(join(import.meta.dir, "..", "README.md"), "utf8");
+
+describe("README", () => {
+  test("declares the thin-wrapper relationship to the ACP channel", () => {
+    expect(readme).toContain("thin, grok-pinned front door");
+    expect(readme).toContain("@synadia-ai/acp-nats-channel");
+  });
+
+  test("documents the permission_mode / query-relay interaction", () => {
+    expect(readme).toContain('permission_mode = "always-approve"');
+    expect(readme).toContain("§7");
+    expect(readme).toContain("decides *when* to ask");
+  });
+
+  test("documents all three agent-home strategies", () => {
+    expect(readme).toContain("--agent-home ~/.grok");
+    expect(readme).toContain("Dedicated authed home");
+    expect(readme).toContain("Ephemeral");
+  });
+
+  test("carries the live-verified approve and deny evidence", () => {
+    expect(readme).toContain("live-verified");
+    expect(readme).toContain("file created with the exact content");
+    expect(readme).toContain("file not created");
+  });
+
+  test("points at the ACP channel for limitations instead of overclaiming", () => {
+    expect(readme).toContain("limitations");
+    expect(readme).not.toContain("attachments are supported");
+  });
+});

--- a/agents/grok/tsconfig.json
+++ b/agents/grok/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true,
+    "types": ["bun-types", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## What

Two new packages that put **ACP-speaking coding agents** on the NATS bus:

- **`agents/acp/`** — `@synadia-ai/acp-nats-channel`, bin `acp-agent`: one generic channel for every agent that speaks the [Agent Client Protocol](https://agentclientprotocol.com). Ships a **`grok`** preset (Grok Build via `grok agent stdio`) and a **`custom`** escape hatch (live-validated with Google Antigravity through a community ACP adapter).
- **`agents/grok/`** — `@synadia-ai/grok-nats-channel`, bin `grok-agent`: a thin, grok-pinned front door. Sole runtime dependency is the ACP channel; `grok-agent start` ≡ `acp-agent start --agent grok --mode managed`.

## Why

Grok Build shipped as a Rust binary with no pi-style plugin API and no Claude-Code-style channel injection — but it (like a rapidly growing agent list) speaks ACP natively. ACP is the industry converging on exactly the interface every `agents/*` channel has had to invent per-agent. Building the bridge once at the protocol level means each future ACP agent is a preset entry (plus an optional ~30-line front-door package), not a new bespoke channel.

## Design

Mirrors `agents/codex/` module-for-module, with the codex JSON-RPC layer swapped for the official `@agentclientprotocol/sdk@1.2.1` (the maintained successor to the frozen `@zed-industries/agent-client-protocol`):

| Synadia Agent Protocol v0.3 | ACP |
| --- | --- |
| prompt envelope (§5) | `session/prompt` |
| response chunks (§6.3) | `agent_message_chunk` updates |
| status chunks (§6.4) | `tool_call` / `plan` updates |
| query chunks (§7) | `session/request_permission` (policy `query`; `reject` default, `allow` opt-in) |
| terminator (§6.5) | prompt resolves with `stopReason` |

- Thin `AgentService` adapter — all §3/§6/§8/§9 host plumbing from `@synadia-ai/agent-service`; same `Bridge*Client` seam as codex; `fake` + `managed` modes.
- One long-lived ACP session per instance (conversation memory across prompts; turns serialized per ACP's one-prompt-per-session rule).
- Managed grok runs in an isolated ephemeral `GROK_HOME` (also keeps grok's leader socket away from interactive sessions); `--agent-home ~/.grok` reuses existing auth.
- Identity env vars per the fleet convention: `SYNADIA_GROK_*` > `SYNADIA_ACP_*` > `SYNADIA_OWNER`/`SYNADIA_NAME`.
- The front-door pattern: `agents/acp` exports `runCli(argv)`; the grok wrapper injects `--agent grok --mode managed` (pass-through `--agent` rejected, user `--mode` wins). Thinness is test-enforced (`dependencies === ["@synadia-ai/acp-nats-channel"]`).
- `attachments_ok=false` in v0.1 (codex precedent); no subprocess supervision (crash → 500s until restart, documented).

## Live verification (grok 0.2.103, agy 1.1.4)

| Scenario | Result |
| --- | --- |
| `"Reply with exactly one word: pong"` | ✓ `pong` streamed over the bus |
| File-creation prompt (always-approve home) | ✓ file on disk, exact content |
| Shell prompts (`uname`, `curl`) | ✓ `tool: run_terminal_command` → `tool completed` status chunks + correct output |
| **§7 permission relay — approve** (default-mode home) | ✓ `session/request_permission` → query chunk (tool + path + content) → `approve` → `allow_once` → file on disk |
| **§7 permission relay — deny** | ✓ query → `deny` → `reject_once` → `tool failed`, `stop: cancelled`, file absent |
| `grok-agent start` (front door) | ✓ registered `agents.prompt.grok.m64.front-door`, full query loop |
| **Antigravity via `custom` preset** (community `antigravity-acp` adapter) | ✓ `pong` end-to-end at `agents.prompt.antigravity.m64.agy-test`; tool calls surface, adapter's edit flow still maturing (documented) |

Deterministic CI (no real binaries): 48 acp + 13 grok unit tests, `smoke:protocol` (full §6/§7/§9 wire shapes incl. 400/500 + terminators), `smoke:acp-fake-runtime` (spawned fake ACP agent over real NDJSON — `scripts/fake-acp-agent.ts`, dependency-free). New `acp` job in `agents-typescript.yml` covers both packages.

## Findings made along the way (documented in-repo)

- **The agent decides *when* to ask**: grok advertises no ACP session modes (`modes: null`); its own pipeline (hooks → rules → read-only auto-approvals → `permission_mode` from the agent home's `config.toml`) gates `session/request_permission`. A reused interactive home with `permission_mode = "always-approve"` means no queries ever reach the bus — README section + troubleshooting entry, and the try-out docs steer to a dedicated authed home.
- **Gemini CLI is gone**: superseded by Google Antigravity (`agy`), which has [no native ACP yet](https://github.com/google-antigravity/antigravity-cli/issues/31). The short-lived `gemini` preset was removed pre-release (guard test asserts absence); the README documents the working `custom`-preset recipe via [`antigravity-acp`](https://github.com/shubzkothekar/antigravity-acp), regression-guarded so the documented command can't lose `--mode managed`.
- **Published `agent-service@0.5.2` maps handler-thrown `ProtocolError` to 500** — the handler-400 name-guard is local/unreleased, so the CI job overrides published SDKs with locally-built tgz (same as the codex job). Resolves at the next agent-service release.

## Docs

Each package README is a self-serve path: `agents/grok/` (repo-clone walkthrough: `bun install` → PATH symlink → `grok-agent doctor` → start variants with the permission caveat inline → `nats req` → §7 loop via `manual:live`, with live transcripts), `agents/acp/` (architecture, presets, repo-clone section, full Antigravity recipe). Root README + CLAUDE.md tables updated.

## Ripple notes / follow-ups

- **Spec repo (synadia-ai/synadia-agent-sdk-docs):** register `grok` as a canonical Appendix C agent identifier.
- **Release ladder:** publish `acp-nats-channel` → flip the grok wrapper's pre-publish `file:../acp` link to semver → publish `grok-nats-channel` (each gated separately).
- **Phase 2:** attachments via ACP content blocks (grok advertises `embeddedContext: true`), `session/load` persistence (`loadSession: true`), ACP elicitation relay as §7 queries, first-party `antigravity` preset + front door once `agy` ships `--acp`.

## Review path (by commit)

1. `c6e19e0` — the generic channel (start with `src/bridge.ts` + `src/managed-runtime.ts`; `scripts/fake-acp-agent.ts` is the wire fixture)
2. `801212a` — permission findings docs
3. `ebb6bac` — grok front door + `runCli` export
4. `5e44d8c` — grok try-out walkthrough
5. `e0e6140` — gemini removal + Antigravity via custom preset
6. `57368d3` — full Antigravity recipe + `--mode managed` regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)