### PR TITLE
fix(pi-headless): pin @earendil-works/pi-coding-agent to 0.74.0 (unblocks CI)

### DIFF
--- a/examples/pi-headless/bun.lock
+++ b/examples/pi-headless/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@synadia-ai/nats-pi-headless",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "latest",
+        "@earendil-works/pi-coding-agent": "0.74.0",
         "@nats-io/services": "^3.4.0",
         "@nats-io/transport-node": "^3.4.0",
         "@synadia-ai/agent-service": "file:../../agent-sdk/typescript",

--- a/examples/pi-headless/package.json
+++ b/examples/pi-headless/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.79.1",
-    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-coding-agent": "0.74.0",
     "@nats-io/services": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
     "@synadia-ai/agents": "file:../../client-sdk/typescript",


### PR DESCRIPTION
## Why

`examples/pi-headless/package.json` declares `@earendil-works/pi-coding-agent: "latest"`, but its `bun.lock` was generated against **0.74.0**. The examples workflow installs with `npm install`, which ignores `bun.lock`, so every CI run resolves the newest release — **0.84.3** today — whose API removed `AuthStorage`, `ModelRegistry.create` and the `authStorage` option of `CreateAgentSessionOptions`:

```
src/pi-session-manager.ts(11,3): error TS2305: Module '"@earendil-works/pi-coding-agent"' has no exported member 'AuthStorage'.
src/pi-session-manager.ts(88,40): error TS2339: Property 'create' does not exist on type 'typeof ModelRegistry'.
src/pi-session-manager.ts(187,9): error TS2353: ... 'authStorage' does not exist in type 'CreateAgentSessionOptions'.
```

The `examples/pi-headless (typecheck)` job therefore fails on every branch, including `main`, and blocks unrelated PRs — currently #172.

## What

- Pin `@earendil-works/pi-coding-agent` to the exact version the code was written against, `0.74.0`.
- Update the spec string in `bun.lock` to match (the resolved entry and integrity hash were already `0.74.0`; nothing else in the lockfile changes).

Upgrading `pi-session-manager.ts` to the 0.8x API is a separate, larger change and not attempted here — this is the minimal "-1" fix to get CI green again.

## Verification

Reproduced the CI recipe locally (npm-built `client-sdk/typescript` + `agent-sdk/typescript`, then `npm install && npm run typecheck` in `examples/pi-headless`): `tsc` exit 0 with `pi-coding-agent@0.74.0` and `pi-ai@0.79.10`.

## Follow-ups (not in this PR)

- `examples/claude-code-headless` has the same hazard: `@anthropic-ai/claude-agent-sdk: "latest"` (lockfile at 0.2.139, npm resolves 0.3.x today). It passes for now; it will break the same way.
- The examples workflow could honour a lockfile (`npm ci` with a `package-lock.json`, or `bun install --frozen-lockfile`) so a floating dependency can never turn CI red on an unrelated branch.
- `agents/pi` declares `pi-coding-agent` as a `"*"` **peer** dependency — that one is intentional (the extension runs inside whatever pi the user has installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)