### PR TITLE
feat(sdk): resolve connection identity from one credential snapshot

### DIFF
--- a/client-sdk/python/CHANGELOG.md
+++ b/client-sdk/python/CHANGELOG.md
@@ -8,6 +8,20 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
 
 ## [Unreleased]
 
+### Added
+
+- `resolve_nats_connection_bundle(...)` snapshots a selected `nats` CLI
+  context or direct URL plus `.creds` / nkey connection source exactly once.
+  `identity="off"` is the default and exposes no signer;
+  `identity="signed"` derives the signer from that same authentication
+  snapshot and fails clearly when the connection uses token, user/password,
+  JWT-without-seed, or anonymous authentication. The returned connection
+  options use captured JWT/signature callbacks for `.creds` reconnects, not
+  a mutable path; nkey files are normalized once before both connection auth
+  and signing. `wipe()` is idempotent and must run after the NATS connection
+  closes. Bundle representations are redacted; callers must still never log
+  the necessarily sensitive `connection_options` mapping.
+
 ### Changed
 
 - Sender identity is now opt-in: omitting `identity` performs no lookup and
@@ -19,6 +33,9 @@ the 0.x line is explicitly unstable per protocol spec §11.2.
   account must match that live connection; any failure is fatal and never
   downgrades to unsigned or headerless delivery. Explicit diagnostic
   `self_id()` calls remain memoised.
+- NATS URL errors redact token and user/password userinfo. URL and context
+  bundle resolution preserve WebSocket paths and query strings. The existing
+  `load_context_options` API and auth precedence remain compatible.
 
 ## [0.8.0] - 2026-08-29
 

--- a/client-sdk/python/CLAUDE.md
+++ b/client-sdk/python/CLAUDE.md
@@ -149,24 +149,30 @@ responsible for `nc.close()`.
 
 ```python
 import nats
-from synadia_ai.agents import Agents, load_context_options
+from synadia_ai.agents import Agents, resolve_nats_connection_bundle
 
 # 1. Direct URL(s) — caller drives nats-py directly.
 nc = await nats.connect(servers="nats://127.0.0.1:4222")
 
-# 2. Load a `nats` CLI context (~/.config/nats/context/<name>.json) and
-#    splat its kwargs into nats.connect. Pass `"current"` to honour
-#    $NATS_CONTEXT → the `context.txt` pointer written by
-#    `nats context select`.
-nc = await nats.connect(**load_context_options("prod"))
-nc = await nats.connect(**load_context_options("current"))
+# 2. Snapshot a `nats` CLI context and its selected auth once. Pass
+#    `"current"` to honour $NATS_CONTEXT → the `context.txt` pointer.
+bundle = resolve_nats_connection_bundle(context="prod")
+nc = await nats.connect(**bundle.connection_options)
 
 # Then in either case:
 agents = Agents(nc=nc)
 ```
 
-`load_context_options` returns a dict ready to splat into
-`nats.connect(...)`. Supported context fields: `url` → `servers`,
+`resolve_nats_connection_bundle` is preferred for new connections. Its
+default `identity="off"` exposes no signer. With `identity="signed"`, its
+signer is derived from the exact connection-auth snapshot and must be passed
+to `Identity(signer=bundle.signer)`. URL mode accepts one connection source:
+`creds=` or `nkey=`. Close SDK controllers and NATS before calling the
+idempotent `bundle.wipe()`; never log `bundle.connection_options`.
+
+`load_context_options` remains the connection-only compatibility helper and
+returns a dict ready to splat into `nats.connect(...)`. Supported context
+fields: `url` → `servers`,
 `token`, `user`/`password`, `creds` (with `~` expansion, mapped to
 `user_credentials`), `nkey` (a seed-file path, with `~` expansion; the
 seed line is read and passed as `nkeys_seed_str` — nats-py's
@@ -180,11 +186,11 @@ is the reading half (the identity module's `signer_from_context`
 reuses it to find the seed / creds path). The SDK itself does NOT
 read `NATS_URL`; that stays a convenience default inside `examples/`.
 
-Sender identity is configured separately, on `Agents(identity=Identity(
-signer=…, name=…))` — the SDK never reads the seed out of the
-connection (`nc._nkeys_seed` and friends are private API; explicit
-signer only, plan §2.1). `examples/_connect_cli.py` shows the pairing:
-`--nkey` / `--creds` feed both `nats.connect` and `Identity`.
+Sender identity is still explicitly enabled on `Agents(identity=Identity(
+signer=…, name=…))`; resolving a signed bundle does not silently enable it.
+One bundle/signer may be shared by multiple controllers on its one NATS
+connection, because the signer represents the connection user rather than a
+session. The SDK never reaches into private `nc._nkeys_seed` state.
 
 ### Examples vs scripts
 

--- a/client-sdk/python/README.md
+++ b/client-sdk/python/README.md
@@ -92,6 +92,7 @@ asyncio.run(main())
 | `AgentInfo` | [`discovery.py`](src/synadia_ai/agents/discovery.py) | Pure-data record (parsed `$SRV.INFO` per §4.3). What `build_agent_info()` returns. |
 | `Liveness` | [`heartbeat.py`](src/synadia_ai/agents/heartbeat.py) | Frozen snapshot from `Agents.liveness(instance_id)`. |
 | `load_context_options` | [`context.py`](src/synadia_ai/agents/context.py) | Resolve a `nats` CLI context into kwargs for `nats.connect(...)`. |
+| `resolve_nats_connection_bundle` | [`connection_bundle.py`](src/synadia_ai/agents/connection_bundle.py) | Read connection auth once and optionally derive a signer from that exact snapshot. |
 | `Identity`, `signer_from_seed` / `signer_from_creds_file` / `signer_from_context` | [`identity/`](src/synadia_ai/agents/identity/) | Sender identity: sign every `prompt` / `status` with the connection's NKEY — see below. |
 | `Agents.self_id()`, `Agents.sign_sender` / `publish_signed` / `request_signed`, `Agents.resolve_sender` | [`agents.py`](src/synadia_ai/agents/agents.py) | The connection's own agent ID; signed publishes for any subject; the reverse lookup. |
 | `Agent.status()` | [`agent.py`](src/synadia_ai/agents/agent.py) | The §8.7 status probe (header attached) → `HeartbeatPayload`. |
@@ -112,16 +113,28 @@ the `identity` argument is omitted.
 
 ```python
 import nats
-from synadia_ai.agents import Agents, Identity, signer_from_creds_file
+from synadia_ai.agents import Agents, Identity, resolve_nats_connection_bundle
 
-nc = await nats.connect(servers="tls://connect.ngs.global", user_credentials="~/.config/nats/user.creds")
-agents = Agents(
-    nc=nc,
-    identity=Identity(signer=signer_from_creds_file("~/.config/nats/user.creds"), name="claude-code"),
+bundle = resolve_nats_connection_bundle(
+    url="tls://connect.ngs.global",
+    creds="~/.config/nats/user.creds",
+    identity="signed",
 )
-print(await agents.self_id())   # "AABY….UAWW…" — 113 chars on NGS, "$G.U…" / "ACME.U…" on a config-file server
-async for msg in agent.prompt("hello"):
-    ...                         # the receiver sees a VerifiedSender
+nc = None
+try:
+    nc = await nats.connect(**bundle.connection_options)
+    agents = Agents(
+        nc=nc,
+        identity=Identity(signer=bundle.signer, name="claude-code"),
+    )
+    try:
+        print(await agents.self_id())
+    finally:
+        await agents.close()
+finally:
+    if nc is not None:
+        await nc.close()
+    bundle.wipe()               # after NATS closes; reconnect needs the snapshot
 ```
 
 What to know:
@@ -130,15 +143,25 @@ What to know:
   Pass `Identity()` explicitly for an unsigned claim, or use
   `Identity(send_unsigned_claim=False)` for no automatic identity work.
   An unsigned claim discloses your user NKEY to the receiver.
-- **Use the connection's credentials.** The SDK cannot extract a private
-  seed from an already-open connection, so the signer is supplied
-  explicitly. Derive the NATS authenticator and `signer_from_creds` from
-  the same credentials snapshot (or otherwise ensure
-  `signer_from_seed` / `signer_from_context` represents that connection).
+- **Use the connection's credentials.** Prefer
+  `resolve_nats_connection_bundle(context=..., identity="signed")`, or its
+  `url=...` plus `creds=...` / `nkey=...` form. It reads the selected context
+  and credential file once, builds reconnect-safe NATS options, and derives
+  the signer from that exact snapshot. There is no separate identity
+  credential path. The older `load_context_options` and `signer_from_*`
+  helpers remain available for compatibility and advanced use, but do not
+  independently read the same mutable file for a new signed connection.
   Before every signed send, the SDK compares the signer's user and account
   with live `$SYS.REQ.USER.INFO`; a mismatch or unavailable binding fails
   and never downgrades to unsigned or headerless delivery. An HSM / KMS
   signer can implement `SenderSigner` (`sign` may be async).
+- **One bundle belongs to one connection.** Multiple `Agents` controllers
+  or sessions sharing that connection may reuse `bundle.signer`; it names
+  the NATS user, not an individual chat session. Close every controller,
+  close NATS, then call the idempotent `bundle.wipe()`. Do not wipe while
+  reconnect is possible. `bundle.connection_options` necessarily contains
+  authentication configuration: never log or serialize it. The bundle's
+  own `repr` / `str` are redacted.
 - An endpoint that
   declares `min_sender_trust: signed` fails early with
   `SenderSignatureRequiredError` at call time when no signer is
@@ -220,18 +243,45 @@ See [`examples/README.md`](examples/README.md) for the full tour.
 ## Connecting to NATS in production
 
 For [Synadia Cloud](https://www.synadia.com/cloud/) or any self-hosted
-NATS that needs credentials, JWTs, or a non-default URL, use a `nats`
-CLI context and load its kwargs into `nats.connect`:
+NATS that needs credentials, JWTs, or a non-default URL, resolve a `nats`
+CLI context once. Identity is off by default, so ordinary connections do
+not expose a signer:
 
 ```python
 import nats
-from synadia_ai.agents import Agents, load_context_options
+from synadia_ai.agents import Agents, resolve_nats_connection_bundle
 
-nc = await nats.connect(**load_context_options("prod"))
-agents = Agents(nc=nc)
+bundle = resolve_nats_connection_bundle(context="prod")
+nc = None
+try:
+    nc = await nats.connect(**bundle.connection_options)
+    agents = Agents(nc=nc)
+    try:
+        ...
+    finally:
+        await agents.close()
+finally:
+    if nc is not None:
+        await nc.close()
+    bundle.wipe()
 ```
 
-`load_context_options(...)` reads
+Pass `identity="signed"` and configure `Identity(signer=bundle.signer)`
+when outgoing requests should carry signed sender identity. Signed mode
+fails clearly for anonymous, token, user/password, or JWT-without-seed
+authentication; it never silently sends unsigned requests. URL mode is
+also available:
+
+```python
+bundle = resolve_nats_connection_bundle(
+    url="tls://connect.example.com",
+    creds="~/user.creds",  # or: nkey="~/user.nk"
+    identity="signed",
+)
+```
+
+`load_context_options(...)` remains available as the compatibility helper
+when a connection-only dict is all you need. It reads
 `~/.config/nats/context/<name>.json` — URL, creds file, nkey seed
 file, token, user/password, inbox prefix are all honored. See
 [`CLAUDE.md`](CLAUDE.md#connecting-to-nats) for the full field-by-field

--- a/client-sdk/python/src/synadia_ai/agents/__init__.py
+++ b/client-sdk/python/src/synadia_ai/agents/__init__.py
@@ -13,6 +13,8 @@ Public API entry points:
   kwargs for :func:`nats.connect`.
 * :func:`parse_nats_url` — parse a NATS URL (with optional userinfo
   for token / user:password) into kwargs for :func:`nats.connect`.
+* :func:`resolve_nats_connection_bundle` — snapshot connection auth once
+  and optionally derive a sender signer from that same source.
 * :class:`Identity` + the ``signer_from_*`` helpers — the sender-identity
   extension (optional ``Agent-Sender`` on ``prompt`` / ``status`` requests,
   ``Agents.self_id()``, the signed wrappers); the shared codec lives in
@@ -41,6 +43,12 @@ from .agent import (
     StreamMessage,
 )
 from .agents import DEFAULT_REQUEST_SIGNED_TIMEOUT_S, NATS_MSG_ID_HEADER, Agents
+from .connection_bundle import (
+    CredentialSource,
+    IdentityMode,
+    NatsConnectionBundle,
+    resolve_nats_connection_bundle,
+)
 from .context import NatsContextFile, load_context_options, parse_nats_url, read_context_file
 from .discovery import (
     DEFAULT_DISCOVER_MAX_WAIT_S,
@@ -182,6 +190,7 @@ __all__ = [
     "AttachmentsNotSupportedError",
     "Chunk",
     "ClaimedSender",
+    "CredentialSource",
     "DiscoverFilter",
     "EndpointInfo",
     "Envelope",
@@ -189,6 +198,7 @@ __all__ = [
     "Identity",
     "IdentityError",
     "IdentityMismatchError",
+    "IdentityMode",
     "IdentityUnavailableError",
     "InvalidAgentIdError",
     "InvalidSubjectToken",
@@ -196,6 +206,7 @@ __all__ = [
     "MalformedSenderHeaderError",
     "MinSenderTrust",
     "NatsAgentError",
+    "NatsConnectionBundle",
     "NatsContextError",
     "NatsContextFile",
     "NkeySigner",
@@ -241,6 +252,7 @@ __all__ = [
     "read_context_file",
     "read_sender_header_value",
     "refresh_self_id",
+    "resolve_nats_connection_bundle",
     "resolve_sender",
     "self_id",
     "serialize_sender_header",

--- a/client-sdk/python/src/synadia_ai/agents/connection_bundle.py
+++ b/client-sdk/python/src/synadia_ai/agents/connection_bundle.py
@@ -163,7 +163,8 @@ def _resolve_context(selector: str, *, signed: bool) -> NatsConnectionBundle[Nke
     options = _build_context_base_options(ctx)
     fields = ctx.fields
     context_url = _nonempty_str(fields.get("url"))
-    assert context_url is not None  # validated by _build_context_base_options
+    if context_url is None:  # defensive: already validated by _build_context_base_options
+        raise NatsContextError(f"NATS context {selector!r} is missing `url`")
     parsed_url = parse_nats_url(context_url)
     options["servers"] = parsed_url["servers"]
     for key in ("token", "user", "password"):
@@ -281,7 +282,8 @@ def _creds_connection_options(signer: NkeySigner) -> dict[str, Any]:
     # callback branch wins, while without a nonce nats-py sends neither `user`
     # nor `pass` because no user is configured. Do not use a token sentinel:
     # that would become a real fallback credential on a no-nonce server.
-    # This remains compatible with the declared minimum nats-py 2.7.0.
+    # Verified against the declared minimum nats-py 2.7.0 and current 2.x;
+    # the no-nonce CONNECT-shape regression test locks this assumption.
     return {
         "password": _JWT_CALLBACK_AUTH_PASSWORD_SENTINEL,
         "signature_cb": signature_cb,

--- a/client-sdk/python/src/synadia_ai/agents/connection_bundle.py
+++ b/client-sdk/python/src/synadia_ai/agents/connection_bundle.py
@@ -1,0 +1,396 @@
+"""One-shot NATS connection authentication and optional sender signer.
+
+The bundle resolver reads a context and its selected authentication source
+exactly once.  Its connection options and optional signer therefore cannot
+silently diverge if a credentials or nkey file changes between two reads.
+The caller still owns the NATS connection and must call :meth:`wipe` only
+after that connection has closed.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
+
+from .context import (
+    _build_context_base_options,
+    _extract_seed_line,
+    expand_user,
+    parse_nats_url,
+    read_context_file,
+)
+from .errors import IdentityError, IdentityMismatchError, NatsContextError
+from .identity.signer import NkeySigner, identity_from_jwt, signer_from_creds, signer_from_seed
+
+IdentityMode: TypeAlias = Literal["off", "signed"]
+CredentialSource: TypeAlias = str | Path
+SignerT = TypeVar("SignerT", bound=NkeySigner | None)
+
+_AUTH_OPTION_KEYS = (
+    "nkeys_seed_str",
+    "password",
+    "signature_cb",
+    "token",
+    "user",
+    "user_jwt_cb",
+)
+_JWT_CALLBACK_AUTH_PASSWORD_SENTINEL = "_synadia_jwt_callbacks_enabled"
+
+
+class NatsConnectionBundle(Generic[SignerT]):
+    """NATS connect kwargs paired with a signer from the same auth snapshot.
+
+    ``connection_options`` necessarily contains authentication configuration;
+    treat it as secret and never log it.  The custom representation exposes
+    neither values nor option names.  :meth:`wipe` is idempotent and removes
+    retained auth options plus any in-memory nkey signers.  Call it only after
+    the NATS connection is closed, because reconnect authentication uses the
+    captured material.
+    """
+
+    __slots__ = ("_owned_signers", "_wiped", "connection_options", "signer")
+
+    connection_options: dict[str, Any]
+    signer: SignerT
+    _owned_signers: tuple[NkeySigner, ...]
+    _wiped: bool
+
+    def __init__(
+        self,
+        connection_options: dict[str, Any],
+        signer: SignerT,
+        *,
+        owned_signers: tuple[NkeySigner, ...] = (),
+    ) -> None:
+        self.connection_options = connection_options
+        self.signer = signer
+        self._owned_signers = owned_signers
+        self._wiped = False
+
+    def wipe(self) -> None:
+        """Clear retained auth material after the NATS connection is closed."""
+        if self._wiped:
+            return
+        self._wiped = True
+        try:
+            for owned in self._owned_signers:
+                owned.wipe()
+        finally:
+            # Do not leave live callbacks or auth values in the public
+            # mapping even if a future/custom signer cleanup raises.
+            for key in _AUTH_OPTION_KEYS:
+                self.connection_options.pop(key, None)
+
+    def __repr__(self) -> str:
+        mode = "signed" if self.signer is not None else "off"
+        return f"NatsConnectionBundle(identity={mode!r}, redacted=True, wiped={self._wiped})"
+
+    __str__ = __repr__
+
+
+@overload
+def resolve_nats_connection_bundle(
+    *,
+    context: str | None = None,
+    url: str | None = None,
+    creds: CredentialSource | None = None,
+    nkey: CredentialSource | None = None,
+    identity: Literal["signed"],
+) -> NatsConnectionBundle[NkeySigner]: ...
+
+
+@overload
+def resolve_nats_connection_bundle(
+    *,
+    context: str | None = None,
+    url: str | None = None,
+    creds: CredentialSource | None = None,
+    nkey: CredentialSource | None = None,
+    identity: Literal["off"] = "off",
+) -> NatsConnectionBundle[None]: ...
+
+
+@overload
+def resolve_nats_connection_bundle(
+    *,
+    context: str | None = None,
+    url: str | None = None,
+    creds: CredentialSource | None = None,
+    nkey: CredentialSource | None = None,
+    identity: IdentityMode = "off",
+) -> NatsConnectionBundle[NkeySigner | None]: ...
+
+
+def resolve_nats_connection_bundle(
+    *,
+    context: str | None = None,
+    url: str | None = None,
+    creds: CredentialSource | None = None,
+    nkey: CredentialSource | None = None,
+    identity: IdentityMode = "off",
+) -> NatsConnectionBundle[Any]:
+    """Snapshot NATS auth once and optionally derive its sender signer.
+
+    Select exactly one connection source: ``context=...`` or ``url=...``.
+    URL mode may additionally select one connection credential source,
+    either ``creds=...`` (a NATS ``.creds`` file) or ``nkey=...`` (a user
+    seed file).  These are connection credentials, not a second
+    identity-only path.
+
+    ``identity="off"`` is the default and returns ``signer=None`` while
+    preserving every supported connection-auth mode.  ``"signed"`` returns
+    a signer only when the selected connection authentication contains a
+    user seed; it fails instead of falling back for token, user/password,
+    JWT-without-seed, or anonymous connections.
+    """
+    if identity not in ("off", "signed"):
+        raise ValueError("identity must be 'off' or 'signed'")
+    if (context is None) == (url is None):
+        raise NatsContextError("select exactly one NATS source: `context` or `url`")
+    if context is not None:
+        if creds is not None or nkey is not None:
+            raise NatsContextError(
+                "`creds` and `nkey` are URL connection sources and cannot accompany `context`"
+            )
+        return _resolve_context(context, signed=identity == "signed")
+    assert url is not None
+    return _resolve_url(url, creds=creds, nkey=nkey, signed=identity == "signed")
+
+
+def _resolve_context(selector: str, *, signed: bool) -> NatsConnectionBundle[NkeySigner | None]:
+    ctx = read_context_file(selector)
+    options = _build_context_base_options(ctx)
+    fields = ctx.fields
+    context_url = _nonempty_str(fields.get("url"))
+    assert context_url is not None  # validated by _build_context_base_options
+    parsed_url = parse_nats_url(context_url)
+    options["servers"] = parsed_url["servers"]
+    for key in ("token", "user", "password"):
+        if key in parsed_url:
+            options[key] = parsed_url[key]
+
+    creds = _nonempty_str(fields.get("creds"))
+    nkey = _nonempty_str(fields.get("nkey"))
+    user_jwt = _nonempty_str(fields.get("user_jwt"))
+    user_seed = _nonempty_str(fields.get("user_seed"))
+
+    if creds is not None:
+        _clear_basic_auth(options)
+        signer = _signer_from_creds_path(creds, source=f"NATS context {ctx.name!r}")
+        options.update(_creds_connection_options(signer))
+        return _bundle_with_connection_signer(options, signer, signed=signed)
+
+    if nkey is not None:
+        _clear_basic_auth(options)
+        seed = _read_nkey_path(nkey, source=f"NATS context {ctx.name!r}")
+        return _nkey_bundle(options, seed, signed=signed)
+
+    if user_jwt is not None:
+        _clear_basic_auth(options)
+        if user_seed is not None:
+            signer = _signer_from_jwt_seed(user_jwt, user_seed)
+            options.update(_creds_connection_options(signer))
+            return _bundle_with_connection_signer(options, signer, signed=signed)
+
+        options.update(_seedless_jwt_connection_options(user_jwt))
+        if signed:
+            raise IdentityError(
+                f"NATS context {ctx.name!r} selected `user_jwt` without `user_seed`; "
+                "signed identity requires the connection's user seed"
+            )
+        return NatsConnectionBundle(options, None)
+
+    if any(_nonempty_str(fields.get(key)) is not None for key in ("user", "password", "token")):
+        _clear_basic_auth(options)
+        _apply_password_or_token(options, fields)
+    if signed:
+        raise IdentityError(_missing_seed_message(_auth_kind(options)))
+    return NatsConnectionBundle(options, None)
+
+
+def _resolve_url(
+    url: str,
+    *,
+    creds: CredentialSource | None,
+    nkey: CredentialSource | None,
+    signed: bool,
+) -> NatsConnectionBundle[NkeySigner | None]:
+    if creds is not None and nkey is not None:
+        raise NatsContextError("select at most one URL credential source: `creds` or `nkey`")
+
+    options = parse_nats_url(url)
+    if creds is not None or nkey is not None:
+        # Match normal NATS option precedence: an explicit credential source
+        # is authoritative over URL userinfo.  parse_nats_url has already
+        # stripped that userinfo from every server URL, so remove its kwargs.
+        for key in ("token", "user", "password"):
+            options.pop(key, None)
+
+    if creds is not None:
+        signer = _signer_from_creds_path(creds, source="NATS URL")
+        options.update(_creds_connection_options(signer))
+        return _bundle_with_connection_signer(options, signer, signed=signed)
+
+    if nkey is not None:
+        seed = _read_nkey_path(nkey, source="NATS URL")
+        return _nkey_bundle(options, seed, signed=signed)
+
+    if signed:
+        raise IdentityError(_missing_seed_message(_auth_kind(options)))
+    return NatsConnectionBundle(options, None)
+
+
+def _bundle_with_connection_signer(
+    options: dict[str, Any], signer: NkeySigner, *, signed: bool
+) -> NatsConnectionBundle[NkeySigner | None]:
+    if signed:
+        return NatsConnectionBundle(options, signer, owned_signers=(signer,))
+    return NatsConnectionBundle(options, None, owned_signers=(signer,))
+
+
+def _nkey_bundle(
+    options: dict[str, Any], seed: str, *, signed: bool
+) -> NatsConnectionBundle[NkeySigner | None]:
+    # nats-py snapshots `nkeys_seed_str` on connect and derives its reconnect
+    # callback from that string.  Passing a path would reread it; passing raw
+    # block text or a trailing newline would fail nkeys decoding.
+    options["nkeys_seed_str"] = seed
+    if not signed:
+        return NatsConnectionBundle(options, None)
+    signer = signer_from_seed(seed)
+    return NatsConnectionBundle(options, signer, owned_signers=(signer,))
+
+
+def _creds_connection_options(signer: NkeySigner) -> dict[str, Any]:
+    jwt = signer.jwt
+    if jwt is None:  # pragma: no cover - internal invariant
+        signer.wipe()
+        raise IdentityError("credentials snapshot did not contain a user JWT")
+    jwt_bytes = jwt.encode("utf-8")
+
+    def user_jwt_cb() -> bytes:
+        return jwt_bytes
+
+    def signature_cb(nonce: str) -> bytes:
+        return base64.b64encode(signer.sign(nonce.encode("utf-8")))
+
+    # nats-py 2.x does not mark a connection as authenticated when only its
+    # public `user_jwt_cb` / `signature_cb` options are supplied. A non-secret
+    # password-only sentinel makes it enter the auth branch; with a nonce the
+    # callback branch wins, while without a nonce nats-py sends neither `user`
+    # nor `pass` because no user is configured. Do not use a token sentinel:
+    # that would become a real fallback credential on a no-nonce server.
+    # This remains compatible with the declared minimum nats-py 2.7.0.
+    return {
+        "password": _JWT_CALLBACK_AUTH_PASSWORD_SENTINEL,
+        "signature_cb": signature_cb,
+        "user_jwt_cb": user_jwt_cb,
+    }
+
+
+def _seedless_jwt_connection_options(jwt: str) -> dict[str, Any]:
+    """Captured callbacks for a bearer user JWT without a signing seed."""
+    jwt_bytes = jwt.encode("utf-8")
+
+    def user_jwt_cb() -> bytes:
+        return jwt_bytes
+
+    def empty_signature_cb(_nonce: str) -> bytes:
+        # Mirrors the TypeScript jwtAuthenticator(jwt) shape. Bearer user
+        # JWTs do not sign the server nonce, but nats-py emits `jwt` only
+        # from its nonce callback branch.
+        return b""
+
+    return {
+        "password": _JWT_CALLBACK_AUTH_PASSWORD_SENTINEL,
+        "signature_cb": empty_signature_cb,
+        "user_jwt_cb": user_jwt_cb,
+    }
+
+
+def _signer_from_creds_path(source_path: CredentialSource, *, source: str) -> NkeySigner:
+    path = Path(expand_user(str(source_path)))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise NatsContextError(
+            f"{source}: failed to read creds file {path}: {exc.strerror}"
+        ) from exc
+    return signer_from_creds(text)
+
+
+def _read_nkey_path(source_path: CredentialSource, *, source: str) -> str:
+    path = Path(expand_user(str(source_path)))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise NatsContextError(
+            f"{source}: failed to read nkey seed file {path}: {exc.strerror}"
+        ) from exc
+    seed = _extract_seed_line(text)
+    if seed is None:
+        raise NatsContextError(f"{source}: no nkey seed line found in {path}")
+    return seed
+
+
+def _signer_from_jwt_seed(jwt: str, seed: str) -> NkeySigner:
+    signer = signer_from_seed(seed, jwt)
+    try:
+        jwt_user = identity_from_jwt(jwt).user
+        if jwt_user == signer.public_key:
+            return signer
+        raise IdentityMismatchError(
+            signer.public_key,
+            signer.public_key,
+            credential_user=jwt_user,
+        )
+    except Exception:
+        signer.wipe()
+        raise
+
+
+def _apply_password_or_token(options: dict[str, Any], fields: dict[str, Any]) -> None:
+    user = _nonempty_str(fields.get("user"))
+    password = _nonempty_str(fields.get("password"))
+    if user is not None or password is not None:
+        if user is not None:
+            options["user"] = user
+        if password is not None:
+            options["password"] = password
+        return
+    token = _nonempty_str(fields.get("token"))
+    if token is not None:
+        options["token"] = token
+
+
+def _clear_basic_auth(options: dict[str, Any]) -> None:
+    for key in ("token", "user", "password"):
+        options.pop(key, None)
+
+
+def _auth_kind(options: dict[str, Any]) -> str:
+    if "token" in options:
+        return "token"
+    if "user" in options or "password" in options:
+        return "user/password"
+    return "anonymous"
+
+
+def _missing_seed_message(auth_kind: str) -> str:
+    return (
+        f"signed identity is unavailable for {auth_kind} NATS authentication; "
+        "select connection credentials that contain the connection's user seed"
+    )
+
+
+def _nonempty_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__ = [
+    "CredentialSource",
+    "IdentityMode",
+    "NatsConnectionBundle",
+    "resolve_nats_connection_bundle",
+]

--- a/client-sdk/python/src/synadia_ai/agents/context.py
+++ b/client-sdk/python/src/synadia_ai/agents/context.py
@@ -143,6 +143,21 @@ def load_context_options(selector: str) -> dict[str, Any]:
     """
     ctx = read_context_file(selector)
     name, parsed = ctx.name, ctx.fields
+    out = _build_context_base_options(ctx)
+    out.update(_build_auth_kwargs(name, parsed))
+
+    return out
+
+
+def _build_context_base_options(ctx: NatsContextFile) -> dict[str, Any]:
+    """Build the non-auth connection options from an already-read context.
+
+    ``resolve_nats_connection_bundle`` uses this internal half so it can
+    select and snapshot authentication material itself without reading the
+    context twice.  Keeping validation here also prevents the legacy
+    :func:`load_context_options` and the bundle resolver from drifting.
+    """
+    name, parsed = ctx.name, ctx.fields
 
     url = parsed.get("url")
     if not isinstance(url, str) or not url:
@@ -166,7 +181,6 @@ def load_context_options(selector: str) -> dict[str, Any]:
             )
 
     out: dict[str, Any] = {"servers": servers}
-    out.update(_build_auth_kwargs(name, parsed))
 
     inbox_prefix = parsed.get("inbox_prefix")
     if isinstance(inbox_prefix, str) and inbox_prefix:
@@ -237,11 +251,16 @@ def _read_seed_file(name: str, path: str) -> str:
         raise NatsContextError(
             f"NATS context {name!r}: cannot read nkey seed file {path}: {exc.strerror}"
         ) from exc
-    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
-    seed = next((ln for ln in lines if ln.startswith("S") and "-" not in ln), None)
+    seed = _extract_seed_line(text)
     if seed is None:
         raise NatsContextError(f"NATS context {name!r}: no nkey seed line found in {path}")
     return seed
+
+
+def _extract_seed_line(text: str) -> str | None:
+    """Return a normalized seed from a bare file or a NATS seed block."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return next((line for line in lines if line.startswith("S") and "-" not in line), None)
 
 
 # --- internals ----------------------------------------------------------
@@ -413,7 +432,9 @@ def parse_nats_url(url: str) -> dict[str, Any]:
             or p.get("user") != first.get("user")
             or p.get("password") != first.get("password")
         ):
-            raise NatsContextError(f"NATS URL has mixed credentials across server entries: {url}")
+            raise NatsContextError(
+                f"NATS URL has mixed credentials across server entries: {_redact_nats_url(url)}"
+            )
 
     out: dict[str, Any] = {"servers": [p["server"] for p in parsed_all]}
     for k in ("token", "user", "password"):
@@ -430,12 +451,14 @@ def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
     try:
         parsed = urlparse(with_scheme)
     except ValueError as exc:
-        raise NatsContextError(f"invalid NATS URL {original!r}: {exc}") from exc
+        raise NatsContextError(f"invalid NATS URL {_redact_nats_url(original)!r}: {exc}") from exc
 
     if parsed.scheme not in _SUPPORTED_URL_SCHEMES:
-        raise NatsContextError(f"unsupported scheme {parsed.scheme!r} in NATS URL {original!r}")
+        raise NatsContextError(
+            f"unsupported scheme {parsed.scheme!r} in NATS URL {_redact_nats_url(original)!r}"
+        )
     if not parsed.hostname:
-        raise NatsContextError(f"NATS URL {original!r} is missing a host")
+        raise NatsContextError(f"NATS URL {_redact_nats_url(original)!r} is missing a host")
 
     # Reconstruct the server URL without userinfo. Re-bracket IPv6 hosts —
     # urlparse strips the brackets but `nats-py` (and most other tools)
@@ -448,7 +471,16 @@ def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
         netloc = f"{host_token}:{_DEFAULT_NATS_PORT}"
     else:
         netloc = host_token
-    server = f"{parsed.scheme}://{netloc}"
+    # WebSocket transports use the URL path/query as their NATS endpoint.
+    # TCP NATS/tls URLs do not, so retain the existing host-only shape there.
+    websocket_suffix = ""
+    if parsed.scheme in ("ws", "wss"):
+        websocket_suffix = parsed.path
+        if parsed.params:
+            websocket_suffix += f";{parsed.params}"
+        if parsed.query:
+            websocket_suffix += f"?{parsed.query}"
+    server = f"{parsed.scheme}://{netloc}{websocket_suffix}"
 
     out: dict[str, Any] = {"server": server}
     if parsed.password is not None:
@@ -460,6 +492,20 @@ def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
         # Single userinfo component → token (matches `nats` CLI behaviour).
         out["token"] = unquote(parsed.username)
     return out
+
+
+def _redact_nats_url(url: str) -> str:
+    """Redact userinfo in one or more NATS URLs for safe error messages."""
+    redacted: list[str] = []
+    for raw_part in url.split(","):
+        part = raw_part.strip()
+        scheme_end = part.find("://")
+        authority_start = scheme_end + 3 if scheme_end >= 0 else 0
+        at = part.rfind("@", authority_start)
+        if at >= authority_start:
+            part = f"{part[:authority_start]}<redacted>@{part[at + 1 :]}"
+        redacted.append(part)
+    return ",".join(redacted)
 
 
 __all__ = [

--- a/client-sdk/python/src/synadia_ai/agents/context.py
+++ b/client-sdk/python/src/synadia_ai/agents/context.py
@@ -475,7 +475,9 @@ def _parse_single_nats_url(part: str, *, original: str) -> dict[str, Any]:
     # TCP NATS/tls URLs do not, so retain the existing host-only shape there.
     websocket_suffix = ""
     if parsed.scheme in ("ws", "wss"):
-        websocket_suffix = parsed.path
+        # Match WHATWG URL canonicalisation used by the TypeScript SDK: a
+        # query on a bare authority receives the implicit root path.
+        websocket_suffix = parsed.path or ("/" if parsed.query else "")
         if parsed.params:
             websocket_suffix += f";{parsed.params}"
         if parsed.query:

--- a/client-sdk/python/src/synadia_ai/agents/identity/signer.py
+++ b/client-sdk/python/src/synadia_ai/agents/identity/signer.py
@@ -240,15 +240,18 @@ def signer_from_creds(creds_text: str) -> NkeySigner:
     """
     parsed = parse_creds(creds_text)
     signer = signer_from_seed(parsed.seed, parsed.jwt)
-    jwt_user = identity_from_jwt(parsed.jwt).user
-    if jwt_user != signer.public_key:
-        signer.wipe()
+    try:
+        jwt_user = identity_from_jwt(parsed.jwt).user
+        if jwt_user == signer.public_key:
+            return signer
         raise IdentityMismatchError(
             signer.public_key,
             signer.public_key,
             credential_user=jwt_user,
         )
-    return signer
+    except Exception:
+        signer.wipe()
+        raise
 
 
 def signer_from_creds_file(path: str | Path) -> NkeySigner:
@@ -284,17 +287,21 @@ def signer_from_context(selector: str) -> NkeySigner:
                 f"failed to read nkey seed file {seed_path}: {exc.strerror}"
             ) from exc
     if user_seed is not None:
+        if user_jwt is None:
+            return signer_from_seed(user_seed)
         signer = signer_from_seed(user_seed, user_jwt)
-        if user_jwt is not None:
+        try:
             jwt_user = identity_from_jwt(user_jwt).user
-            if jwt_user != signer.public_key:
-                signer.wipe()
-                raise IdentityMismatchError(
-                    signer.public_key,
-                    signer.public_key,
-                    credential_user=jwt_user,
-                )
-        return signer
+            if jwt_user == signer.public_key:
+                return signer
+            raise IdentityMismatchError(
+                signer.public_key,
+                signer.public_key,
+                credential_user=jwt_user,
+            )
+        except Exception:
+            signer.wipe()
+            raise
     raise IdentityError(
         f"NATS context {ctx.name!r} has no creds, nkey, or user_seed — nothing to sign "
         "Agent-Sender with"

--- a/client-sdk/python/tests/test_connection_bundle.py
+++ b/client-sdk/python/tests/test_connection_bundle.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 import nats
 import pytest
-from nats.aio.client import Client
 
 from synadia_ai.agents import (
     Agents,
@@ -276,32 +275,57 @@ def test_context_token_and_jwt_without_seed_reject_signed_mode(
     assert "user" not in jwt_off.connection_options
     assert isinstance(jwt_off.connection_options["password"], str)
 
-    # nats-py only enters its JWT callback branch when it considers auth
-    # configured. The password-only sentinel activates that branch without
-    # becoming a fallback wire credential when INFO has no nonce.
-    client = Client()
-    client._signature_cb = signature_cb
-    client._user_jwt_cb = jwt_cb
-    client._auth_configured = bool(jwt_off.connection_options["password"])
-    client.options.update(
-        {
-            "name": None,
-            "no_echo": None,
-            "password": jwt_off.connection_options["password"],
-            "pedantic": False,
-            "token": None,
-            "user": None,
-            "verbose": False,
-        }
-    )
-    connect_payload = json.loads(client._connect_command().removeprefix(b"CONNECT ").strip())
-    for field in ("auth_token", "jwt", "pass", "sig", "user"):
-        assert field not in connect_payload
-
     assert token_off.signer is None and jwt_off.signer is None
     token_off.wipe()
     jwt_off.wipe()
     assert "password" not in jwt_off.connection_options
+
+
+async def test_jwt_callback_sentinel_is_never_sent_without_a_server_nonce() -> None:
+    connect_line: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
+
+    async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(
+            b'INFO {"server_id":"test","server_name":"test","version":"2.12.7",'
+            b'"proto":1,"host":"127.0.0.1","port":4222,"headers":true,'
+            b'"max_payload":1048576}\r\n'
+        )
+        await writer.drain()
+        try:
+            while line := await reader.readline():
+                if line.startswith(b"CONNECT ") and not connect_line.done():
+                    connect_line.set_result(line)
+                elif line == b"PING\r\n":
+                    writer.write(b"PONG\r\n")
+                    await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, "127.0.0.1", 0)
+    socket = server.sockets[0]
+    port = socket.getsockname()[1]
+    bundle = resolve_nats_connection_bundle(
+        url=f"nats://127.0.0.1:{port}",
+        creds=identity_fixture("operator/alice.creds"),
+    )
+    nc = None
+    try:
+        nc = await nats.connect(
+            **bundle.connection_options,
+            allow_reconnect=False,
+            connect_timeout=1,
+        )
+        wire = await asyncio.wait_for(connect_line, timeout=1)
+        payload = json.loads(wire.removeprefix(b"CONNECT ").strip())
+        for field in ("auth_token", "jwt", "pass", "sig", "user"):
+            assert field not in payload
+    finally:
+        if nc is not None:
+            await nc.close()
+        server.close()
+        await server.wait_closed()
+        bundle.wipe()
 
 
 def test_context_inline_jwt_and_seed_share_one_snapshot(

--- a/client-sdk/python/tests/test_connection_bundle.py
+++ b/client-sdk/python/tests/test_connection_bundle.py
@@ -1,0 +1,430 @@
+"""Immutable NATS connection auth + optional signer bundles."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import nats
+import pytest
+from nats.aio.client import Client
+
+from synadia_ai.agents import (
+    Agents,
+    Identity,
+    IdentityError,
+    NatsConnectionBundle,
+    NatsContextError,
+    parse_nats_url,
+    resolve_nats_connection_bundle,
+)
+from synadia_ai.agents.identity import identity_from_jwt, parse_creds, verify_with_public_key
+from tests.harness.nats_server import find_nats_server, identity_fixture, start_server
+
+if TYPE_CHECKING:
+    from tests.conftest import NkeyUser
+
+
+def _write_context(root: Path, name: str, fields: dict[str, object]) -> Path:
+    context_dir = root / "nats" / "context"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    path = context_dir / f"{name}.json"
+    path.write_text(json.dumps(fields), encoding="utf-8")
+    return path
+
+
+def _point_at_context_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NATS_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("NATS_CONTEXT", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+
+def test_source_selection_and_identity_mode_are_explicit(tmp_path: Path) -> None:
+    with pytest.raises(NatsContextError, match="exactly one"):
+        resolve_nats_connection_bundle()
+    with pytest.raises(NatsContextError, match="exactly one"):
+        resolve_nats_connection_bundle(context="prod", url="nats://localhost:4222")
+    with pytest.raises(NatsContextError, match="cannot accompany"):
+        resolve_nats_connection_bundle(context="prod", creds=tmp_path / "user.creds")
+    with pytest.raises(NatsContextError, match="at most one"):
+        resolve_nats_connection_bundle(
+            url="nats://localhost:4222",
+            creds=tmp_path / "user.creds",
+            nkey=tmp_path / "user.nk",
+        )
+    with pytest.raises(ValueError, match="'off' or 'signed'"):
+        resolve_nats_connection_bundle(url="nats://localhost:4222", identity=cast(Any, "maybe"))
+
+
+def test_identity_off_preserves_plain_auth_and_exposes_no_signer() -> None:
+    token = "super-secret-token"
+    password = "super-secret-password"
+    token_bundle = resolve_nats_connection_bundle(url=f"nats://{token}@localhost:4222")
+    password_bundle = resolve_nats_connection_bundle(url=f"nats://alice:{password}@localhost:4222")
+
+    assert token_bundle.connection_options["token"] == token
+    assert password_bundle.connection_options["user"] == "alice"
+    assert password_bundle.connection_options["password"] == password
+    assert token_bundle.signer is None and password_bundle.signer is None
+
+    for bundle in (token_bundle, password_bundle):
+        rendered = f"{bundle!r} {bundle!s}"
+        assert rendered == (
+            "NatsConnectionBundle(identity='off', redacted=True, wiped=False) "
+            "NatsConnectionBundle(identity='off', redacted=True, wiped=False)"
+        )
+        for secret in (token, password, "alice", "token", "password", "connection_options"):
+            assert secret not in rendered
+
+    token_bundle.wipe()
+    token_bundle.wipe()
+    password_bundle.wipe()
+    assert "token" not in token_bundle.connection_options
+    assert "user" not in password_bundle.connection_options
+    assert "password" not in password_bundle.connection_options
+
+
+@pytest.mark.parametrize(
+    "url, auth_kind",
+    [
+        ("nats://localhost:4222", "anonymous"),
+        ("nats://token@localhost:4222", "token"),
+        ("nats://user:pass@localhost:4222", "user/password"),
+    ],
+)
+def test_signed_mode_never_falls_back_without_a_connection_seed(url: str, auth_kind: str) -> None:
+    with pytest.raises(IdentityError, match=auth_kind):
+        resolve_nats_connection_bundle(url=url, identity="signed")
+
+
+def test_nkey_is_normalized_once_for_connection_and_signer(
+    tmp_path: Path, identity_keys: dict[str, NkeyUser]
+) -> None:
+    alice = identity_keys["alice"]
+    bob = identity_keys["bob"]
+    nkey = tmp_path / "alice.nk"
+    nkey.write_text(
+        f"-----BEGIN USER NKEY SEED-----\n{alice.seed}\n------END USER NKEY SEED------\n",
+        encoding="utf-8",
+    )
+
+    bundle = resolve_nats_connection_bundle(
+        url="nats://localhost:4222", nkey=nkey, identity="signed"
+    )
+    nkey.write_text(f"{bob.seed}\n", encoding="utf-8")
+
+    assert bundle.connection_options["nkeys_seed_str"] == alice.seed
+    assert bundle.signer.public_key == alice.public
+    rendered = repr(bundle)
+    assert alice.seed not in rendered and str(nkey) not in rendered
+
+    bundle.wipe()
+    bundle.wipe()
+    assert "nkeys_seed_str" not in bundle.connection_options
+    with pytest.raises(IdentityError, match="wiped"):
+        bundle.signer.sign(b"after-close")
+
+
+def test_creds_snapshot_drives_callbacks_and_optional_public_signer(tmp_path: Path) -> None:
+    alice_source = identity_fixture("operator/alice.creds")
+    bob_source = identity_fixture("operator/bob.creds")
+    creds = tmp_path / "current-user.creds"
+    alice_text = alice_source.read_text(encoding="utf-8")
+    creds.write_text(alice_text, encoding="utf-8")
+    alice = parse_creds(alice_text)
+
+    bundle = resolve_nats_connection_bundle(
+        url="nats://url-token@localhost:4222", creds=creds, identity="signed"
+    )
+    creds.write_text(bob_source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert "user_credentials" not in bundle.connection_options
+    assert "nkeys_seed_str" not in bundle.connection_options
+    assert "token" not in bundle.connection_options
+    assert "user" not in bundle.connection_options
+    assert isinstance(bundle.connection_options["password"], str)
+    assert bundle.signer.jwt == alice.jwt
+    assert "url-token" not in bundle.connection_options.values()
+
+    jwt_cb = cast(Callable[[], bytes], bundle.connection_options["user_jwt_cb"])
+    signature_cb = cast(Callable[[str], bytes], bundle.connection_options["signature_cb"])
+    assert jwt_cb().decode() == alice.jwt
+    assert verify_with_public_key(
+        bundle.signer.public_key,
+        b"server-nonce",
+        base64.b64decode(signature_cb("server-nonce")),
+    )
+
+    rendered = f"{bundle!r} {bundle!s}"
+    for secret in (
+        alice.jwt,
+        alice.seed,
+        str(creds),
+        "url-token",
+        "signature_cb",
+        "user_jwt_cb",
+    ):
+        assert secret not in rendered
+
+    bundle.wipe()
+    with pytest.raises(IdentityError, match="wiped"):
+        signature_cb("after-close")
+
+    off = resolve_nats_connection_bundle(url="nats://localhost:4222", creds=bob_source)
+    assert off.signer is None
+    assert callable(off.connection_options["signature_cb"])
+    off.wipe()
+
+
+def test_context_and_selected_creds_are_each_read_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_at_context_root(tmp_path, monkeypatch)
+    creds = tmp_path / "home" / "alice.creds"
+    creds.parent.mkdir(parents=True)
+    creds.write_text(identity_fixture("operator/alice.creds").read_text(), encoding="utf-8")
+    context = _write_context(
+        tmp_path,
+        "prod",
+        {
+            "url": "nats://url-context-secret@127.0.0.1:4222",
+            "creds": str(creds),
+            "token": "lower-priority-secret",
+        },
+    )
+
+    original_read_text = Path.read_text
+    reads: dict[Path, int] = {}
+
+    def counted_read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        reads[path] = reads.get(path, 0) + 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counted_read_text)
+    bundle = resolve_nats_connection_bundle(context="prod", identity="signed")
+
+    assert reads[context] == 1
+    assert reads[creds] == 1
+    assert bundle.signer.jwt is not None
+    assert "lower-priority-secret" not in bundle.connection_options.values()
+    assert "url-context-secret" not in repr(bundle.connection_options["servers"])
+    bundle.wipe()
+
+
+def test_context_nkey_block_is_normalized_and_identity_off_stays_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    identity_keys: dict[str, NkeyUser],
+) -> None:
+    _point_at_context_root(tmp_path, monkeypatch)
+    alice = identity_keys["alice"]
+    nkey = tmp_path / "home" / "alice.nk"
+    nkey.parent.mkdir(parents=True)
+    nkey.write_text(
+        f"-----BEGIN USER NKEY SEED-----\n{alice.seed}\n------END USER NKEY SEED------\n",
+        encoding="utf-8",
+    )
+    _write_context(
+        tmp_path,
+        "nkey",
+        {"url": "nats://127.0.0.1:4222", "nkey": "~/alice.nk"},
+    )
+
+    off = resolve_nats_connection_bundle(context="nkey")
+    assert off.connection_options["nkeys_seed_str"] == alice.seed
+    assert off.signer is None
+    signed = resolve_nats_connection_bundle(context="nkey", identity="signed")
+    assert signed.connection_options["nkeys_seed_str"] == alice.seed
+    assert signed.signer.public_key == alice.public
+    off.wipe()
+    signed.wipe()
+
+
+def test_context_token_and_jwt_without_seed_reject_signed_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_at_context_root(tmp_path, monkeypatch)
+    _write_context(
+        tmp_path,
+        "token",
+        {"url": "nats://127.0.0.1:4222", "token": "secret-token"},
+    )
+    _write_context(
+        tmp_path,
+        "jwt",
+        {"url": "nats://127.0.0.1:4222", "user_jwt": "header.payload.signature"},
+    )
+
+    with pytest.raises(IdentityError, match="token"):
+        resolve_nats_connection_bundle(context="token", identity="signed")
+    with pytest.raises(IdentityError, match="without `user_seed`"):
+        resolve_nats_connection_bundle(context="jwt", identity="signed")
+
+    token_off = resolve_nats_connection_bundle(context="token")
+    jwt_off = resolve_nats_connection_bundle(context="jwt")
+    assert token_off.connection_options["token"] == "secret-token"
+    jwt_cb = cast(Callable[[], bytes], jwt_off.connection_options["user_jwt_cb"])
+    signature_cb = cast(Callable[[str], bytes], jwt_off.connection_options["signature_cb"])
+    assert jwt_cb() == b"header.payload.signature"
+    assert signature_cb("server-nonce") == b""
+    assert "token" not in jwt_off.connection_options
+    assert "user" not in jwt_off.connection_options
+    assert isinstance(jwt_off.connection_options["password"], str)
+
+    # nats-py only enters its JWT callback branch when it considers auth
+    # configured. The password-only sentinel activates that branch without
+    # becoming a fallback wire credential when INFO has no nonce.
+    client = Client()
+    client._signature_cb = signature_cb
+    client._user_jwt_cb = jwt_cb
+    client._auth_configured = bool(jwt_off.connection_options["password"])
+    client.options.update(
+        {
+            "name": None,
+            "no_echo": None,
+            "password": jwt_off.connection_options["password"],
+            "pedantic": False,
+            "token": None,
+            "user": None,
+            "verbose": False,
+        }
+    )
+    connect_payload = json.loads(client._connect_command().removeprefix(b"CONNECT ").strip())
+    for field in ("auth_token", "jwt", "pass", "sig", "user"):
+        assert field not in connect_payload
+
+    assert token_off.signer is None and jwt_off.signer is None
+    token_off.wipe()
+    jwt_off.wipe()
+    assert "password" not in jwt_off.connection_options
+
+
+def test_context_inline_jwt_and_seed_share_one_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_at_context_root(tmp_path, monkeypatch)
+    parsed = parse_creds(identity_fixture("operator/alice.creds").read_text(encoding="utf-8"))
+    _write_context(
+        tmp_path,
+        "inline",
+        {
+            "url": "nats://127.0.0.1:4222",
+            "user_jwt": parsed.jwt,
+            "user_seed": parsed.seed,
+        },
+    )
+
+    bundle = resolve_nats_connection_bundle(context="inline", identity="signed")
+    jwt_cb = cast(Callable[[], bytes], bundle.connection_options["user_jwt_cb"])
+    assert jwt_cb().decode() == parsed.jwt
+    assert bundle.signer.jwt == parsed.jwt
+    assert bundle.signer.public_key == identity_from_jwt(jwt_cb().decode()).user
+    bundle.wipe()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "nats://first-secret@one:4222,nats://second-secret@two:4222",
+        "http://scheme-secret@localhost:4222",
+        "nats://missing-host-secret@",
+    ],
+)
+def test_url_errors_redact_userinfo(url: str) -> None:
+    with pytest.raises((NatsContextError, ValueError)) as exc_info:
+        parse_nats_url(url)
+    message = str(exc_info.value)
+    assert "first-secret" not in message
+    assert "second-secret" not in message
+    assert "scheme-secret" not in message
+    assert "missing-host-secret" not in message
+
+
+def test_websocket_paths_and_queries_survive_direct_and_context_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    direct = resolve_nats_connection_bundle(
+        url="wss://direct-token@ws.example.test/nats?tenant=direct"
+    )
+    assert direct.connection_options["servers"] == ["wss://ws.example.test/nats?tenant=direct"]
+    assert direct.connection_options["token"] == "direct-token"
+
+    _point_at_context_root(tmp_path, monkeypatch)
+    _write_context(
+        tmp_path,
+        "websocket",
+        {"url": "ws://context-token@ws.example.test:9222/nats?tenant=context"},
+    )
+    context = resolve_nats_connection_bundle(context="websocket")
+    assert context.connection_options["servers"] == [
+        "ws://ws.example.test:9222/nats?tenant=context"
+    ]
+    assert context.connection_options["token"] == "context-token"
+    direct.wipe()
+    context.wipe()
+
+
+async def test_creds_callbacks_survive_file_rotation_and_real_reconnect(tmp_path: Path) -> None:
+    if find_nats_server() is None:
+        pytest.skip("nats-server not on PATH — connection-bundle reconnect test skipped")
+
+    log_dir = tmp_path / "logs"
+    config = identity_fixture("operator/operator.conf")
+    first = start_server(log_dir, config_path=config)
+    try:
+        second = start_server(log_dir, config_path=config)
+        try:
+            creds = tmp_path / "alice.creds"
+            creds.write_text(
+                identity_fixture("operator/alice.creds").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            bundle = resolve_nats_connection_bundle(
+                url=f"{first.url},{second.url}", creds=creds, identity="signed"
+            )
+            reconnected = asyncio.Event()
+
+            async def reconnected_cb() -> None:
+                reconnected.set()
+
+            options = {
+                **bundle.connection_options,
+                "dont_randomize": True,
+                "max_reconnect_attempts": 50,
+                "reconnect_time_wait": 0.05,
+                "reconnected_cb": reconnected_cb,
+            }
+            nc = await nats.connect(**options)
+            try:
+                connected_url = nc.connected_url
+                assert connected_url is not None and connected_url.port == first.port
+                agents = Agents(nc=nc, identity=Identity(signer=bundle.signer))
+                try:
+                    assert (await agents.self_id()).user == bundle.signer.public_key
+                    creds.write_text("rotated-invalid-creds", encoding="utf-8")
+                    first.stop()
+                    await asyncio.wait_for(reconnected.wait(), timeout=10)
+                    connected_url = nc.connected_url
+                    assert connected_url is not None and connected_url.port == second.port
+                    await nc.flush()
+                finally:
+                    await agents.close()
+            finally:
+                await nc.close()
+                bundle.wipe()
+            with pytest.raises(IdentityError, match="wiped"):
+                bundle.signer.sign(b"after-close")
+        finally:
+            second.stop()
+    finally:
+        first.stop()
+
+
+def test_public_bundle_type_is_exported() -> None:
+    bundle = resolve_nats_connection_bundle(url="nats://localhost:4222")
+    assert isinstance(bundle, NatsConnectionBundle)

--- a/client-sdk/python/tests/test_context_load.py
+++ b/client-sdk/python/tests/test_context_load.py
@@ -453,6 +453,12 @@ def test_parse_url_ws_and_wss_schemes() -> None:
     ws_bare = parse_nats_url("ws://host:9222")
     assert ws_bare == {"servers": ["ws://host:9222"]}
 
+    path = parse_nats_url("wss://tok@host:9222/nats/connect?tenant=acme")
+    assert path == {
+        "servers": ["wss://host:9222/nats/connect?tenant=acme"],
+        "token": "tok",
+    }
+
 
 def test_parse_url_defaults_port_for_bare_nats_host() -> None:
     opts = parse_nats_url("nats://host")

--- a/client-sdk/python/tests/test_context_load.py
+++ b/client-sdk/python/tests/test_context_load.py
@@ -459,6 +459,9 @@ def test_parse_url_ws_and_wss_schemes() -> None:
         "token": "tok",
     }
 
+    bare_query = parse_nats_url("ws://host:9222?route=one")
+    assert bare_query == {"servers": ["ws://host:9222/?route=one"]}
+
 
 def test_parse_url_defaults_port_for_bare_nats_host() -> None:
     opts = parse_nats_url("nats://host")

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -15,6 +15,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- `resolveNatsConnectionBundle(source, { identity: "off" | "signed" })`
+  resolves a NATS CLI context, direct `creds` file, direct `nkey` seed file,
+  or bare URL into connection options and, only in signed mode, a
+  `SenderSigner` derived from the exact same immutable credential snapshot.
+  The returned idempotent `wipe()` clears retained auth/signing bytes and
+  removes auth-bearing option fields after the NATS connection closes. Bundle
+  JSON / Node inspection is redacted; direct `connectionOptions` access is
+  intentionally live and must not be logged.
 - **Sender identity (the sender-identity extension).** Every `prompt` /
   `status` request can now carry an `Agent-Sender` header that names the
   caller's agent ID (`{account}.{user}`, the connection's NKEY pair) and,
@@ -101,6 +109,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- NATS URL errors redact token and user/password userinfo. URL and context
+  resolution preserve WebSocket paths and query strings.
 - **`prompt()` counts the `Agent-Sender` header against `max_payload`**
   (spec: the header counts). The synchronous throw contract holds: a
   _sound upper bound_ of the header is applied synchronously (thrown

--- a/client-sdk/typescript/CHANGELOG.md
+++ b/client-sdk/typescript/CHANGELOG.md
@@ -109,8 +109,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- NATS URL errors redact token and user/password userinfo. URL and context
-  resolution preserve WebSocket paths and query strings.
+- `loadContextOptions` now parses context URLs through `parseNatsUrl`: it
+  validates the supported scheme and host, extracts URL userinfo into auth
+  options, rejects mixed credentials across server entries, and preserves
+  WebSocket paths and query strings. This may reject unusual context URL
+  strings that the previous implementation passed through unchanged. NATS
+  URL errors now redact token and user/password userinfo.
 - **`prompt()` counts the `Agent-Sender` header against `max_payload`**
   (spec: the header counts). The synchronous throw contract holds: a
   _sound upper bound_ of the header is applied synchronously (thrown

--- a/client-sdk/typescript/README.md
+++ b/client-sdk/typescript/README.md
@@ -82,6 +82,7 @@ Both error types extend `ValidationError` → `NatsAgentError`. See [Error handl
 | `agent.status({ subject?, sub?, timeoutMs? })`                                                                     | §8.7 status probe; returns the agent's heartbeat payload.                                |
 | `agents.close()`                                                                                                   | Tear down SDK state; aborts all in-flight streams.                                       |
 | `loadContextOptions(name)` / `parseNatsUrl(url)`                                                                   | Bridge `nats` CLI context files / URLs into `NodeConnectionOptions` for `connect()`.     |
+| `resolveNatsConnectionBundle(source, { identity })`                                                                | Resolve connection auth and an optional signer from one immutable credential snapshot.   |
 | `withAgentReconnectDefaults(opts?)`                                                                                | Opt-in resilient reconnect defaults for agent runtimes — see below. Pure transform.      |
 | `new Agents({ nc, identity: { signer, name } })`                                                                   | Sender identity: sign every `prompt` / `status` with the connection's NKEY — see below.  |
 | `agents.selfId()` / `refreshSelfId()`                                                                              | Resolve the connection's own agent ID (`{account}.{user}`).                              |
@@ -109,23 +110,60 @@ When you adopt these defaults, also handle the terminal `close` status event in 
 
 The optional sender-identity extension lets a receiving agent know _who_ prompted it, verified per message: the caller attaches an `Agent-Sender` header that names its agent ID — the `(account, user)` NKEY pair authenticated on that connection — and, with a signer, an ed25519 signature bound to the subject, payload, timestamp, and nonce. Nothing in it changes protocol `0.3`: support is advertised by `min_sender_trust` on the prompt endpoint (`agent.supportsSenderIdentity`). Identity is off when the `identity` option is omitted.
 
-```ts
-import { Agents, signerFromCredsFile } from "@synadia-ai/agents";
+Use `resolveNatsConnectionBundle` when this process owns the connection. It
+reads a NATS CLI context or direct credential file once and derives connection
+authentication and the optional signer from that same immutable snapshot:
 
-const agents = new Agents({
-  nc,
-  identity: { signer: await signerFromCredsFile("~/.config/nats/user.creds"), name: "claude-code" },
-});
-console.log(await agents.selfId()); // "AABY….UAWW…" — 113 chars on NGS, "$G.U…" / "ACME.U…" on a config-file server
-for await (const msg of await agent.prompt("hello")) {
-  /* the receiver sees a VerifiedSender */
+```ts
+import { connect } from "@nats-io/transport-node";
+import {
+  Agents,
+  resolveNatsConnectionBundle,
+  withAgentReconnectDefaults,
+} from "@synadia-ai/agents";
+
+const bundle = await resolveNatsConnectionBundle(
+  { context: "current" }, // or { url, creds }, { url, nkey }, or { url }
+  { identity: "signed" },
+);
+let nc: Awaited<ReturnType<typeof connect>> | undefined;
+let agents: Agents | undefined;
+try {
+  nc = await connect(withAgentReconnectDefaults(bundle.connectionOptions));
+  agents = new Agents({ nc, identity: { signer: bundle.signer, name: "my-client" } });
+  console.log(await agents.selfId());
+  const [agent] = await agents.discover();
+  if (agent === undefined) throw new Error("no agents discovered");
+  for await (const msg of await agent.prompt("hello")) {
+    /* the receiver sees a VerifiedSender */
+  }
+} finally {
+  await agents?.close();
+  await nc?.close();
+  bundle.wipe(); // after close: reconnect authentication no longer needs the snapshot
 }
 ```
+
+Omit the second argument or pass `{ identity: "off" }` to get connection
+options without constructing or returning a signer. This makes one dynamic
+`"off" | "signed"` configuration usable without branching. Signed mode
+requires the selected connection source itself to contain a user seed: a
+`creds` file, an `nkey` seed file, or a context selecting one of those (an
+inline context `user_jwt` + `user_seed` is supported too). Token,
+username/password, and seedless JWT connections work in off mode and fail
+clearly in signed mode. There is deliberately no second identity-only
+credential path.
+
+The bundle's JSON and Node inspection views are redacted, but the explicitly
+accessed `bundle.connectionOptions` necessarily contains live authentication
+configuration. Never log or serialize those options. Keep the bundle alive
+for reconnects, then call the idempotent `wipe()` only after closing NATS; it
+zeros retained credential bytes and removes auth/TLS fields from the options.
 
 What to know:
 
 - **Identity is opt-in.** Omit `identity` for no lookup and no header. Pass `identity: {}` explicitly for an unsigned claim, or set `sendUnsignedClaim: false` to perform no automatic identity work. An unsigned claim discloses your user NKEY to the receiver.
-- **Use the connection's credentials.** The SDK cannot extract a private seed from an already-open connection, so the signer is supplied explicitly. Build the NATS authenticator and `signerFromCreds` from the same credentials snapshot (or otherwise ensure `signerFromSeed` / `signerFromContext` represents that connection). Before a signed send, the SDK compares the signer's user and account with live `$SYS.REQ.USER.INFO`; a mismatch or unavailable binding fails and never downgrades to unsigned or headerless delivery.
+- **Use the connection's credentials.** The SDK cannot extract a private seed from an already-open connection. Prefer `resolveNatsConnectionBundle` to bind connection authentication and signing to one read. The lower-level `signerFromSeed` / `signerFromCreds` helpers remain available for externally managed connections and HSM/KMS adapters, where the caller must guarantee the signer represents that exact connection. Before a signed send, the SDK compares the signer's user and account with live `$SYS.REQ.USER.INFO`; a mismatch or unavailable binding fails and never downgrades to unsigned or headerless delivery.
 - **Cost.** Identity lookup has a 2 s timeout. TypeScript memoises by connection and public identity-source fingerprint, clears all entries on reconnect, negative-caches failures for 30 s, and never lets an unsigned lookup satisfy a signer's validation. A signed header is ~400 bytes and counts against `max_payload` (header framing included — `PayloadTooLargeError.headerBytes`).
 - **Behind a service import that remaps the subject** — an export that inserts the caller's account token (`account_token_position`), or a `to:` / `local_subject` rename by your own account — discovery reports the exporter's subject, which you cannot publish to. Pass `prompt(text, { subject })` / `status({ subject })` with the local name; the receiver strips an inserted token by itself. Only for a rename by **your own** account also pass `sub: agent.promptEndpoint.subject` (sign the exporter's subject). `signSender` / `publishSigned` / `requestSigned` take the same `sub` option.
 - **A trusted server over TLS is a precondition.** The NATS handshake signs a server-chosen nonce with the same seed that signs `Agent-Sender`; a server you should not have trusted could obtain a signature valid for 30 s. Identity is meaningful only over TLS to a server whose certificate you verify.

--- a/client-sdk/typescript/src/connection-bundle.ts
+++ b/client-sdk/typescript/src/connection-bundle.ts
@@ -59,7 +59,10 @@ export interface NatsConnectionBundle {
   /**
    * Clear retained auth/signing bytes and remove auth-bearing option fields.
    * Idempotent. Call only after the NATS connection has closed, because
-   * reconnect authentication still needs them.
+   * reconnect authentication still needs them. Calling this while the
+   * connection is open zeroes the shared authenticator snapshot, so the
+   * next reconnect will fail authentication with a lower-level signing
+   * error rather than a bundle-specific error.
    */
   wipe(): void;
 }
@@ -204,7 +207,7 @@ function makeBundle(
       try {
         wipeSnapshot();
       } finally {
-        clearAuthOptions(connectionOptions);
+        clearSensitiveOptions(connectionOptions);
       }
     }
   };
@@ -233,7 +236,8 @@ function makeBundle(
   return Object.freeze(bundle) as unknown as NatsConnectionBundle | SignedNatsConnectionBundle;
 }
 
-function clearAuthOptions(connectionOptions: NodeConnectionOptions): void {
+/** Drop auth fields and TLS material, which may contain a client private key. */
+function clearSensitiveOptions(connectionOptions: NodeConnectionOptions): void {
   delete connectionOptions.authenticator;
   delete connectionOptions.token;
   delete connectionOptions.user;

--- a/client-sdk/typescript/src/connection-bundle.ts
+++ b/client-sdk/typescript/src/connection-bundle.ts
@@ -1,0 +1,313 @@
+// Resolve one NATS connection credential source into connection options and,
+// only when explicitly requested, a sender-identity signer derived from the
+// exact same immutable input snapshot.
+//
+// This is the safe high-level seam for long-running agent integrations. A
+// pre-opened NatsConnection cannot reveal its private seed, while composing
+// `loadContextOptions()` with `signerFromContext()` (or two separate creds
+// reads) allows a file rotation between reads. This helper reads the selected
+// context and auth/TLS files once, then builds both capabilities together.
+
+import { credsAuthenticator, jwtAuthenticator, nkeyAuthenticator } from "@nats-io/nats-core";
+import type { NodeConnectionOptions } from "@nats-io/transport-node";
+import {
+  expandHome,
+  loadContextConnectionSnapshot,
+  parseNatsUrl,
+  readAuthFile,
+  type ContextAuthSnapshot,
+} from "./context.js";
+import { IdentityError, NatsContextError } from "./errors.js";
+import {
+  normalizeUserSeed,
+  signerFromCanonicalSeed,
+  signerFromCanonicalSeedAndJwt,
+  signerFromCreds,
+  type SenderSigner,
+} from "./identity/signer.js";
+
+/** A direct URL with at most one connection credential source. */
+export type NatsUrlConnectionSource = { readonly url: string } & (
+  | { readonly creds: string; readonly nkey?: never }
+  | { readonly nkey: string; readonly creds?: never }
+  | { readonly creds?: never; readonly nkey?: never }
+);
+
+/**
+ * The one source from which a connection bundle is resolved. `creds` and
+ * `nkey` are connection credentials, never separate identity credentials.
+ */
+export type NatsConnectionSource =
+  | {
+      readonly context: string;
+      readonly url?: never;
+      readonly creds?: never;
+      readonly nkey?: never;
+    }
+  | NatsUrlConnectionSource;
+
+export interface ResolveNatsConnectionBundleOptions {
+  /** Omit or use `"off"` for no signer; `"signed"` derives one from the connection credential snapshot. */
+  readonly identity?: "off" | "signed";
+}
+
+/** Connection options backed by one retained credential snapshot. */
+export interface NatsConnectionBundle {
+  readonly connectionOptions: NodeConnectionOptions;
+  /** Present only when `identity: "signed"` was selected. */
+  readonly signer?: SenderSigner;
+  /**
+   * Clear retained auth/signing bytes and remove auth-bearing option fields.
+   * Idempotent. Call only after the NATS connection has closed, because
+   * reconnect authentication still needs them.
+   */
+  wipe(): void;
+}
+
+/** A connection bundle whose signer came from the same credential snapshot. */
+export interface SignedNatsConnectionBundle extends NatsConnectionBundle {
+  readonly signer: SenderSigner;
+}
+
+export function resolveNatsConnectionBundle(
+  source: NatsConnectionSource,
+  options?: { readonly identity?: "off" },
+): Promise<NatsConnectionBundle>;
+export function resolveNatsConnectionBundle(
+  source: NatsConnectionSource,
+  options: { readonly identity: "signed" },
+): Promise<SignedNatsConnectionBundle>;
+export function resolveNatsConnectionBundle(
+  source: NatsConnectionSource,
+  options?: ResolveNatsConnectionBundleOptions,
+): Promise<NatsConnectionBundle | SignedNatsConnectionBundle>;
+export async function resolveNatsConnectionBundle(
+  source: NatsConnectionSource,
+  options: ResolveNatsConnectionBundleOptions = {},
+): Promise<NatsConnectionBundle | SignedNatsConnectionBundle> {
+  validateSource(source);
+  if (
+    options.identity !== undefined &&
+    options.identity !== "off" &&
+    options.identity !== "signed"
+  ) {
+    throw new IdentityError('connection bundle identity must be "off" or "signed"');
+  }
+
+  const context = (source as Record<string, unknown>)["context"];
+  if (typeof context === "string") {
+    const snapshot = await loadContextConnectionSnapshot(context);
+    let prepared: PreparedContextSnapshot;
+    try {
+      prepared = prepareContextSnapshot(snapshot);
+    } catch (error) {
+      snapshot.wipe();
+      throw error;
+    }
+    if (options.identity !== "signed") {
+      return makeBundle(prepared.connectionOptions, undefined, () => prepared.wipe());
+    }
+    try {
+      const signer = signerFromContextSnapshot(snapshot.name, prepared.auth);
+      return makeBundle(prepared.connectionOptions, signer, () => prepared.wipe());
+    } catch (error) {
+      prepared.wipe();
+      throw error;
+    }
+  }
+
+  // Runtime validation above established the URL branch; keep the cast here
+  // rather than relying on property presence, since `{ context: undefined,
+  // url: "…" }` is a valid JavaScript shape at this boundary.
+  const directSource = source as NatsUrlConnectionSource;
+  const connectionOptions = parseNatsUrl(directSource.url);
+  const credential = await readDirectCredential(directSource);
+  if (credential !== undefined) {
+    // An explicit creds/nkey file is the selected connection auth source;
+    // userinfo from the URL must not become a second competing credential.
+    delete connectionOptions.token;
+    delete connectionOptions.user;
+    delete connectionOptions.pass;
+    connectionOptions.authenticator =
+      credential.kind === "creds"
+        ? credsAuthenticator(credential.bytes)
+        : nkeyAuthenticator(credential.bytes);
+  }
+
+  if (options.identity !== "signed") {
+    return makeBundle(connectionOptions, undefined, () => credential?.bytes.fill(0));
+  }
+  if (credential === undefined) {
+    throw new IdentityError(
+      "signed identity requires URL connection credentials with a user seed (`creds` or `nkey`)",
+    );
+  }
+  try {
+    const signer =
+      credential.kind === "creds"
+        ? signerFromCreds(new TextDecoder().decode(credential.bytes))
+        : signerFromCanonicalSeed(credential.bytes);
+    return makeBundle(connectionOptions, signer, () => credential.bytes.fill(0));
+  } catch (error) {
+    credential.bytes.fill(0);
+    throw error;
+  }
+}
+
+function signerFromContextSnapshot(name: string, auth: ContextAuthSnapshot): SenderSigner {
+  if (auth.kind === "creds") return signerFromCreds(new TextDecoder().decode(auth.bytes));
+  if (auth.kind === "nkey") return signerFromCanonicalSeed(auth.bytes);
+  if (auth.kind === "jwt-seed") return signerFromCanonicalSeedAndJwt(auth.seed, auth.jwt);
+  throw new IdentityError(
+    `NATS context "${name}" has no user seed; signed identity requires creds, nkey, or user_jwt with user_seed in that same context`,
+  );
+}
+
+type DirectCredential =
+  | { readonly kind: "creds"; readonly bytes: Uint8Array }
+  | { readonly kind: "nkey"; readonly bytes: Uint8Array };
+
+async function readDirectCredential(
+  source: NatsUrlConnectionSource,
+): Promise<DirectCredential | undefined> {
+  if (source.creds !== undefined) {
+    const bytes = await readAuthFile("creds", expandHome(source.creds));
+    return {
+      kind: "creds",
+      bytes: new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+    };
+  }
+  if (source.nkey !== undefined) {
+    const bytes = await readAuthFile("nkey", expandHome(source.nkey));
+    const raw = new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    try {
+      return { kind: "nkey", bytes: normalizeUserSeed(raw) };
+    } finally {
+      raw.fill(0);
+    }
+  }
+  return undefined;
+}
+
+function makeBundle(
+  connectionOptions: NodeConnectionOptions,
+  signer: SenderSigner | undefined,
+  wipeSnapshot: () => void,
+): NatsConnectionBundle | SignedNatsConnectionBundle {
+  let wiped = false;
+  const wipe = (): void => {
+    if (wiped) return;
+    wiped = true;
+    try {
+      signer?.wipe?.();
+    } finally {
+      try {
+        wipeSnapshot();
+      } finally {
+        clearAuthOptions(connectionOptions);
+      }
+    }
+  };
+  const identity = signer === undefined ? "off" : "signed";
+  const bundle = Object.create(null) as Record<PropertyKey, unknown>;
+  Object.defineProperty(bundle, "connectionOptions", {
+    value: connectionOptions,
+    enumerable: false,
+  });
+  if (signer !== undefined) {
+    Object.defineProperty(bundle, "signer", { value: signer, enumerable: false });
+  }
+  Object.defineProperty(bundle, "wipe", { value: wipe, enumerable: false });
+  Object.defineProperty(bundle, "toJSON", {
+    value: (): { identity: "off" | "signed" } => ({ identity }),
+    enumerable: false,
+  });
+  Object.defineProperty(bundle, "toString", {
+    value: (): string => `NatsConnectionBundle(${identity})`,
+    enumerable: false,
+  });
+  Object.defineProperty(bundle, Symbol.for("nodejs.util.inspect.custom"), {
+    value: (): string => `NatsConnectionBundle(${identity})`,
+    enumerable: false,
+  });
+  return Object.freeze(bundle) as unknown as NatsConnectionBundle | SignedNatsConnectionBundle;
+}
+
+function clearAuthOptions(connectionOptions: NodeConnectionOptions): void {
+  delete connectionOptions.authenticator;
+  delete connectionOptions.token;
+  delete connectionOptions.user;
+  delete connectionOptions.pass;
+  delete connectionOptions.tls;
+}
+
+interface PreparedContextSnapshot {
+  readonly connectionOptions: NodeConnectionOptions;
+  readonly auth: ContextAuthSnapshot;
+  wipe(): void;
+}
+
+/** Canonicalize seed auth once, then give NATS and signing that same buffer. */
+function prepareContextSnapshot(
+  snapshot: Awaited<ReturnType<typeof loadContextConnectionSnapshot>>,
+): PreparedContextSnapshot {
+  if (snapshot.auth.kind !== "nkey" && snapshot.auth.kind !== "jwt-seed") {
+    return {
+      connectionOptions: snapshot.connectionOptions,
+      auth: snapshot.auth,
+      wipe: () => snapshot.wipe(),
+    };
+  }
+
+  const canonicalSeed = normalizeUserSeed(
+    snapshot.auth.kind === "nkey" ? snapshot.auth.bytes : snapshot.auth.seed,
+  );
+  const auth: ContextAuthSnapshot =
+    snapshot.auth.kind === "nkey"
+      ? { kind: "nkey", bytes: canonicalSeed }
+      : { kind: "jwt-seed", jwt: snapshot.auth.jwt, seed: canonicalSeed };
+  snapshot.connectionOptions.authenticator =
+    auth.kind === "nkey"
+      ? nkeyAuthenticator(canonicalSeed)
+      : jwtAuthenticator(auth.jwt, canonicalSeed);
+  // The original raw bytes are no longer retained by the selected
+  // authenticator. Zero them immediately; keep the canonical bytes until the
+  // connection has closed so reconnect authentication remains possible.
+  snapshot.wipe();
+  let wiped = false;
+  return {
+    connectionOptions: snapshot.connectionOptions,
+    auth,
+    wipe() {
+      if (wiped) return;
+      wiped = true;
+      canonicalSeed.fill(0);
+    },
+  };
+}
+
+function validateSource(source: NatsConnectionSource): void {
+  if (typeof source !== "object" || source === null || Array.isArray(source)) {
+    throw new NatsContextError("connection source must be an object");
+  }
+  const candidate = source as Record<string, unknown>;
+  for (const field of ["context", "url", "creds", "nkey"] as const) {
+    const value = candidate[field];
+    if (value !== undefined && (typeof value !== "string" || value.length === 0)) {
+      throw new NatsContextError(`connection source \`${field}\` must be a non-empty string`);
+    }
+  }
+  const hasContext = typeof candidate["context"] === "string";
+  const hasUrl = typeof candidate["url"] === "string";
+  if (hasContext === hasUrl) {
+    throw new NatsContextError("connection source must select exactly one of `context` or `url`");
+  }
+  if (hasContext && (candidate["creds"] !== undefined || candidate["nkey"] !== undefined)) {
+    throw new NatsContextError(
+      "a context connection cannot also select direct `creds` or `nkey` credentials",
+    );
+  }
+  if (candidate["creds"] !== undefined && candidate["nkey"] !== undefined) {
+    throw new NatsContextError("a URL connection must select at most one of `creds` or `nkey`");
+  }
+}

--- a/client-sdk/typescript/src/context.ts
+++ b/client-sdk/typescript/src/context.ts
@@ -59,6 +59,37 @@ export interface NatsContextFile {
 }
 
 /**
+ * Auth material selected from one context-file read. Internal contract for
+ * `resolveNatsConnectionBundle`; raw bytes are never exported from the
+ * package root or included in logs/errors.
+ *
+ * @internal
+ */
+export type ContextAuthSnapshot =
+  | { readonly kind: "creds"; readonly bytes: Uint8Array }
+  | { readonly kind: "nkey"; readonly bytes: Uint8Array }
+  | { readonly kind: "jwt-seed"; readonly jwt: string; readonly seed: Uint8Array }
+  | { readonly kind: "jwt" }
+  | { readonly kind: "user-password" }
+  | { readonly kind: "token" }
+  | { readonly kind: "none" };
+
+/**
+ * Connection options plus the exact auth snapshot used to build their
+ * authenticator. Internal so the connection-bundle helper can derive a
+ * signer without re-reading a context or credential file.
+ *
+ * @internal
+ */
+export interface ContextConnectionSnapshot {
+  readonly name: string;
+  readonly connectionOptions: NodeConnectionOptions;
+  readonly auth: ContextAuthSnapshot;
+  /** Zero retained auth bytes. Call only after the connection is closed. */
+  wipe(): void;
+}
+
+/**
  * Read a NATS CLI context by name. Pass `"current"` to resolve via
  * `$NATS_CONTEXT` or the `context.txt` selection file. This is the
  * *reading* half of {@link loadContextOptions}; `signerFromContext` in the
@@ -103,71 +134,124 @@ export async function readContextFile(selector: string): Promise<NatsContextFile
  * the `context.txt` selection file.
  */
 export async function loadContextOptions(selector: string): Promise<NodeConnectionOptions> {
+  return (await loadContextConnectionSnapshot(selector)).connectionOptions;
+}
+
+/**
+ * Resolve a context once, retaining the selected auth bytes long enough for
+ * both the NATS authenticator and an optional sender signer to consume the
+ * same snapshot. Not exported from the package root.
+ *
+ * @internal
+ */
+export async function loadContextConnectionSnapshot(
+  selector: string,
+): Promise<ContextConnectionSnapshot> {
   const { name, fields: parsed } = await readContextFile(selector);
 
   const url = str(parsed["url"]);
   if (!url) throw new NatsContextError(`NATS context "${name}" is missing \`url\``);
-  const servers = url
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-
-  const opts: NodeConnectionOptions = { servers };
+  // Parse userinfo just as direct URL mode does. Explicit context auth below
+  // wins and removes these fields, so a context can never retain two
+  // competing connection credential sources.
+  const opts = parseNatsUrl(url);
+  let auth: ContextAuthSnapshot =
+    opts.user !== undefined || opts.pass !== undefined
+      ? { kind: "user-password" }
+      : opts.token !== undefined
+        ? { kind: "token" }
+        : { kind: "none" };
 
   const creds = str(parsed["creds"]);
   const nkey = str(parsed["nkey"]);
   const userJwt = str(parsed["user_jwt"]);
   const userSeed = str(parsed["user_seed"]);
   if (creds) {
+    clearBasicAuth(opts);
     const bytes = await readAuthFile("creds", expandHome(creds));
-    opts.authenticator = credsAuthenticator(
-      new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
-    );
+    const snapshot = new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    opts.authenticator = credsAuthenticator(snapshot);
+    auth = { kind: "creds", bytes: snapshot };
   } else if (nkey) {
+    clearBasicAuth(opts);
     // `nats context add` writes `nkey` as a path to a file containing the
     // raw seed. Read it once and pass through `nkeyAuthenticator`, which
     // signs the server nonce on each CONNECT.
     const bytes = await readAuthFile("nkey", expandHome(nkey));
-    opts.authenticator = nkeyAuthenticator(
-      new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
-    );
+    const snapshot = new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    opts.authenticator = nkeyAuthenticator(snapshot);
+    auth = { kind: "nkey", bytes: snapshot };
   } else if (userJwt) {
+    clearBasicAuth(opts);
     // Inline JWT + optional inline seed. When `user_seed` is present
     // alongside `user_jwt` (the typical "decentralised auth without a
     // .creds file" shape), pass the seed bytes so nonce signing works.
     if (userSeed) {
-      opts.authenticator = jwtAuthenticator(userJwt, new TextEncoder().encode(userSeed));
+      const snapshot = new TextEncoder().encode(userSeed);
+      opts.authenticator = jwtAuthenticator(userJwt, snapshot);
+      auth = { kind: "jwt-seed", jwt: userJwt, seed: snapshot };
     } else {
       opts.authenticator = jwtAuthenticator(userJwt);
+      auth = { kind: "jwt" };
     }
   } else {
     const token = str(parsed["token"]);
     const user = str(parsed["user"]);
     const password = str(parsed["password"]);
-    if (token) opts.token = token;
-    if (user) opts.user = user;
-    if (password) opts.pass = password;
+    if (token || user || password) {
+      clearBasicAuth(opts);
+      if (token) opts.token = token;
+      if (user) opts.user = user;
+      if (password) opts.pass = password;
+      auth = user || password ? { kind: "user-password" } : { kind: "token" };
+    }
   }
 
-  // Optional TLS triple. `nats context add --tlscert/--tlskey/--tlsca`
-  // writes file paths; load them into standard node:tls options.
-  const cert = str(parsed["cert"]);
-  const key = str(parsed["key"]);
-  const ca = str(parsed["ca"]);
-  const tlsFirst = parsed["tls_first"];
-  if (cert || key || ca || tlsFirst === true) {
-    const tls: NonNullable<NodeConnectionOptions["tls"]> = {};
-    if (cert) tls.cert = await readTlsFile("cert", expandHome(cert));
-    if (key) tls.key = await readTlsFile("key", expandHome(key));
-    if (ca) tls.ca = await readTlsFile("ca", expandHome(ca));
-    if (tlsFirst === true) tls.handshakeFirst = true;
-    opts.tls = tls;
+  try {
+    // Optional TLS triple. `nats context add --tlscert/--tlskey/--tlsca`
+    // writes file paths; load them into standard node:tls options.
+    const cert = str(parsed["cert"]);
+    const key = str(parsed["key"]);
+    const ca = str(parsed["ca"]);
+    const tlsFirst = parsed["tls_first"];
+    if (cert || key || ca || tlsFirst === true) {
+      const tls: NonNullable<NodeConnectionOptions["tls"]> = {};
+      if (cert) tls.cert = await readTlsFile("cert", expandHome(cert));
+      if (key) tls.key = await readTlsFile("key", expandHome(key));
+      if (ca) tls.ca = await readTlsFile("ca", expandHome(ca));
+      if (tlsFirst === true) tls.handshakeFirst = true;
+      opts.tls = tls;
+    }
+  } catch (error) {
+    wipeContextAuth(auth);
+    throw error;
   }
 
   const inboxPrefix = str(parsed["inbox_prefix"]);
   if (inboxPrefix) opts.inboxPrefix = inboxPrefix;
 
-  return opts;
+  let wiped = false;
+  return {
+    name,
+    connectionOptions: opts,
+    auth,
+    wipe() {
+      if (wiped) return;
+      wiped = true;
+      wipeContextAuth(auth);
+    },
+  };
+}
+
+function clearBasicAuth(options: NodeConnectionOptions): void {
+  delete options.token;
+  delete options.user;
+  delete options.pass;
+}
+
+function wipeContextAuth(auth: ContextAuthSnapshot): void {
+  if (auth.kind === "creds" || auth.kind === "nkey") auth.bytes.fill(0);
+  if (auth.kind === "jwt-seed") auth.seed.fill(0);
 }
 
 /** Expand a leading `~/` to `$HOME/`. */
@@ -225,7 +309,7 @@ export function parseNatsUrl(url: string): NodeConnectionOptions {
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   if (parts.length === 0) {
-    throw new NatsContextError(`empty NATS URL: ${JSON.stringify(url)}`);
+    throw new NatsContextError("empty NATS URL");
   }
 
   const parsedAll = parts.map((p) => parseSingleNatsUrl(p, url));
@@ -235,7 +319,9 @@ export function parseNatsUrl(url: string): NodeConnectionOptions {
   const first = parsedAll[0]!;
   for (const p of parsedAll.slice(1)) {
     if (p.token !== first.token || p.user !== first.user || p.pass !== first.pass) {
-      throw new NatsContextError(`NATS URL has mixed credentials across server entries: ${url}`);
+      throw new NatsContextError(
+        `NATS URL has mixed credentials across server entries: ${redactNatsUrl(url)}`,
+      );
     }
   }
 
@@ -249,7 +335,7 @@ export function parseNatsUrl(url: string): NodeConnectionOptions {
 }
 
 interface ParsedNatsUrl {
-  server: string; // protocol + host (no userinfo)
+  server: string; // protocol + host, plus WebSocket path/query (no userinfo)
   token?: string;
   user?: string;
   pass?: string;
@@ -263,21 +349,25 @@ function parseSingleNatsUrl(part: string, original: string): ParsedNatsUrl {
   let parsed: URL;
   try {
     parsed = new URL(withScheme);
-  } catch (e) {
-    throw new NatsContextError(
-      `invalid NATS URL ${JSON.stringify(original)}: ${(e as Error).message}`,
-    );
+  } catch {
+    throw new NatsContextError(`invalid NATS URL ${redactNatsUrl(original)}`);
   }
   if (!/^(nats|tls|ws|wss):$/.test(parsed.protocol)) {
     throw new NatsContextError(
-      `unsupported scheme "${parsed.protocol}" in NATS URL ${JSON.stringify(original)}`,
+      `unsupported scheme "${parsed.protocol}" in NATS URL ${redactNatsUrl(original)}`,
     );
   }
   if (!parsed.host) {
-    throw new NatsContextError(`NATS URL ${JSON.stringify(original)} is missing a host`);
+    throw new NatsContextError(`NATS URL ${redactNatsUrl(original)} is missing a host`);
   }
 
-  const out: ParsedNatsUrl = { server: `${parsed.protocol}//${parsed.host}` };
+  const websocketSuffix =
+    parsed.protocol === "ws:" || parsed.protocol === "wss:"
+      ? `${explicitUrlSuffix(withScheme) ? parsed.pathname : ""}${parsed.search}`
+      : "";
+  const out: ParsedNatsUrl = {
+    server: `${parsed.protocol}//${parsed.host}${websocketSuffix}`,
+  };
 
   // WHATWG `URL` squashes both `nats://user@host` and `nats://user:@host`
   // into `password === ""`, losing the distinction between "no separator"
@@ -299,6 +389,33 @@ function parseSingleNatsUrl(part: string, original: string): ParsedNatsUrl {
     out.token = decodeURIComponent(parsed.username);
   }
   return out;
+}
+
+/** Whether the raw URL explicitly contained a path or query. */
+function explicitUrlSuffix(url: string): boolean {
+  const authorityStart = url.indexOf("://") + 3;
+  return /[/?]/.test(url.slice(authorityStart));
+}
+
+/** Preserve schemes/hosts in diagnostics while replacing every URL userinfo. */
+function redactNatsUrl(url: string): string {
+  return JSON.stringify(
+    url
+      .split(",")
+      .map((entry) => {
+        const trimmed = entry.trim();
+        const scheme = trimmed.match(/^[a-z]+:\/\//i)?.[0];
+        const authorityStart = scheme?.length ?? 0;
+        // Redact through the final `@` even when malformed userinfo contains
+        // a literal slash. This may over-redact an `@` in a WebSocket path,
+        // which is preferable to leaking credentials from an error path.
+        const at = trimmed.lastIndexOf("@");
+        return at >= authorityStart
+          ? `${trimmed.slice(0, authorityStart)}[redacted]@${trimmed.slice(at + 1)}`
+          : trimmed;
+      })
+      .join(","),
+  );
 }
 
 function str(v: unknown): string | undefined {

--- a/client-sdk/typescript/src/identity/signer.ts
+++ b/client-sdk/typescript/src/identity/signer.ts
@@ -83,6 +83,34 @@ class NkeySigner implements SenderSigner {
  * is not retained; the message of a rejection never includes it.
  */
 export function signerFromSeed(seed: string | Uint8Array, jwt?: string): SenderSigner {
+  const canonicalSeed = normalizeUserSeed(seed);
+  return signerFromCanonicalSeed(canonicalSeed, jwt);
+}
+
+/** Use an already-normalized user-seed snapshot without copying it. @internal */
+export function signerFromCanonicalSeed(canonicalSeed: Uint8Array, jwt?: string): SenderSigner {
+  // `fromSeed` keeps this buffer by reference and decodes it lazily on
+  // every `sign()` / `getPublicKey()`. Ownership transfers to the key pair;
+  // `wipe()` -> `kp.clear()` is what zeroes it.
+  try {
+    return new NkeySigner(fromSeed(canonicalSeed), jwt);
+  } catch (err) {
+    canonicalSeed.fill(0);
+    throw new IdentityError(
+      `invalid nkey seed (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+/**
+ * Normalize a raw seed file / seed block to canonical `SU...` bytes, and
+ * validate both its checksum and user-key prefix. Internal connection-bundle
+ * seam so the NATS authenticator and sender signer can share one exact byte
+ * snapshot.
+ *
+ * @internal
+ */
+export function normalizeUserSeed(seed: string | Uint8Array): Uint8Array {
   const text = typeof seed === "string" ? seed : utf8.decode(seed);
   const line = text.includes("BEGIN")
     ? extractBlock(text, BEGIN_SEED_REGEX, "USER NKEY SEED")
@@ -90,26 +118,35 @@ export function signerFromSeed(seed: string | Uint8Array, jwt?: string): SenderS
   if (!USER_SEED_REGEX.test(line)) {
     throw new IdentityError("invalid nkey seed: expected a user seed (SU + 56 base32 characters)");
   }
-  // `fromSeed` keeps this buffer by reference and decodes it lazily on
-  // every `sign()` / `getPublicKey()` — so it must be a private copy
-  // (`utf8.encode` allocates one) and must NOT be zeroed here; `wipe()`
-  // → `kp.clear()` is what zeroes it.
-  let kp: KeyPair;
+  const canonicalSeed = utf8.encode(line);
+  // `KeyPair.clear()` zeroes the input buffer retained by `fromSeed`, so use
+  // a throwaway copy for validation and return a separate canonical snapshot.
+  const validationSeed = canonicalSeed.slice();
+  let kp: KeyPair | undefined;
+  let valid = false;
   try {
-    kp = fromSeed(utf8.encode(line));
+    kp = fromSeed(validationSeed);
+    // nkeys decodes lazily, so validation includes getPublicKey(), not only
+    // fromSeed(). This is where a syntactically valid seed with a bad CRC
+    // fails.
+    const publicKey = kp.getPublicKey();
+    if (!publicKey.startsWith("U")) {
+      throw new IdentityError(
+        `seed is not a user seed (derives ${publicKey.slice(0, 1)}… public key)`,
+      );
+    }
+    valid = true;
+    return canonicalSeed;
   } catch (err) {
+    if (err instanceof IdentityError) throw err;
     throw new IdentityError(
       `invalid nkey seed (${err instanceof Error ? err.message : String(err)})`,
     );
+  } finally {
+    kp?.clear();
+    validationSeed.fill(0);
+    if (!valid) canonicalSeed.fill(0);
   }
-  const publicKey = kp.getPublicKey();
-  if (!publicKey.startsWith("U")) {
-    kp.clear();
-    throw new IdentityError(
-      `seed is not a user seed (derives ${publicKey.slice(0, 1)}… public key)`,
-    );
-  }
-  return new NkeySigner(kp, jwt);
 }
 
 /** The two blocks of a credentials file. */
@@ -199,10 +236,29 @@ export function identityFromJwt(jwt: string): AgentId {
  */
 export function signerFromCreds(credsText: string): SenderSigner {
   const { jwt, seed } = parseCreds(credsText);
-  const signer = signerFromSeed(seed, jwt);
-  const jwtUser = agentIdUser(identityFromJwt(jwt));
-  if (jwtUser !== signer.publicKey) {
-    signer.wipe?.();
+  return signerFromSeedAndJwt(seed, jwt);
+}
+
+/**
+ * Build a signer from one seed/JWT snapshot and verify that the JWT names
+ * the derived user. Internal connection-bundle seam; intentionally not
+ * exported from the package root.
+ *
+ * @internal
+ */
+export function signerFromSeedAndJwt(seed: string | Uint8Array, jwt: string): SenderSigner {
+  return signerFromCanonicalSeedAndJwt(normalizeUserSeed(seed), jwt);
+}
+
+/** Verify a JWT against an already-normalized seed snapshot. @internal */
+export function signerFromCanonicalSeedAndJwt(
+  canonicalSeed: Uint8Array,
+  jwt: string,
+): SenderSigner {
+  const signer = signerFromCanonicalSeed(canonicalSeed, jwt);
+  try {
+    const jwtUser = agentIdUser(identityFromJwt(jwt));
+    if (jwtUser === signer.publicKey) return signer;
     throw new IdentityMismatchError(
       signer.publicKey,
       signer.publicKey,
@@ -210,8 +266,10 @@ export function signerFromCreds(credsText: string): SenderSigner {
       undefined,
       jwtUser,
     );
+  } catch (error) {
+    signer.wipe?.();
+    throw error;
   }
-  return signer;
 }
 
 /** {@link signerFromCreds} over a file path (`~/` expanded). */
@@ -244,21 +302,9 @@ export async function signerFromContext(selector: string): Promise<SenderSigner>
     return signerFromSeed(new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength));
   }
   if (userSeed !== undefined) {
-    const signer = signerFromSeed(userSeed, userJwt);
-    if (userJwt !== undefined) {
-      const jwtUser = agentIdUser(identityFromJwt(userJwt));
-      if (jwtUser !== signer.publicKey) {
-        signer.wipe?.();
-        throw new IdentityMismatchError(
-          signer.publicKey,
-          signer.publicKey,
-          undefined,
-          undefined,
-          jwtUser,
-        );
-      }
-    }
-    return signer;
+    return userJwt === undefined
+      ? signerFromSeed(userSeed)
+      : signerFromSeedAndJwt(userSeed, userJwt);
   }
   throw new IdentityError(
     `NATS context "${name}" has no creds, nkey, or user_seed — nothing to sign Agent-Sender with`,

--- a/client-sdk/typescript/src/index.ts
+++ b/client-sdk/typescript/src/index.ts
@@ -261,6 +261,16 @@ export {
   type NatsContextFile,
 } from "./context.js";
 
+// One-snapshot connection credentials + optional sender signer.
+export {
+  resolveNatsConnectionBundle,
+  type NatsConnectionBundle,
+  type NatsConnectionSource,
+  type NatsUrlConnectionSource,
+  type ResolveNatsConnectionBundleOptions,
+  type SignedNatsConnectionBundle,
+} from "./connection-bundle.js";
+
 // Opinionated reconnect defaults for agent runtimes — see #121.
 export { AGENT_RECONNECT_DEFAULTS, withAgentReconnectDefaults } from "./connect-defaults.js";
 

--- a/client-sdk/typescript/test/integration/nkey-context.test.ts
+++ b/client-sdk/typescript/test/integration/nkey-context.test.ts
@@ -18,6 +18,7 @@ import { connect } from "@nats-io/transport-node";
 import { createUser } from "@nats-io/nkeys";
 import { findFreePort, findNatsServerBinary, waitForTcp } from "../harness/nats-server.js";
 import { loadContextOptions } from "../../src/context.js";
+import { resolveNatsConnectionBundle } from "../../src/connection-bundle.js";
 
 const bin = await findNatsServerBinary();
 
@@ -26,6 +27,9 @@ describe.skipIf(!bin)("loadContextOptions — nkey auth", () => {
   let port = 0;
   let tmpRoot = "";
   let originalConfigHome: string | undefined;
+  let seedPath = "";
+  let seedText = "";
+  let publicKey = "";
 
   beforeAll(async () => {
     if (!bin) return;
@@ -35,8 +39,9 @@ describe.skipIf(!bin)("loadContextOptions — nkey auth", () => {
     // "SU..." text — the same string `nats nkey gen user` would write.
     const kp = createUser();
     const seedBytes = kp.getSeed();
-    const publicKey = kp.getPublicKey();
-    const seedPath = join(tmpRoot, "user.nk");
+    seedText = new TextDecoder().decode(seedBytes);
+    publicKey = kp.getPublicKey();
+    seedPath = join(tmpRoot, "user.nk");
     await writeFile(seedPath, seedBytes);
 
     // Minimal nats-server config: only the user with this nkey is
@@ -131,5 +136,30 @@ describe.skipIf(!bin)("loadContextOptions — nkey auth", () => {
     delete stripped.authenticator;
 
     await expect(connect({ ...stripped, reconnect: false, timeout: 1_000 })).rejects.toBeDefined();
+  });
+
+  it("uses one canonical nkey snapshot for connection auth and signed identity", async () => {
+    const block =
+      `-----BEGIN USER NKEY SEED-----\n${seedText}\n` + "------END USER NKEY SEED------\n";
+    await writeFile(seedPath, block);
+    const bundle = await resolveNatsConnectionBundle(
+      { context: "nkey-test" },
+      { identity: "signed" },
+    );
+    // A rotation after resolution cannot split connection authentication
+    // from sender signing: both capabilities retained the original snapshot.
+    await writeFile(seedPath, createUser().getSeed());
+
+    let nc: Awaited<ReturnType<typeof connect>> | undefined;
+    try {
+      expect(bundle.signer.publicKey).toBe(publicKey);
+      nc = await connect(bundle.connectionOptions);
+      expect(nc.isClosed()).toBe(false);
+    } finally {
+      if (nc !== undefined) await nc.close();
+      bundle.wipe();
+      await writeFile(seedPath, seedText);
+    }
+    expect(() => bundle.signer.sign(new TextEncoder().encode("after wipe"))).toThrow(/wiped/);
   });
 });

--- a/client-sdk/typescript/test/unit/connection-bundle.test.ts
+++ b/client-sdk/typescript/test/unit/connection-bundle.test.ts
@@ -1,0 +1,307 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { inspect } from "node:util";
+import { createAccount, createUser } from "@nats-io/nkeys";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveNatsConnectionBundle,
+  type NatsConnectionSource,
+} from "../../src/connection-bundle.js";
+import { IdentityError, NatsContextError } from "../../src/errors.js";
+import { base64UrlEncode } from "../../src/identity/crypto.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function fakeJwt(user: string, account: string): string {
+  const part = (value: unknown): string => base64UrlEncode(encoder.encode(JSON.stringify(value)));
+  return `${part({ typ: "JWT", alg: "ed25519-nkey" })}.${part({ sub: user, iss: account })}.${base64UrlEncode(new Uint8Array(64))}`;
+}
+
+function credsText(jwt: string, seed: string): string {
+  return [
+    "-----BEGIN NATS USER JWT-----",
+    jwt,
+    "------END NATS USER JWT------",
+    "",
+    "-----BEGIN USER NKEY SEED-----",
+    seed,
+    "------END USER NKEY SEED------",
+    "",
+  ].join("\n");
+}
+
+describe("resolveNatsConnectionBundle", () => {
+  let root = "";
+  let originalConfigHome: string | undefined;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "connection-bundle-"));
+    await mkdir(join(root, "context"), { recursive: true });
+    originalConfigHome = process.env["NATS_CONFIG_HOME"];
+    process.env["NATS_CONFIG_HOME"] = root;
+  });
+
+  afterEach(async () => {
+    if (originalConfigHome === undefined) delete process.env["NATS_CONFIG_HOME"];
+    else process.env["NATS_CONFIG_HOME"] = originalConfigHome;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("keeps identity off by default or explicitly and does not parse a signer", async () => {
+    const path = join(root, "opaque.creds");
+    await writeFile(path, "connection-auth-bytes-that-are-not-a-signer");
+
+    const dynamicMode = (enabled: boolean): "off" | "signed" => (enabled ? "signed" : "off");
+    const identity = dynamicMode(false);
+    const bundle = await resolveNatsConnectionBundle(
+      {
+        url: "nats://token-value@demo.example:4222",
+        creds: path,
+      },
+      { identity },
+    );
+
+    expect(bundle.connectionOptions.servers).toEqual(["nats://demo.example:4222"]);
+    expect(bundle.connectionOptions.authenticator).toBeDefined();
+    expect(bundle.connectionOptions.token).toBeUndefined();
+    expect("signer" in bundle).toBe(false);
+    expect(JSON.stringify(bundle)).toBe('{"identity":"off"}');
+    expect(inspect(bundle)).toBe("NatsConnectionBundle(off)");
+    expect(Object.keys(bundle)).toEqual([]);
+    bundle.wipe();
+    bundle.wipe();
+  });
+
+  it("derives direct creds connection auth and signer from one resolved snapshot", async () => {
+    const alice = createUser();
+    const bob = createUser();
+    const account = createAccount();
+    const aliceSeed = decoder.decode(alice.getSeed());
+    const bobSeed = decoder.decode(bob.getSeed());
+    const path = join(root, "rotating.creds");
+    const aliceJwt = fakeJwt(alice.getPublicKey(), account.getPublicKey());
+    await writeFile(path, credsText(aliceJwt, aliceSeed));
+
+    const bundle = await resolveNatsConnectionBundle(
+      { url: "nats://demo.example:4222", creds: path },
+      { identity: "signed" },
+    );
+    await writeFile(path, credsText(fakeJwt(bob.getPublicKey(), account.getPublicKey()), bobSeed));
+
+    expect(bundle.signer.publicKey).toBe(alice.getPublicKey());
+    expect(bundle.connectionOptions.authenticator).toBeDefined();
+    const configured = Array.isArray(bundle.connectionOptions.authenticator)
+      ? bundle.connectionOptions.authenticator[0]
+      : bundle.connectionOptions.authenticator;
+    const auth = configured?.("rotation-nonce");
+    expect(auth && "jwt" in auth ? auth.jwt : undefined).toBe(aliceJwt);
+    expect(auth && "nkey" in auth ? auth.nkey : undefined).toBe(alice.getPublicKey());
+    expect(await readFile(path, "utf8")).toContain(bobSeed);
+    bundle.wipe();
+    bundle.wipe();
+    expect(bundle.connectionOptions.authenticator).toBeUndefined();
+    expect(() => bundle.signer.sign(encoder.encode("after wipe"))).toThrow(/wiped/);
+  });
+
+  it.each([
+    ["trailing newline", (value: string): string => `${value}\n`],
+    [
+      "BEGIN block",
+      (value: string): string =>
+        `-----BEGIN USER NKEY SEED-----\n${value}\n------END USER NKEY SEED------\n`,
+    ],
+  ])("supports direct nkey with a %s", async (_label, format) => {
+    const user = createUser();
+    const path = join(root, "user.nk");
+    await writeFile(path, format(decoder.decode(user.getSeed())));
+
+    const bundle = await resolveNatsConnectionBundle(
+      { url: "nats://demo.example:4222", nkey: path },
+      { identity: "signed" },
+    );
+
+    expect(bundle.signer.publicKey).toBe(user.getPublicKey());
+    expect(bundle.connectionOptions.authenticator).toBeDefined();
+    bundle.wipe();
+  });
+
+  it("uses one context snapshot for creds, nkey, inline JWT+seed, and TLS options", async () => {
+    const user = createUser();
+    const account = createAccount();
+    const seed = decoder.decode(user.getSeed());
+    const jwt = fakeJwt(user.getPublicKey(), account.getPublicKey());
+    const creds = join(root, "user.creds");
+    const nkey = join(root, "user.nk");
+    const ca = join(root, "ca.pem");
+    await writeFile(creds, credsText(jwt, seed));
+    await writeFile(
+      nkey,
+      `-----BEGIN USER NKEY SEED-----\n${seed}\n------END USER NKEY SEED------\n`,
+    );
+    await writeFile(ca, "test-ca");
+    await writeContext("creds", { url: "tls://demo.example:4222", creds, ca });
+    await writeContext("nkey", { url: "nats://demo.example:4222", nkey });
+    await writeContext("inline", {
+      url: "nats://demo.example:4222",
+      user_jwt: jwt,
+      user_seed: seed,
+    });
+
+    for (const name of ["creds", "nkey", "inline"]) {
+      const bundle = await resolveNatsConnectionBundle({ context: name }, { identity: "signed" });
+      expect(bundle.signer.publicKey).toBe(user.getPublicKey());
+      expect(bundle.connectionOptions.authenticator).toBeDefined();
+      if (name === "creds") expect(bundle.connectionOptions.tls?.ca).toBe("test-ca");
+      bundle.wipe();
+      if (name === "creds") expect(bundle.connectionOptions.tls).toBeUndefined();
+    }
+  });
+
+  it("allows non-seed auth when identity is off and fails clearly when signed", async () => {
+    await writeContext("password", {
+      url: "nats://demo.example:4222",
+      user: "alice",
+      password: "not-logged",
+    });
+    const off = await resolveNatsConnectionBundle({ context: "password" });
+    expect(off.connectionOptions.user).toBe("alice");
+    expect("signer" in off).toBe(false);
+    off.wipe();
+    expect(off.connectionOptions.user).toBeUndefined();
+    expect(off.connectionOptions.pass).toBeUndefined();
+
+    await expect(
+      resolveNatsConnectionBundle({ context: "password" }, { identity: "signed" }),
+    ).rejects.toThrow(/has no user seed/);
+
+    await writeContext("url-token", {
+      url: "nats://context-url-token@demo.example:4222",
+    });
+    const urlTokenOff = await resolveNatsConnectionBundle({ context: "url-token" });
+    expect(urlTokenOff.connectionOptions.servers).toEqual(["nats://demo.example:4222"]);
+    expect(urlTokenOff.connectionOptions.token).toBe("context-url-token");
+    urlTokenOff.wipe();
+    await expect(
+      resolveNatsConnectionBundle({ context: "url-token" }, { identity: "signed" }),
+    ).rejects.toThrow(/has no user seed/);
+
+    await expect(
+      resolveNatsConnectionBundle(
+        { url: "nats://token@demo.example:4222" },
+        {
+          identity: "signed",
+        },
+      ),
+    ).rejects.toThrow(/requires URL connection credentials/);
+  });
+
+  it("redacts URL token/password and option internals from JSON and inspection", async () => {
+    const password = "password-sentinel-7f486";
+    const token = "token-sentinel-82a04";
+    const passwordBundle = await resolveNatsConnectionBundle({
+      url: `nats://alice:${password}@demo.example:4222`,
+    });
+    const tokenBundle = await resolveNatsConnectionBundle({
+      url: `nats://${token}@demo.example:4222`,
+    });
+
+    expect(passwordBundle.connectionOptions.pass).toBe(password);
+    expect(tokenBundle.connectionOptions.token).toBe(token);
+    for (const bundle of [passwordBundle, tokenBundle]) {
+      expect(JSON.stringify(bundle)).not.toContain(password);
+      expect(JSON.stringify(bundle)).not.toContain(token);
+      expect(inspect(bundle)).not.toContain(password);
+      expect(inspect(bundle)).not.toContain(token);
+    }
+    passwordBundle.wipe();
+    tokenBundle.wipe();
+    expect(passwordBundle.connectionOptions.user).toBeUndefined();
+    expect(passwordBundle.connectionOptions.pass).toBeUndefined();
+    expect(tokenBundle.connectionOptions.token).toBeUndefined();
+  });
+
+  it("preserves WebSocket paths and queries in direct and context sources", async () => {
+    const direct = await resolveNatsConnectionBundle({
+      url: "wss://direct-token@ws.example.test/nats?tenant=direct",
+    });
+    expect(direct.connectionOptions.servers).toEqual(["wss://ws.example.test/nats?tenant=direct"]);
+    expect(direct.connectionOptions.token).toBe("direct-token");
+
+    await writeContext("websocket", {
+      url: "ws://context-token@ws.example.test:9222/nats?tenant=context",
+    });
+    const context = await resolveNatsConnectionBundle({ context: "websocket" });
+    expect(context.connectionOptions.servers).toEqual([
+      "ws://ws.example.test:9222/nats?tenant=context",
+    ]);
+    expect(context.connectionOptions.token).toBe("context-token");
+    direct.wipe();
+    context.wipe();
+  });
+
+  it("redacts URL userinfo from resolver errors while retaining the host", async () => {
+    const token = "resolver-error-token-sentinel";
+    let caught: unknown;
+    try {
+      await resolveNatsConnectionBundle({
+        url: `nats://${token}@one.example:4222,nats://different@two.example:4222`,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NatsContextError);
+    expect((caught as Error).message).toContain("one.example:4222");
+    expect((caught as Error).message).not.toContain(token);
+    expect((caught as Error).message).not.toContain("different");
+  });
+
+  it("rejects ambiguous sources without exposing their values", async () => {
+    const ambiguous = {
+      url: "nats://secret-token@demo.example:4222",
+      creds: "/secret/alice.creds",
+      nkey: "/secret/bob.nk",
+    } as unknown as NatsConnectionSource;
+    let caught: unknown;
+    try {
+      await resolveNatsConnectionBundle(ambiguous);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NatsContextError);
+    expect((caught as Error).message).not.toContain("secret-token");
+    expect((caught as Error).message).not.toContain("alice.creds");
+    expect((caught as Error).message).not.toContain("bob.nk");
+
+    await expect(
+      resolveNatsConnectionBundle({ url: "nats://demo.example:4222" }, {
+        identity: "invalid",
+      } as never),
+    ).rejects.toBeInstanceOf(IdentityError);
+  });
+
+  it("validates runtime source shapes without misrouting undefined fields", async () => {
+    const withUndefinedContext = {
+      context: undefined,
+      url: "nats://demo.example:4222",
+    } as unknown as NatsConnectionSource;
+    const bundle = await resolveNatsConnectionBundle(withUndefinedContext);
+    expect(bundle.connectionOptions.servers).toEqual(["nats://demo.example:4222"]);
+    bundle.wipe();
+
+    await expect(
+      resolveNatsConnectionBundle({
+        url: "nats://demo.example:4222",
+        creds: 42,
+      } as unknown as NatsConnectionSource),
+    ).rejects.toThrow(/`creds` must be a non-empty string/);
+    await expect(resolveNatsConnectionBundle(null as never)).rejects.toThrow(
+      /source must be an object/,
+    );
+  });
+
+  async function writeContext(name: string, fields: Record<string, unknown>): Promise<void> {
+    await writeFile(join(root, "context", `${name}.json`), JSON.stringify(fields));
+  }
+});

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -447,5 +447,8 @@ describe("parseNatsUrl", () => {
       servers: ["wss://host:9222/nats/connect?tenant=acme"],
       token: "tok",
     });
+
+    const bareQuery = parseNatsUrl("ws://host:9222?route=one");
+    expect(bareQuery).toEqual({ servers: ["ws://host:9222/?route=one"] });
   });
 });

--- a/client-sdk/typescript/test/unit/context.test.ts
+++ b/client-sdk/typescript/test/unit/context.test.ts
@@ -38,6 +38,15 @@ describe("loadContextOptions", () => {
     expect(opts.servers).toEqual(["nats://a:4222", "nats://b:4222", "nats://c:4222"]);
   });
 
+  it("preserves a WebSocket path and query from a context URL", async () => {
+    await writeContext("websocket", {
+      url: "wss://token@ws.example.test/nats/connect?tenant=acme",
+    });
+    const opts = await loadContextOptions("websocket");
+    expect(opts.servers).toEqual(["wss://ws.example.test/nats/connect?tenant=acme"]);
+    expect(opts.token).toBe("token");
+  });
+
   it("maps user/password/token/inbox_prefix", async () => {
     await writeContext("creds-basic", {
       url: "nats://localhost:4222",
@@ -51,6 +60,25 @@ describe("loadContextOptions", () => {
     expect(opts.pass).toBe("s3cret");
     expect(opts.token).toBe("tok");
     expect(opts.inboxPrefix).toBe("_INBOX.alice");
+  });
+
+  it("parses URL userinfo and lets explicit context auth replace it", async () => {
+    await writeContext("url-token", {
+      url: "nats://url-secret@example.test:4222",
+    });
+    const urlOnly = await loadContextOptions("url-token");
+    expect(urlOnly.servers).toEqual(["nats://example.test:4222"]);
+    expect(urlOnly.token).toBe("url-secret");
+
+    await writeContext("explicit-token", {
+      url: "nats://url-secret@example.test:4222",
+      token: "field-secret",
+    });
+    const explicit = await loadContextOptions("explicit-token");
+    expect(explicit.servers).toEqual(["nats://example.test:4222"]);
+    expect(explicit.token).toBe("field-secret");
+    expect(explicit.user).toBeUndefined();
+    expect(explicit.pass).toBeUndefined();
   });
 
   it("prefers user_jwt over user/password/token", async () => {
@@ -336,6 +364,47 @@ describe("parseNatsUrl", () => {
     expect(() => parseNatsUrl("nats://tok1@a:4222,nats://tok2@b:4222")).toThrow(NatsContextError);
   });
 
+  it("redacts URL userinfo in parse errors while retaining actionable host/scheme details", () => {
+    const token = "parse-error-token-sentinel";
+    let mixed: unknown;
+    try {
+      parseNatsUrl(`nats://${token}@a.example:4222,nats://different@b.example:4222`);
+    } catch (error) {
+      mixed = error;
+    }
+    expect((mixed as Error).message).toContain("a.example:4222");
+    expect((mixed as Error).message).not.toContain(token);
+    expect((mixed as Error).message).not.toContain("different");
+
+    let schemeLess: unknown;
+    try {
+      parseNatsUrl(`${token}@a.example:4222,different@b.example:4222`);
+    } catch (error) {
+      schemeLess = error;
+    }
+    expect((schemeLess as Error).message).toContain("a.example:4222");
+    expect((schemeLess as Error).message).not.toContain(token);
+    expect((schemeLess as Error).message).not.toContain("different");
+
+    let scheme: unknown;
+    try {
+      parseNatsUrl(`http://alice:${token}@nats.example:4222`);
+    } catch (error) {
+      scheme = error;
+    }
+    expect((scheme as Error).message).toContain('unsupported scheme "http:"');
+    expect((scheme as Error).message).toContain("nats.example:4222");
+    expect((scheme as Error).message).not.toContain(token);
+
+    let malformed: unknown;
+    try {
+      parseNatsUrl(`nats://alice:${token}/broken@nats.example:4222`);
+    } catch (error) {
+      malformed = error;
+    }
+    expect((malformed as Error).message).not.toContain(token);
+  });
+
   it("throws on empty / blank input", () => {
     expect(() => parseNatsUrl("")).toThrow(NatsContextError);
     expect(() => parseNatsUrl("   ,  ")).toThrow(NatsContextError);
@@ -372,5 +441,11 @@ describe("parseNatsUrl", () => {
     // bare ws/wss without userinfo
     const wsBare = parseNatsUrl("ws://host:9222");
     expect(wsBare).toEqual({ servers: ["ws://host:9222"] });
+
+    const path = parseNatsUrl("wss://tok@host:9222/nats/connect?tenant=acme");
+    expect(path).toEqual({
+      servers: ["wss://host:9222/nats/connect?tenant=acme"],
+      token: "tok",
+    });
   });
 });

--- a/client-sdk/typescript/test/unit/identity/signer.test.ts
+++ b/client-sdk/typescript/test/unit/identity/signer.test.ts
@@ -17,7 +17,9 @@ import { base64UrlEncode } from "../../../src/identity/crypto.js";
 import {
   decodeJwtPayload,
   identityFromJwt,
+  normalizeUserSeed,
   parseCreds,
+  signerFromCanonicalSeedAndJwt,
   signerFromContext,
   signerFromCreds,
   signerFromCredsFile,
@@ -69,7 +71,8 @@ describe("signerFromSeed", () => {
 
   it("rejects a non-user seed, garbage, a public key — without echoing the input", () => {
     const accountSeed = new TextDecoder().decode(account.getSeed());
-    for (const bad of [accountSeed, "garbage", user.getPublicKey(), seed.slice(0, 40) + "AAAA"]) {
+    const badCrc = `${seed.slice(0, -1)}${seed.endsWith("A") ? "B" : "A"}`;
+    for (const bad of [accountSeed, "garbage", user.getPublicKey(), badCrc]) {
       let caught: unknown;
       try {
         signerFromSeed(bad);
@@ -87,6 +90,14 @@ describe("signerFromSeed", () => {
     expect(inspect(s)).toBe(`SenderSigner(${s.publicKey})`);
     s.wipe?.();
     expect(() => s.sign(enc.encode("x"))).toThrow(/wiped/);
+  });
+
+  it("wipes an owned canonical seed when JWT validation fails", () => {
+    const canonicalSeed = normalizeUserSeed(seed);
+    expect(() => signerFromCanonicalSeedAndJwt(canonicalSeed, "malformed-jwt")).toThrow(
+      IdentityError,
+    );
+    expect(canonicalSeed.every((byte) => byte === 0)).toBe(true);
   });
 });
 

--- a/client-sdk/typescript/test/unit/identity/signer.test.ts
+++ b/client-sdk/typescript/test/unit/identity/signer.test.ts
@@ -71,7 +71,9 @@ describe("signerFromSeed", () => {
 
   it("rejects a non-user seed, garbage, a public key — without echoing the input", () => {
     const accountSeed = new TextDecoder().decode(account.getSeed());
-    const badCrc = `${seed.slice(0, -1)}${seed.endsWith("A") ? "B" : "A"}`;
+    // Do not mutate the final base32 character: it contains padding bits, so
+    // some textual changes decode to the same bytes on different runtimes.
+    const badCrc = `${seed.slice(0, 10)}${seed[10] === "A" ? "B" : "A"}${seed.slice(11)}`;
     for (const bad of [accountSeed, "garbage", user.getPublicKey(), badCrc]) {
       let caught: unknown;
       try {

--- a/docs/sdk-release-rollout-roadmap.md
+++ b/docs/sdk-release-rollout-roadmap.md
@@ -43,7 +43,8 @@ The rollout has five non-negotiable outcomes:
 - [x] The Python [identity workbook](../examples/identity-workbook/python/README.md) demonstrates
       signed Echo, signed Hello-to-Echo forwarding, and identity-free calls.
 - Review status: independent read-only audits were completed and reconciled into these gates.
-- [ ] The signer/live-connection correctness blockers in this roadmap are fixed.
+- [x] The signer/live-connection correctness blockers in this roadmap are fixed
+      ([PR #188](https://github.com/synadia-ai/synadia-agents/pull/188)).
 - [ ] The optional tracing feature is merged and its release gate is complete.
 - [ ] All intended SDK and integration artifacts are published through the recorded registry contract.
 - [ ] Every provided integration and release-consuming example is assessed.
@@ -85,9 +86,10 @@ merging shared-branch feature work; complete the remaining operational items bef
       workflows are path-filtered, use an always-running evaluator rather than a naive pending
       fan-in over skipped jobs.
 - Setup implementation and green component/aggregate evidence: [PR #186](https://github.com/synadia-ai/synadia-agents/pull/186).
-- Every rollout PR uses a closed review loop: wait for Claude's review on the current head,
-  address every finding in a follow-up commit, comment `@claude please review my fixes`, and wait
-  for the follow-up review. Repeat until the latest head has no remaining findings; only then merge.
+- Every rollout PR uses a closed review loop: wait for Claude's review on the current head before
+  making a follow-up commit, address every finding in that commit, comment
+  `@claude please review my fixes`, and wait for the follow-up review before making another commit.
+  Repeat until the latest head has no remaining findings; only then merge.
 - These workflow changes live on the rollout branch. Once it is pushed, PRs targeting it use its
   base-branch workflows and pushes use the workflow files in the pushed commit; `main` need not
   receive them first.
@@ -158,6 +160,12 @@ supply signer material alongside an already-created `NatsConnection`, because th
 not expose its private seed; those two inputs must still represent the same NATS user and account
 context.
 
+- [x] Add shared TypeScript and Python connection-bundle helpers that resolve context or URL plus
+      credentials once and return connection options plus an optional signer from the same
+      snapshot. Identity-free mode remains the default; signed mode fails if the selected
+      connection credentials cannot sign. The bundle owns cleanup after the connection closes.
+- [ ] Require every provided integration and release-consuming example to use those helpers; do not
+      copy context, credentials, seed, authenticator, or signer resolution into integrations.
 - [ ] Remove or reject independently selectable connection and identity credentials in integration
       CLIs, environment variables, config files, and plugin settings.
 - [x] Require live-connection binding before every signed send or registration path can become


### PR DESCRIPTION
## Summary

- add shared TypeScript and Python connection-bundle helpers
- derive optional sender signers from the exact connection-auth snapshot
- preserve identity-off behavior for anonymous, token, password, and seedless JWT auth
- capture reconnect auth, redact representations and URL errors, and provide explicit cleanup
- keep WebSocket paths and queries intact and reject ambiguous credential sources
- document the product-neutral Agent client SDK usage and make helpers mandatory for integrations in the rollout roadmap

## Validation

- TypeScript caller SDK: typecheck, lint, format, 525 passed / 2 skipped, build
- Python caller SDK: ruff, strict mypy, 393 passed, wheel build
- TypeScript AgentService SDK: 70 passed and build
- Python AgentService SDK: 86 passed
- nats-py 2.7.0: no-nonce callback shape and real reconnect after credential-file rotation
- clean install/import from the packed npm artifact and Python wheel

## Contract

Identity is off by default. Signed mode only succeeds when the selected connection credential source contains the connection user seed. There is no second identity-only credentials path. Integrations must consume these helpers instead of copying context, creds, seed, authenticator, or signer resolution.