### PR TITLE
ci(agents): pin Bun to 1.3.14 — Bun 1.4.0 breaks nested file: installs

### DIFF
--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - name: Install nats-server
         run: |
           curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - name: Install nats-server
         run: |
           curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - name: Install nats-server
         run: |
           curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - name: Install nats-server
         run: |
           curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz


### PR DESCRIPTION
## Why

Bun **1.4.0** was released today (2026-08-28). `bun install` with it fails for packages whose `file:` dependencies themselves carry `file:` dependencies — which is every agent here (`agents/* → file:../../agent-sdk/typescript → file:../../client-sdk/typescript`):

```
error: Could not find package.json for "file:../../client-sdk/typescript" dependency "@synadia-ai/agents"
error: Could not find package.json for "file:../../agent-sdk/typescript" dependency "@synadia-ai/agent-service"
```

The four agent jobs in `agents-typescript.yml` use `bun-version: latest`, so the regression turned the `agents/pi (unit + spec smoke)` job red on every branch the moment 1.4.0 became `latest` — currently blocking #172 (which does not touch `agents/pi`). The same job passed on `main` at the last run (2026-07-18, Bun 1.3.x).

Reproduced locally in `agents/pi`: Bun 1.4.0 → the error above; Bun 1.3.14 → 403 packages installed.

## What

Pin `bun-version` to `"1.3.14"` (the last 1.3.x) in all four agent jobs. One-line change ×4.

The SDK workflows' `bun: latest` matrix leg still passes on 1.4.0 (a single-level `file:` link) and is left as is.

## Follow-ups (not in this PR)

- Report the nested-`file:` regression upstream to oven-sh/bun (no lockfile involved; `agents/pi` has none, so this isn't the known stale-`bun.lock` case) and un-pin once fixed.
- Same theme as #174: CI should not float on `latest` anywhere it can turn unrelated branches red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)