### PR TITLE
fix: accept rollout push rehearsal in PR summary

### DIFF
--- a/.github/scripts/rollout-ci-summary.sh
+++ b/.github/scripts/rollout-ci-summary.sh
@@ -224,8 +224,8 @@ while (( SECONDS < deadline )); do
   pending=0
   missing=0
   failed=0
-  declare -a pending_names=()
-  declare -a missing_names=()
+  pending_names=()
+  missing_names=()
   for name in "${expected_names[@]}"; do
     state="$(
       workflow_state \
@@ -238,6 +238,7 @@ while (( SECONDS < deadline )); do
         if [[
           "$GITHUB_EVENT_NAME" == "pull_request"
           && "$name" == "CI — release rehearsal"
+          # The unquoted * intentionally matches the state fields after the event.
           && "$state" == $'push\t'*
         ]]; then
           echo "Accepted the successful same-SHA push run for $name."

--- a/.github/scripts/rollout-ci-summary.sh
+++ b/.github/scripts/rollout-ci-summary.sh
@@ -2,6 +2,78 @@
 
 set -euo pipefail
 
+fetch_workflow_runs() {
+  local event_name="$1"
+  local target_sha="$2"
+  local -a query_args=(
+    --method GET
+    -f head_sha="$target_sha"
+    -F per_page=100
+  )
+
+  # A rollout PR to main intentionally reuses the release rehearsal that ran
+  # when the exact same SHA was pushed to sdk-release-rollout. Fetch both
+  # events for PR evaluation; workflow_state still prefers a PR run whenever
+  # one exists and permits the push fallback for release rehearsal only.
+  if [[ "$event_name" != "pull_request" ]]; then
+    query_args+=(-f event="$event_name")
+  fi
+
+  gh api "repos/$GITHUB_REPOSITORY/actions/runs" "${query_args[@]}"
+}
+
+workflow_state() {
+  local name="$1"
+  local event_name="$2"
+  local self_run_id="$3"
+  local target_sha="$4"
+
+  jq -r \
+    --arg name "$name" \
+    --arg event "$event_name" \
+    --arg self "$self_run_id" \
+    --arg target "$target_sha" \
+    '
+      def latest: sort_by([.created_at, .run_attempt]) | last;
+
+      ([.workflow_runs[]
+        | select(
+            .head_sha == $target
+            and .name == $name
+            and (.id | tostring) != $self
+            and .event == $event
+          )]
+        | latest) as $primary
+      | if $primary != null then
+          $primary
+        elif $event == "pull_request" and $name == "CI — release rehearsal" then
+          ([.workflow_runs[]
+            | select(
+                .head_sha == $target
+                and .name == $name
+                and (.id | tostring) != $self
+                and .event == "push"
+              )]
+            | latest)
+        else
+          null
+        end
+      | if . == null then
+          "missing"
+        else
+          [.event, .status, (.conclusion // "")] | @tsv
+        end
+    '
+}
+
+# Unit tests source the two functions above without executing the workflow.
+if [[ "${ROLLOUT_CI_SUMMARY_SOURCE_ONLY:-0}" == "1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+  fi
+  exit 0
+fi
+
 : "${GH_TOKEN:?GH_TOKEN must be set}"
 : "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME must be set}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
@@ -141,37 +213,49 @@ fi
 echo "Waiting for rollout workflows on $TARGET_SHA:"
 printf '  - %s\n' "${expected_names[@]}"
 
-deadline=$((SECONDS + 45 * 60))
+completion_timeout_seconds="${ROLLOUT_CI_SUMMARY_COMPLETION_TIMEOUT_SECONDS:-2700}"
+discovery_timeout_seconds="${ROLLOUT_CI_SUMMARY_DISCOVERY_TIMEOUT_SECONDS:-300}"
+poll_seconds="${ROLLOUT_CI_SUMMARY_POLL_SECONDS:-15}"
+deadline=$((SECONDS + completion_timeout_seconds))
+discovery_deadline=$((SECONDS + discovery_timeout_seconds))
 while (( SECONDS < deadline )); do
-  runs_json="$(
-    gh api "repos/$GITHUB_REPOSITORY/actions/runs" --method GET \
-      -f head_sha="$TARGET_SHA" -f event="$GITHUB_EVENT_NAME" -F per_page=100
-  )"
+  runs_json="$(fetch_workflow_runs "$GITHUB_EVENT_NAME" "$TARGET_SHA")"
 
   pending=0
+  missing=0
   failed=0
+  declare -a pending_names=()
+  declare -a missing_names=()
   for name in "${expected_names[@]}"; do
     state="$(
-      jq -r \
-        --arg name "$name" \
-        --arg self "$GITHUB_RUN_ID" \
-        '[.workflow_runs[]
-          | select(.name == $name and (.id | tostring) != $self)]
-         | sort_by([.created_at, .run_attempt])
-         | last
-         | if . == null then "missing"
-           else [.status, (.conclusion // "")] | @tsv
-           end' <<<"$runs_json"
+      workflow_state \
+        "$name" "$GITHUB_EVENT_NAME" "$GITHUB_RUN_ID" "$TARGET_SHA" \
+        <<<"$runs_json"
     )"
 
     case "$state" in
-      $'completed\tsuccess') ;;
-      $'completed\t'*)
+      $'pull_request\tcompleted\tsuccess'|$'push\tcompleted\tsuccess')
+        if [[
+          "$GITHUB_EVENT_NAME" == "pull_request"
+          && "$name" == "CI — release rehearsal"
+          && "$state" == $'push\t'*
+        ]]; then
+          echo "Accepted the successful same-SHA push run for $name."
+        fi
+        ;;
+      $'pull_request\tcompleted\t'*|$'push\tcompleted\t'*)
         echo "FAILED: $name ($state)"
         failed=1
         ;;
+      missing)
+        pending=$((pending + 1))
+        missing=$((missing + 1))
+        pending_names+=("$name ($state)")
+        missing_names+=("$name")
+        ;;
       *)
         pending=$((pending + 1))
+        pending_names+=("$name ($state)")
         ;;
     esac
   done
@@ -183,11 +267,19 @@ while (( SECONDS < deadline )); do
     echo "All expected rollout workflows succeeded."
     exit 0
   fi
+  if (( missing != 0 && SECONDS >= discovery_deadline )); then
+    echo \
+      "Expected workflow runs did not appear within ${discovery_timeout_seconds} seconds:" \
+      >&2
+    printf '  - %s\n' "${missing_names[@]}" >&2
+    exit 1
+  fi
 
-  echo "$pending workflow(s) not complete yet; checking again in 15 seconds."
-  sleep 15
+  echo "$pending workflow(s) not complete yet; checking again in $poll_seconds seconds."
+  printf '  - %s\n' "${pending_names[@]}"
+  sleep "$poll_seconds"
 done
 
-echo "Timed out waiting for expected rollout workflows:" >&2
-printf '  - %s\n' "${expected_names[@]}" >&2
+echo "Timed out waiting for expected rollout workflows to complete:" >&2
+printf '  - %s\n' "${pending_names[@]}" >&2
 exit 1

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Lint release tool
         run: |
           uv run --project client-sdk/python --locked ruff check \
-            devtools/release/release.py devtools/release/tests/test_release.py
+            devtools/release/release.py devtools/release/tests
           uv run --project client-sdk/python --locked ruff format --check \
-            devtools/release/release.py devtools/release/tests/test_release.py
+            devtools/release/release.py devtools/release/tests
 
       - name: Verify frozen dependency inputs
         run: python3 devtools/release/release.py freeze check

--- a/devtools/release/freeze-baseline.json
+++ b/devtools/release/freeze-baseline.json
@@ -1,8 +1,8 @@
 {
   "files": {
     ".github/scripts/rollout-ci-summary.sh": {
-      "sha256": "fbd9cd7e88dae192b27b7bb094395835a1450ac16b7cda11849aa03cf4d8227d",
-      "size": 8912
+      "sha256": "9c2f5ccfc35129af260108ec9076351c3ba8cec0dc3773e836c56630051ef357",
+      "size": 8973
     },
     ".github/workflows/release-python-agent-service.yml": {
       "sha256": "dd4ea202103012f5dcf752cc1f1dadecc1abe573641fab78ffb33127f1f491a1",

--- a/devtools/release/freeze-baseline.json
+++ b/devtools/release/freeze-baseline.json
@@ -1,8 +1,8 @@
 {
   "files": {
     ".github/scripts/rollout-ci-summary.sh": {
-      "sha256": "dda749a6231b2b3f529141de44c38160e015dd5cc2722ee37713146b72bc1cb9",
-      "size": 6077
+      "sha256": "fbd9cd7e88dae192b27b7bb094395835a1450ac16b7cda11849aa03cf4d8227d",
+      "size": 8912
     },
     ".github/workflows/release-python-agent-service.yml": {
       "sha256": "dd4ea202103012f5dcf752cc1f1dadecc1abe573641fab78ffb33127f1f491a1",
@@ -17,8 +17,8 @@
       "size": 5561
     },
     ".github/workflows/release-rehearsal.yml": {
-      "sha256": "4861f44f5b701ae5b50154ee2a9f2445ba4a88f7e2d95e6e573c4651878850ab",
-      "size": 5489
+      "sha256": "b682a38edeb3a55323568aed2718a0823f187d394bbd051872d67979c4e26b6b",
+      "size": 5457
     },
     ".github/workflows/rollout-ci-summary.yml": {
       "sha256": "be74c44ee4ba3ea36470ca73914c8393744c43d9d5e8bf18bd4360cf136aab3e",

--- a/devtools/release/tests/test_rollout_ci_summary.py
+++ b/devtools/release/tests/test_rollout_ci_summary.py
@@ -216,6 +216,27 @@ esac
         )
         self.assertIn("All expected rollout workflows succeeded.", completed.stdout)
 
+    def test_full_summary_rejects_failed_same_sha_push_rehearsal(self) -> None:
+        completed = self.run_summary([workflow_run(conclusion="failure")])
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(
+            "FAILED: CI — release rehearsal (push\tcompleted\tfailure)",
+            completed.stdout,
+        )
+
+    def test_full_summary_rejects_failed_pr_run_instead_of_using_push(self) -> None:
+        runs = [
+            workflow_run(event="push", conclusion="success"),
+            workflow_run(event="pull_request", conclusion="failure", run_id=2),
+        ]
+        completed = self.run_summary(runs)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(
+            "FAILED: CI — release rehearsal (pull_request\tcompleted\tfailure)",
+            completed.stdout,
+        )
+        self.assertNotIn("Accepted the successful same-SHA push run", completed.stdout)
+
     def test_missing_workflow_fails_fast_with_its_name(self) -> None:
         completed = self.run_summary([])
         self.assertEqual(completed.returncode, 1)

--- a/devtools/release/tests/test_rollout_ci_summary.py
+++ b/devtools/release/tests/test_rollout_ci_summary.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / ".github" / "scripts" / "rollout-ci-summary.sh"
+TARGET_SHA = "a" * 40
+
+
+def workflow_run(
+    *,
+    name: str = "CI — release rehearsal",
+    event: str = "push",
+    head_sha: str = TARGET_SHA,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    run_id: int = 1,
+    created_at: str = "2026-09-01T10:00:00Z",
+    run_attempt: int = 1,
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "name": name,
+        "event": event,
+        "head_sha": head_sha,
+        "status": status,
+        "conclusion": conclusion,
+        "created_at": created_at,
+        "run_attempt": run_attempt,
+    }
+
+
+class RolloutSummaryTests(unittest.TestCase):
+    def state(
+        self,
+        runs: list[dict[str, Any]],
+        *,
+        name: str = "CI — release rehearsal",
+        event: str = "pull_request",
+        self_run_id: str = "999",
+        target_sha: str = TARGET_SHA,
+    ) -> str:
+        env = {
+            **os.environ,
+            "ROLLOUT_CI_SUMMARY_SOURCE_ONLY": "1",
+        }
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; workflow_state "$2" "$3" "$4" "$5"',
+                "rollout-summary-test",
+                str(SCRIPT),
+                name,
+                event,
+                self_run_id,
+                target_sha,
+            ],
+            check=True,
+            input=json.dumps({"workflow_runs": runs}),
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        return completed.stdout.rstrip("\n")
+
+    def fetch_arguments(self, event: str) -> str:
+        env = {
+            **os.environ,
+            "ROLLOUT_CI_SUMMARY_SOURCE_ONLY": "1",
+        }
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                (
+                    'source "$1"; '
+                    'GITHUB_REPOSITORY="synadia-ai/synadia-agents"; '
+                    'gh() { printf "%s\\n" "$*"; }; '
+                    'fetch_workflow_runs "$2" "$3"'
+                ),
+                "rollout-summary-test",
+                str(SCRIPT),
+                event,
+                TARGET_SHA,
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        return completed.stdout.strip()
+
+    def run_summary(
+        self,
+        runs: list[dict[str, Any]],
+        *,
+        discovery_timeout_seconds: int = 0,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            fake_gh = Path(temporary) / "gh"
+            fake_gh.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *repos/synadia-ai/synadia-agents/pulls/1/files*)
+    printf '%s\\n' "$FAKE_CHANGED_PATH"
+    ;;
+  *repos/synadia-ai/synadia-agents/actions/runs*)
+    printf '%s\\n' "$FAKE_RUNS_JSON"
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\\n' "$*" >&2
+    exit 2
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{temporary}{os.pathsep}{os.environ['PATH']}",
+                "GH_TOKEN": "test-token",
+                "GITHUB_EVENT_NAME": "pull_request",
+                "GITHUB_REPOSITORY": "synadia-ai/synadia-agents",
+                "GITHUB_RUN_ID": "999",
+                "TARGET_SHA": TARGET_SHA,
+                "PR_NUMBER": "1",
+                "BEFORE_SHA": "",
+                "FAKE_CHANGED_PATH": "devtools/release/release.py",
+                "FAKE_RUNS_JSON": json.dumps({"workflow_runs": runs}),
+                "ROLLOUT_CI_SUMMARY_COMPLETION_TIMEOUT_SECONDS": "30",
+                "ROLLOUT_CI_SUMMARY_DISCOVERY_TIMEOUT_SECONDS": str(
+                    discovery_timeout_seconds
+                ),
+                "ROLLOUT_CI_SUMMARY_POLL_SECONDS": "0",
+            }
+            return subprocess.run(
+                ["bash", str(SCRIPT)],
+                cwd=REPO,
+                text=True,
+                capture_output=True,
+                env=env,
+            )
+
+    def test_pr_query_fetches_both_events_for_the_narrow_fallback(self) -> None:
+        arguments = self.fetch_arguments("pull_request")
+        self.assertIn(f"head_sha={TARGET_SHA}", arguments)
+        self.assertNotIn("event=pull_request", arguments)
+
+    def test_push_query_remains_event_scoped(self) -> None:
+        arguments = self.fetch_arguments("push")
+        self.assertIn(f"head_sha={TARGET_SHA}", arguments)
+        self.assertIn("event=push", arguments)
+
+    def test_release_rehearsal_accepts_same_sha_push_when_pr_run_is_absent(
+        self,
+    ) -> None:
+        state = self.state([workflow_run()])
+        self.assertEqual(state, "push\tcompleted\tsuccess")
+
+    def test_pr_run_takes_precedence_over_successful_push_fallback(self) -> None:
+        runs = [
+            workflow_run(event="push", status="completed", conclusion="success"),
+            workflow_run(
+                event="pull_request",
+                status="in_progress",
+                conclusion=None,
+                run_id=2,
+            ),
+        ]
+        self.assertEqual(
+            self.state(runs),
+            "pull_request\tin_progress\t",
+        )
+
+    def test_failed_fallback_is_reported_as_failed_state(self) -> None:
+        state = self.state([workflow_run(conclusion="failure")])
+        self.assertEqual(state, "push\tcompleted\tfailure")
+
+    def test_non_rehearsal_workflow_cannot_reuse_a_push_run(self) -> None:
+        name = "CI — client-sdk/typescript"
+        state = self.state([workflow_run(name=name)], name=name)
+        self.assertEqual(state, "missing")
+
+    def test_stale_sha_cannot_satisfy_the_fallback(self) -> None:
+        state = self.state([workflow_run(head_sha="b" * 40)])
+        self.assertEqual(state, "missing")
+
+    def test_latest_attempt_wins_within_the_selected_event(self) -> None:
+        runs = [
+            workflow_run(conclusion="success"),
+            workflow_run(
+                conclusion="failure",
+                run_id=2,
+                created_at="2026-09-01T10:01:00Z",
+                run_attempt=2,
+            ),
+        ]
+        self.assertEqual(self.state(runs), "push\tcompleted\tfailure")
+
+    def test_full_summary_accepts_successful_same_sha_push_rehearsal(self) -> None:
+        completed = self.run_summary([workflow_run()])
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn(
+            "Accepted the successful same-SHA push run for CI — release rehearsal.",
+            completed.stdout,
+        )
+        self.assertIn("All expected rollout workflows succeeded.", completed.stdout)
+
+    def test_missing_workflow_fails_fast_with_its_name(self) -> None:
+        completed = self.run_summary([])
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(
+            "Expected workflow runs did not appear within 0 seconds:",
+            completed.stderr,
+        )
+        self.assertIn("CI — release rehearsal", completed.stderr)
+
+    def test_script_has_valid_bash_syntax(self) -> None:
+        subprocess.run(["bash", "-n", str(SCRIPT)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the rollout-summary dead wait seen on PR #185.

The PR summary now prefers same-event pull-request runs, but for CI — release rehearsal only it may fall back to a successful run from the exact same SHA push. A present PR rehearsal always takes precedence, and pending/failed, stale-SHA, or other-workflow push runs cannot satisfy the gate.

Also fails clearly after five minutes when an expected workflow run never appears, prints pending workflow names and states, and adds executable regression coverage. Release rehearsal now lints the complete release test directory.

Validation: 31 release tests, Ruff check/format, Bash syntax, source inventory, and freeze baseline.