### PR TITLE
ci: bootstrap rollout branch validation

### DIFF
--- a/.github/scripts/rollout-ci-summary.sh
+++ b/.github/scripts/rollout-ci-summary.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME must be set}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID must be set}"
+: "${TARGET_SHA:?TARGET_SHA must be set}"
+
+declare -a changed_paths=()
+
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+  : "${PR_NUMBER:?PR_NUMBER must be set for pull_request runs}"
+  while IFS= read -r path; do
+    changed_paths+=("$path")
+  done < <(
+    gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+      --paginate --jq '.[].filename'
+  )
+else
+  : "${BEFORE_SHA:?BEFORE_SHA must be set for push runs}"
+  if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+    # A new branch has no meaningful comparison base. Requiring the complete
+    # rollout suite is conservative and gives the branch its first baseline.
+    changed_paths=("__all_rollout_components__")
+  else
+    while IFS= read -r path; do
+      changed_paths+=("$path")
+    done < <(
+      gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$TARGET_SHA" \
+        --jq '.files[].filename'
+    )
+  fi
+fi
+
+if (( ${#changed_paths[@]} == 0 )); then
+  echo "No changed paths reported; no component workflows are expected."
+  exit 0
+fi
+
+declare -a expected_names=()
+expected_count=0
+
+expect() {
+  local candidate="$1"
+  local existing
+  if (( expected_count > 0 )); then
+    for existing in "${expected_names[@]}"; do
+      if [[ "$existing" == "$candidate" ]]; then
+        return
+      fi
+    done
+  fi
+  expected_names+=("$candidate")
+  expected_count=$((expected_count + 1))
+}
+
+for path in "${changed_paths[@]}"; do
+  case "$path" in
+    __all_rollout_components__)
+      expect "CI — client-sdk/typescript"
+      expect "CI — agent-sdk/typescript"
+      expect "CI — agents (TypeScript)"
+      expect "CI — examples (TypeScript)"
+      expect "CI — client-sdk/python"
+      expect "CI — agent-sdk/python"
+      expect "CI — agents/deerflow"
+      expect "CI — Python identity workbook"
+      ;;
+    client-sdk/typescript/*|agent-sdk/typescript/*|test-fixtures/*|.github/workflows/client-sdk-typescript.yml)
+      expect "CI — client-sdk/typescript"
+      ;;
+  esac
+
+  case "$path" in
+    client-sdk/typescript/*|agent-sdk/typescript/*|test-fixtures/*|.github/workflows/agent-sdk-typescript.yml)
+      expect "CI — agent-sdk/typescript"
+      ;;
+  esac
+
+  case "$path" in
+    agents/pi/*|agents/openclaw/*|agents/opencode/*|agents/codex/*|agents/acp/*|agents/grok/*|agents/eve/*|agents/flue/*|agents/claude-code/*|agents/open-agent/*|.claude-plugin/*|client-sdk/typescript/*|agent-sdk/typescript/*|.github/workflows/agents-typescript.yml)
+      expect "CI — agents (TypeScript)"
+      ;;
+  esac
+
+  case "$path" in
+    examples/*|client-sdk/typescript/*|agent-sdk/typescript/*|.github/workflows/examples-typescript.yml)
+      expect "CI — examples (TypeScript)"
+      ;;
+  esac
+
+  case "$path" in
+    client-sdk/python/*|test-fixtures/*|client-sdk/typescript/*|agent-sdk/typescript/*|.github/workflows/client-sdk-python.yml)
+      expect "CI — client-sdk/python"
+      ;;
+  esac
+
+  case "$path" in
+    agent-sdk/python/*|client-sdk/python/*|test-fixtures/*|client-sdk/typescript/*|agent-sdk/typescript/*|.github/workflows/client-sdk-python-agent-service.yml)
+      expect "CI — agent-sdk/python"
+      ;;
+  esac
+
+  case "$path" in
+    agents/deerflow/*|client-sdk/python/*|agent-sdk/python/*|.github/workflows/agents-deerflow-python.yml)
+      expect "CI — agents/deerflow"
+      ;;
+  esac
+
+  case "$path" in
+    examples/identity-workbook/python/*|client-sdk/python/*|agent-sdk/python/*|.github/workflows/python-identity-workbook.yml)
+      expect "CI — Python identity workbook"
+      ;;
+  esac
+done
+
+if (( expected_count == 0 )); then
+  echo "No path-filtered rollout workflows are expected for this change."
+  exit 0
+fi
+
+echo "Waiting for rollout workflows on $TARGET_SHA:"
+printf '  - %s\n' "${expected_names[@]}"
+
+deadline=$((SECONDS + 45 * 60))
+while (( SECONDS < deadline )); do
+  runs_json="$(
+    gh api "repos/$GITHUB_REPOSITORY/actions/runs" --method GET \
+      -f head_sha="$TARGET_SHA" -f event="$GITHUB_EVENT_NAME" -F per_page=100
+  )"
+
+  pending=0
+  failed=0
+  for name in "${expected_names[@]}"; do
+    state="$(
+      jq -r \
+        --arg name "$name" \
+        --arg self "$GITHUB_RUN_ID" \
+        '[.workflow_runs[]
+          | select(.name == $name and (.id | tostring) != $self)]
+         | sort_by([.created_at, .run_attempt])
+         | last
+         | if . == null then "missing"
+           else [.status, (.conclusion // "")] | @tsv
+           end' <<<"$runs_json"
+    )"
+
+    case "$state" in
+      $'completed\tsuccess') ;;
+      $'completed\t'*)
+        echo "FAILED: $name ($state)"
+        failed=1
+        ;;
+      *)
+        pending=$((pending + 1))
+        ;;
+    esac
+  done
+
+  if (( failed != 0 )); then
+    exit 1
+  fi
+  if (( pending == 0 )); then
+    echo "All expected rollout workflows succeeded."
+    exit 0
+  fi
+
+  echo "$pending workflow(s) not complete yet; checking again in 15 seconds."
+  sleep 15
+done
+
+echo "Timed out waiting for expected rollout workflows:" >&2
+printf '  - %s\n' "${expected_names[@]}" >&2
+exit 1

--- a/.github/scripts/rollout-ci-summary.sh
+++ b/.github/scripts/rollout-ci-summary.sh
@@ -12,12 +12,15 @@ declare -a changed_paths=()
 
 if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
   : "${PR_NUMBER:?PR_NUMBER must be set for pull_request runs}"
-  while IFS= read -r path; do
-    changed_paths+=("$path")
-  done < <(
+  paths_output="$(
     gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
       --paginate --jq '.[].filename'
-  )
+  )"
+  if [[ -n "$paths_output" ]]; then
+    while IFS= read -r path; do
+      changed_paths+=("$path")
+    done <<<"$paths_output"
+  fi
 else
   : "${BEFORE_SHA:?BEFORE_SHA must be set for push runs}"
   if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
@@ -25,12 +28,15 @@ else
     # rollout suite is conservative and gives the branch its first baseline.
     changed_paths=("__all_rollout_components__")
   else
-    while IFS= read -r path; do
-      changed_paths+=("$path")
-    done < <(
+    paths_output="$(
       gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$TARGET_SHA" \
         --jq '.files[].filename'
-    )
+    )"
+    if [[ -n "$paths_output" ]]; then
+      while IFS= read -r path; do
+        changed_paths+=("$path")
+      done <<<"$paths_output"
+    fi
   fi
 fi
 

--- a/.github/workflows/agent-sdk-typescript.yml
+++ b/.github/workflows/agent-sdk-typescript.yml
@@ -2,7 +2,7 @@ name: CI — agent-sdk/typescript
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "agent-sdk/typescript/**"
       - "client-sdk/typescript/**"

--- a/.github/workflows/agents-deerflow-python.yml
+++ b/.github/workflows/agents-deerflow-python.yml
@@ -13,26 +13,27 @@ name: CI — agents/deerflow
 # pre-publish gate will too.
 #
 # Scope notes:
-#   * Path filter is deerflow-only. deerflow resolves `synadia-ai-agents` /
-#     `synadia-ai-agent-service` to the local checkouts via
-#     `[tool.uv.sources]`, so a breaking SDK change *could* affect it — but
-#     those SDKs have their own CI, and deerflow's release `verify` job is the
-#     backstop. Running deerflow's full matrix on every SDK PR would be
-#     redundant, so we keep it scoped here.
+#   * DeerFlow resolves `synadia-ai-agents` / `synadia-ai-agent-service` to
+#     local checkouts via `[tool.uv.sources]`, so SDK changes trigger this
+#     workflow during the coordinated rollout.
 #   * No `nats-server` step (unlike `client-sdk-python-agent-service.yml`):
 #     deerflow's suite is unit/integration-level with no e2e tests that spawn
 #     a broker, so the binary isn't needed.
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "agents/deerflow/**"
+      - "client-sdk/python/**"
+      - "agent-sdk/python/**"
       - ".github/workflows/agents-deerflow-python.yml"
   pull_request:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "agents/deerflow/**"
+      - "client-sdk/python/**"
+      - "agent-sdk/python/**"
       - ".github/workflows/agents-deerflow-python.yml"
 
 concurrency:

--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -5,7 +5,7 @@ name: CI — agents (TypeScript)
 # use local file links, so SDK changes trigger this workflow too.
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "agents/pi/**"
       - "agents/openclaw/**"
@@ -14,6 +14,10 @@ on:
       - "agents/acp/**"
       - "agents/grok/**"
       - "agents/eve/**"
+      - "agents/flue/**"
+      - "agents/claude-code/**"
+      - "agents/open-agent/**"
+      - ".claude-plugin/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -26,6 +30,10 @@ on:
       - "agents/acp/**"
       - "agents/grok/**"
       - "agents/eve/**"
+      - "agents/flue/**"
+      - "agents/claude-code/**"
+      - "agents/open-agent/**"
+      - ".claude-plugin/**"
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"
       - ".github/workflows/agents-typescript.yml"
@@ -348,3 +356,141 @@ jobs:
       - name: Grok wrapper unit tests
         working-directory: agents/grok
         run: bun test
+
+  flue:
+    name: agents/flue (typecheck + tests + protocol smoke)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Install nats-server
+        run: |
+          curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
+          tar -xzf nats-server.tar.gz --strip-components=1
+          sudo mv nats-server /usr/local/bin/
+          nats-server --version
+      - name: Build current client-sdk artifact
+        working-directory: client-sdk/typescript
+        run: |
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "CLIENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      - name: Build current agent-sdk artifact
+        working-directory: agent-sdk/typescript
+        run: |
+          npm pkg set "dependencies.@synadia-ai/agents=file:$CLIENT_SDK_TGZ"
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "AGENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      - name: Package contents
+        working-directory: agents/flue
+        run: npm pack --dry-run --json
+      # Install from the packed branch SDKs. Resolving both development
+      # `file:` links directly can deadlock Bun on the SDK dependency cycle.
+      - name: Install packed SDKs and dependencies
+        working-directory: agents/flue
+        run: |
+          npm pkg set "dependencies.@synadia-ai/agents=file:$CLIENT_SDK_TGZ"
+          npm pkg set "dependencies.@synadia-ai/agent-service=file:$AGENT_SDK_TGZ"
+          npm install --no-package-lock --no-audit --no-fund
+      - name: Typecheck
+        working-directory: agents/flue
+        run: bun run typecheck
+      - name: Unit tests
+        working-directory: agents/flue
+        run: bun test
+      - name: Protocol smoke
+        working-directory: agents/flue
+        run: |
+          nats-server > "$RUNNER_TEMP/flue-nats.log" 2>&1 &
+          nats_pid=$!
+          trap 'kill "$nats_pid" 2>/dev/null || true' EXIT
+          bun run smoke:protocol
+
+  claude-code:
+    name: agents/claude-code (roundtrip + package shape)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Install nats-server
+        run: |
+          curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
+          tar -xzf nats-server.tar.gz --strip-components=1
+          sudo mv nats-server /usr/local/bin/
+          nats-server --version
+      # Claude Code installs the published SDKs at server start today. The
+      # coordinated artifact install is added with its identity adaptation;
+      # this bootstrap job still protects the existing roundtrip behavior.
+      - name: Install dependencies
+        working-directory: agents/claude-code
+        run: bun install --frozen-lockfile
+      - name: Validate plugin descriptors
+        run: |
+          node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json', 'utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('agents/claude-code/.claude-plugin/plugin.json', 'utf8'))"
+      - name: Roundtrip smoke
+        working-directory: agents/claude-code
+        env:
+          # Override the developer's configured context with the disposable
+          # broker; an empty context selects NATS_URL by design.
+          NATS_CONTEXT: ""
+          NATS_URL: nats://localhost:4222
+        run: |
+          nats-server > "$RUNNER_TEMP/claude-code-nats.log" 2>&1 &
+          nats_pid=$!
+          trap 'kill "$nats_pid" 2>/dev/null || true' EXIT
+          bun scripts/roundtrip-test.ts
+      - name: Package contents
+        working-directory: agents/claude-code
+        run: npm pack --dry-run --json
+
+  open-agent:
+    name: agents/open-agent (typecheck + tests)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Install nats-server
+        run: |
+          curl -L -o nats-server.tar.gz https://github.com/nats-io/nats-server/releases/download/v2.12.3/nats-server-v2.12.3-linux-amd64.tar.gz
+          tar -xzf nats-server.tar.gz --strip-components=1
+          sudo mv nats-server /usr/local/bin/
+          nats-server --version
+      - name: Build current client-sdk artifact
+        working-directory: client-sdk/typescript
+        run: |
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "CLIENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      - name: Build current agent-sdk artifact
+        working-directory: agent-sdk/typescript
+        run: |
+          npm pkg set "dependencies.@synadia-ai/agents=file:$CLIENT_SDK_TGZ"
+          bun install
+          bun run build
+          tgz="$(npm pack --json | node -e "let s=''; process.stdin.on('data', d => s += d).on('end', () => console.log(JSON.parse(s)[0].filename))")"
+          echo "AGENT_SDK_TGZ=$PWD/$tgz" >> "$GITHUB_ENV"
+      # As with Flue, avoid Bun's cyclic local-link resolver and install the
+      # exact packed branch SDK artifacts instead.
+      - name: Install packed SDKs and dependencies
+        working-directory: agents/open-agent
+        run: |
+          npm pkg set "dependencies.@synadia-ai/agents=file:$CLIENT_SDK_TGZ"
+          npm pkg set "dependencies.@synadia-ai/agent-service=file:$AGENT_SDK_TGZ"
+          npm install --no-package-lock --no-audit --no-fund
+      - name: Typecheck
+        working-directory: agents/open-agent
+        run: bun run typecheck
+      - name: Unit and integration tests
+        working-directory: agents/open-agent
+        run: bun test test/

--- a/.github/workflows/client-sdk-python-agent-service.yml
+++ b/.github/workflows/client-sdk-python-agent-service.yml
@@ -2,7 +2,7 @@ name: CI — agent-sdk/python
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     # The agent-sdk's tests resolve `synadia-ai-agents` to the local
     # client-sdk checkout via `[tool.uv.sources]` — a client-sdk change
     # can break agent-sdk CI, so the path filter spans both subtrees
@@ -18,7 +18,7 @@ on:
       - "agent-sdk/typescript/**"
       - ".github/workflows/client-sdk-python-agent-service.yml"
   pull_request:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "agent-sdk/python/**"
       - "client-sdk/python/**"

--- a/.github/workflows/client-sdk-python.yml
+++ b/.github/workflows/client-sdk-python.yml
@@ -2,7 +2,7 @@ name: CI — client-sdk/python
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "client-sdk/python/**"
       # The identity fixtures and the TS SDK (reference agent / client probe)
@@ -13,7 +13,7 @@ on:
       - "agent-sdk/typescript/**"
       - ".github/workflows/client-sdk-python.yml"
   pull_request:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "client-sdk/python/**"
       # The identity fixtures and the TS SDK (reference agent / client probe)

--- a/.github/workflows/client-sdk-typescript.yml
+++ b/.github/workflows/client-sdk-typescript.yml
@@ -2,7 +2,7 @@ name: CI — client-sdk/typescript
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "client-sdk/typescript/**"
       - "agent-sdk/typescript/**"

--- a/.github/workflows/examples-typescript.yml
+++ b/.github/workflows/examples-typescript.yml
@@ -14,7 +14,7 @@ name: CI — examples (TypeScript)
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "examples/**"
       - "client-sdk/typescript/**"

--- a/.github/workflows/python-identity-workbook.yml
+++ b/.github/workflows/python-identity-workbook.yml
@@ -2,14 +2,14 @@ name: CI — Python identity workbook
 
 on:
   push:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "examples/identity-workbook/python/**"
       - "client-sdk/python/**"
       - "agent-sdk/python/**"
       - ".github/workflows/python-identity-workbook.yml"
   pull_request:
-    branches: [main]
+    branches: [main, sdk-release-rollout]
     paths:
       - "examples/identity-workbook/python/**"
       - "client-sdk/python/**"

--- a/.github/workflows/rollout-ci-summary.yml
+++ b/.github/workflows/rollout-ci-summary.yml
@@ -1,0 +1,31 @@
+name: CI — rollout summary
+
+on:
+  push:
+    branches: [main, sdk-release-rollout]
+  pull_request:
+    branches: [main, sdk-release-rollout]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-rollout-summary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Expected component workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for and evaluate expected workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: bash .github/scripts/rollout-ci-summary.sh

--- a/agents/claude-code/scripts/roundtrip-test.ts
+++ b/agents/claude-code/scripts/roundtrip-test.ts
@@ -14,7 +14,8 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { connect } from '@nats-io/transport-node'
 import { readFileSync, rmSync, existsSync } from 'fs'
 
-const SUBJECT = 'agents.prompt.cc.m64.rt-test'
+const OWNER = 'roundtrip'
+const SUBJECT = `agents.prompt.cc.${OWNER}.rt-test`
 const STATE_DIR = '/tmp/rt-test-state'
 const MAX_PAYLOAD = 1024 * 1024
 
@@ -31,6 +32,7 @@ const transport = new StdioClientTransport({
     CLAUDE_CWD: '/tmp/rt-test',
     NATS_SESSION_NAME: 'rt-test',
     NATS_STATE_DIR: STATE_DIR,
+    SYNADIA_CLAUDE_CODE_OWNER: OWNER,
   },
 })
 

--- a/agents/flue/scripts/protocol-smoke.ts
+++ b/agents/flue/scripts/protocol-smoke.ts
@@ -67,7 +67,8 @@ try {
   if (!agent.promptEndpoint.metadata["max_payload"])
     throw new Error("prompt endpoint missing max_payload");
   const statusEndpoint = agent.endpoints.find((e) => e.name === "status");
-  if (statusEndpoint?.subject !== service.subject.status)
+  if (!statusEndpoint) throw new Error("status endpoint missing");
+  if (statusEndpoint.subject !== service.subject.status)
     throw new Error("status endpoint subject mismatch");
   if (statusEndpoint.queueGroup !== "agents")
     throw new Error("status endpoint queue group mismatch");


### PR DESCRIPTION
Bootstraps the coordinated SDK rollout branch before feature work lands.

- enables PR/push validation for `sdk-release-rollout`
- adds Flue, Claude Code, and open-agent integration jobs
- adds an always-running evaluator for path-filtered component workflows
- makes the existing Claude roundtrip and Flue smoke deterministic in clean CI

Validated locally:
- `actionlint .github/workflows/*.yml`
- `shellcheck .github/scripts/rollout-ci-summary.sh`
- rollout evaluator against integration-only PR #171 and docs-only PR #185
- Flue: typecheck, 25 tests, protocol smoke, pack dry-run against packed branch SDKs
- open-agent: typecheck and 71 tests against packed branch SDKs
- Claude Code: three-case roundtrip and pack dry-run

This PR targets `sdk-release-rollout`, not `main`, as required by the rollout roadmap.