### PR TITLE
fix(ci): close rollout review findings

### DIFF
--- a/.github/scripts/rollout-ci-summary.sh
+++ b/.github/scripts/rollout-ci-summary.sh
@@ -28,10 +28,14 @@ else
     # rollout suite is conservative and gives the branch its first baseline.
     changed_paths=("__all_rollout_components__")
   else
-    paths_output="$(
-      gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$TARGET_SHA" \
-        --jq '.files[].filename'
-    )"
+    # The GitHub compare API silently caps its file list at 300. Diff the
+    # commits locally instead so a large push cannot hide an affected
+    # component from the evaluator. A force-push may leave BEFORE_SHA outside
+    # the checked-out history, so fetch that exact commit when necessary.
+    if ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+      git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
+    fi
+    paths_output="$(git diff --name-only "$BEFORE_SHA" "$TARGET_SHA")"
     if [[ -n "$paths_output" ]]; then
       while IFS= read -r path; do
         changed_paths+=("$path")

--- a/.github/workflows/agents-typescript.yml
+++ b/.github/workflows/agents-typescript.yml
@@ -491,6 +491,9 @@ jobs:
       - name: Typecheck
         working-directory: agents/open-agent
         run: bun run typecheck
+      # The bridge integration suite's NatsServerProcess harness starts and
+      # stops the nats-server binary installed above; no shared broker is
+      # started by this job.
       - name: Unit and integration tests
         working-directory: agents/open-agent
         run: bun test test/

--- a/docs/sdk-release-rollout-roadmap.md
+++ b/docs/sdk-release-rollout-roadmap.md
@@ -85,6 +85,9 @@ merging shared-branch feature work; complete the remaining operational items bef
       workflows are path-filtered, use an always-running evaluator rather than a naive pending
       fan-in over skipped jobs.
 - Setup implementation and green component/aggregate evidence: [PR #186](https://github.com/synadia-ai/synadia-agents/pull/186).
+- Every rollout PR uses a closed review loop: wait for Claude's review on the current head,
+  address every finding in a follow-up commit, comment `@claude please review my fixes`, and wait
+  for the follow-up review. Repeat until the latest head has no remaining findings; only then merge.
 - These workflow changes live on the rollout branch. Once it is pushed, PRs targeting it use its
   base-branch workflows and pushes use the workflow files in the pushed commit; `main` need not
   receive them first.


### PR DESCRIPTION
Closes both follow-up findings from the completed review of #186.

- replaces the 300-file-capped push compare API with a local commit diff, fetching the exact pre-push commit when needed
- documents that open-agent integration tests own their nats-server lifecycle
- records the mandatory reviewer/follow-up loop in the persistent rollout roadmap

Validation:
- `shellcheck .github/scripts/rollout-ci-summary.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- evaluator against a real docs-only push range
- evaluator against integration-only PR #171

Follow-up to inline comments on #186.